### PR TITLE
make logging show the line number of the log

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -7,6 +7,16 @@ BetterLyrics.Utils = {
     });
   },
 
+  setUpLog: function () {
+    BetterLyrics.Storage.getStorage({ isLogsEnabled: true }, items => {
+      if (items.isLogsEnabled) {
+        BetterLyrics.Utils.log = console.log.bind(window.console);
+      } else {
+        BetterLyrics.Utils.log = function(){};
+      }
+    });
+  },
+
   timeToInt: function (time) {
     time = time.split(":");
     time = parseFloat(time[0]) * 60 + parseFloat(time[1]);

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ BetterLyrics.App = {
   lyricInjectionPromise: null,
 
   modify: function () {
+    BetterLyrics.Utils.setUpLog();
     BetterLyrics.DOM.injectGetSongInfo();
     BetterLyrics.DOM.injectHeadTags();
     BetterLyrics.Observer.enableLyricsTab();


### PR DESCRIPTION
# Description

Have calls to BetterLyrics.Utils.log(...) show the line number of where to log occurred.

The original function is kept so that it can be used when the async calls to storage work.
Also resolves issues with out of order logs due to the logging previously being async due to the storage callbacks.

Does have the downside of not being able to enable/disable logging without a reboot, but the qol is worth it imo