### PR TITLE
Fix throwing an error when there isn't one

### DIFF
--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -38,7 +38,6 @@ BetterLyrics.Lyrics = {
     // Check for empty strings after trimming
     if (!song || !artist) {
       BetterLyrics.Utils.log(BetterLyrics.Constants.SERVER_ERROR_LOG, "Empty song or artist name");
-      setTimeout(BetterLyrics.DOM.injectError, 500);
       return;
     }
 


### PR DESCRIPTION
The createLyrics function should get recalled if we were executed without a valid song/artist and aren't able to get lyrics. We don't need to go to the error case just yet! This causes races and breaks loading in certain situations