### PR TITLE
Misc patches

### DIFF
--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -112,6 +112,7 @@ BetterLyrics.Constants = {
   LOADING_WITHOUT_SONG_META: "[BetterLyrics] Trying to load without Song/Artist info",
   SKIPPING_LOAD_WITH_META: "[BetterLyrics] Skipping Reload From Metadata Available: Already Loaded",
   LOADER_TRANSITION_ENDED: "[BetterLyrics] Loader Transition Ended",
+  LOADER_ANIMATION_END_FAILED: "[BetterLyrics] Loader Animation Didn't End",
 
   // Feature State Logs
   AUTO_SWITCH_ENABLED_LOG: "[BetterLyrics] Auto switch enabled, switching to lyrics tab",

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -27,8 +27,7 @@ BetterLyrics.Utils = {
     return str.replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">");
   },
 
-  generateAlbumArt: function () {
-    const videoId = new URLSearchParams(window.location.search).get("v");
+  generateAlbumArt: function (videoId) {
     return `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,8 @@ BetterLyrics.App = {
   lastVideoDetails: null,
   lyricInjectionPromise: null,
   queueLyricInjection: false,
+  queueAlbumArtInjection: false,
+  shouldInjectAlbumArt: "Unknown",
 
   modify: function () {
     BetterLyrics.Utils.setUpLog();
@@ -24,6 +26,11 @@ BetterLyrics.App = {
     BetterLyrics.Utils.log(
       BetterLyrics.Constants.INITIALIZE_LOG,
       "background: rgba(10,11,12,1) ; color: rgba(214, 250, 214,1) ; padding: 0.5rem 0.75rem; border-radius: 0.5rem; font-size: 1rem; "
+    );
+
+    BetterLyrics.Settings.onAlbumArtEnabled(
+        () => BetterLyrics.App.shouldInjectAlbumArt = true,
+        () => BetterLyrics.App.shouldInjectAlbumArt = false
     );
   },
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ BetterLyrics.App = {
   queueAlbumArtInjection: false,
   shouldInjectAlbumArt: "Unknown",
   queueSongDetailsInjection: false,
+  loaderAnimationEndTimeout: null,
 
   modify: function () {
     BetterLyrics.Utils.setUpLog();

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ BetterLyrics.App = {
   queueLyricInjection: false,
   queueAlbumArtInjection: false,
   shouldInjectAlbumArt: "Unknown",
+  queueSongDetailsInjection: false,
 
   modify: function () {
     BetterLyrics.Utils.setUpLog();

--- a/src/index.js
+++ b/src/index.js
@@ -31,8 +31,8 @@ BetterLyrics.App = {
     );
 
     BetterLyrics.Settings.onAlbumArtEnabled(
-        () => BetterLyrics.App.shouldInjectAlbumArt = true,
-        () => BetterLyrics.App.shouldInjectAlbumArt = false
+      () => (BetterLyrics.App.shouldInjectAlbumArt = true),
+      () => (BetterLyrics.App.shouldInjectAlbumArt = false)
     );
   },
 

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -26,6 +26,14 @@ BetterLyrics.Lyrics = {
 
     // We should get recalled if we were executed without a valid song/artist and aren't able to get lyrics
     BetterLyrics.DOM.renderLoader(); // Only render the loader after we've checked the cache
+
+    const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
+    console.assert(tabSelector != null);
+    if (tabSelector.getAttribute("aria-selected") !== "true") {
+      BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_TAB_HIDDEN_LOG);
+      return;
+    }
+
     // Input validation
     if (typeof song !== "string" || typeof artist !== "string") {
       BetterLyrics.Utils.log(BetterLyrics.Constants.SERVER_ERROR_LOG, "Invalid song or artist data");

--- a/src/modules/settings/settings.js
+++ b/src/modules/settings/settings.js
@@ -144,11 +144,16 @@ BetterLyrics.Settings = {
       if (request.action === "updateCSS") {
         BetterLyrics.Utils.applyCustomCSS(request.css);
       } else if (request.action === "updateSettings") {
+        BetterLyrics.Utils.setUpLog();
         BetterLyrics.Settings.hideCursorOnIdle();
         BetterLyrics.Settings.handleSettings();
+        BetterLyrics.App.shouldInjectAlbumArt = "Unknown"
         BetterLyrics.Settings.onAlbumArtEnabled(
-          BetterLyrics.DOM.addAlbumArtToLayout,
-          BetterLyrics.DOM.removeAlbumArtFromLayout
+            () => BetterLyrics.App.shouldInjectAlbumArt = true,
+            () => {
+              BetterLyrics.App.shouldInjectAlbumArt = false;
+              BetterLyrics.DOM.removeAlbumArtFromLayout();
+            }
         );
         BetterLyrics.App.reloadLyrics();
       } else if (request.action === "clearCache") {

--- a/src/modules/settings/settings.js
+++ b/src/modules/settings/settings.js
@@ -147,13 +147,13 @@ BetterLyrics.Settings = {
         BetterLyrics.Utils.setUpLog();
         BetterLyrics.Settings.hideCursorOnIdle();
         BetterLyrics.Settings.handleSettings();
-        BetterLyrics.App.shouldInjectAlbumArt = "Unknown"
+        BetterLyrics.App.shouldInjectAlbumArt = "Unknown";
         BetterLyrics.Settings.onAlbumArtEnabled(
-            () => BetterLyrics.App.shouldInjectAlbumArt = true,
-            () => {
-              BetterLyrics.App.shouldInjectAlbumArt = false;
-              BetterLyrics.DOM.removeAlbumArtFromLayout();
-            }
+          () => (BetterLyrics.App.shouldInjectAlbumArt = true),
+          () => {
+            BetterLyrics.App.shouldInjectAlbumArt = false;
+            BetterLyrics.DOM.removeAlbumArtFromLayout();
+          }
         );
         BetterLyrics.App.reloadLyrics();
       } else if (request.action === "clearCache") {

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -282,9 +282,20 @@ BetterLyrics.DOM = {
     (document.head || document.documentElement).appendChild(s);
   },
   tickLyrics: function (currentTime) {
-    if (BetterLyrics.DOM.isLoaderActive() || !BetterLyrics.App.areLyricsTicking) {
+    if (BetterLyrics.DOM.isLoaderActive()
+        || !BetterLyrics.App.areLyricsTicking
+        || document.visibilityState !== 'visible'
+    ) {
       return;
     }
+
+    const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
+    console.assert(tabSelector != null);
+    // Don't tick lyrics if they're not visible
+    if (tabSelector.getAttribute("aria-selected") !== "true") {
+      return;
+    }
+
     currentTime += 0.25; //adjust time to account for scroll time
 
     try {

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -262,16 +262,6 @@ BetterLyrics.DOM = {
       existingFooter.classList.remove("blyrics--fallback");
     }
 
-    const existingSongInfo = document.getElementById("blyrics-song-info");
-    const existingWatermark = document.getElementById("blyrics-watermark");
-
-    if (existingSongInfo) {
-      existingSongInfo.remove();
-    }
-    if (existingWatermark) {
-      existingWatermark.remove();
-    }
-
     BetterLyrics.DOM.clearLyrics();
   },
   injectGetSongInfo: function () {
@@ -343,4 +333,27 @@ BetterLyrics.DOM = {
       return true;
     }
   },
+  injectSongAttributes: function (title, artist) {
+    const mainPanel = document.getElementById("main-panel");
+    console.assert(mainPanel != null);
+    const existingSongInfo = document.getElementById("blyrics-song-info");
+    const existingWatermark = document.getElementById("blyrics-watermark");
+
+    existingSongInfo?.remove();
+    existingWatermark?.remove();
+
+    const titleElm = document.createElement("p");
+    titleElm.id = "blyrics-title";
+    titleElm.textContent = title;
+
+    const artistElm = document.createElement("p");
+    artistElm.id = "blyrics-artist";
+    artistElm.textContent = artist;
+
+    const songInfoWrapper = document.createElement("div");
+    songInfoWrapper.id = "blyrics-song-info";
+    songInfoWrapper.appendChild(titleElm);
+    songInfoWrapper.appendChild(artistElm);
+    mainPanel.appendChild(songInfoWrapper);
+  }
 };

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -199,10 +199,10 @@ BetterLyrics.DOM = {
       BetterLyrics.Utils.log(err);
     }
   },
-  addAlbumArtToLayout: function () {
+  addAlbumArtToLayout: function (videoId) {
     let albumArt = document.querySelector(BetterLyrics.Constants.SONG_IMAGE_SELECTOR).src;
     if (albumArt === BetterLyrics.Constants.EMPTY_THUMBNAIL_SRC) {
-      albumArt = BetterLyrics.Utils.generateAlbumArt();
+      albumArt = BetterLyrics.Utils.generateAlbumArt(videoId);
     }
     document.getElementById("layout").style = `--blyrics-background-img: url('${albumArt}')`;
     BetterLyrics.Utils.log(BetterLyrics.Constants.ALBUM_ART_ADDED_LOG);

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -90,6 +90,7 @@ BetterLyrics.DOM = {
 
   renderLoader: function () {
     try {
+      clearTimeout(BetterLyrics.App.loaderAnimationEndTimeout);
       const tabRenderer = document.querySelector(BetterLyrics.Constants.TAB_RENDERER_SELECTOR);
       let loaderWrapper = document.getElementById(BetterLyrics.Constants.LYRICS_LOADER_ID);
       if (!loaderWrapper) {
@@ -115,14 +116,21 @@ BetterLyrics.DOM = {
     try {
       const loaderWrapper = document.getElementById(BetterLyrics.Constants.LYRICS_LOADER_ID);
       if (loaderWrapper && loaderWrapper.hasAttribute("active")) {
+        clearTimeout(BetterLyrics.App.loaderAnimationEndTimeout);
         loaderWrapper.dataset.animatingOut = true;
         loaderWrapper.removeAttribute("active");
 
         loaderWrapper.addEventListener("transitionend", function handleTransitionEnd(_event) {
+          clearTimeout(BetterLyrics.App.loaderAnimationEndTimeout);
           loaderWrapper.dataset.animatingOut = false;
           loaderWrapper.removeEventListener("transitionend", handleTransitionEnd);
           BetterLyrics.Utils.log(BetterLyrics.Constants.LOADER_TRANSITION_ENDED);
         });
+
+        BetterLyrics.App.loaderAnimationEndTimeout = setTimeout(() => {
+          loaderWrapper.dataset.animatingOut = false;
+          console.error("[BetterLyrics] Loader Animation Didn't End!")
+        }, 1000);
       }
     } catch (err) {
       BetterLyrics.Utils.log(err);

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -282,9 +282,10 @@ BetterLyrics.DOM = {
     (document.head || document.documentElement).appendChild(s);
   },
   tickLyrics: function (currentTime) {
-    if (BetterLyrics.DOM.isLoaderActive()
-        || !BetterLyrics.App.areLyricsTicking
-        || document.visibilityState !== 'visible'
+    if (
+      BetterLyrics.DOM.isLoaderActive() ||
+      !BetterLyrics.App.areLyricsTicking ||
+      document.visibilityState !== "visible"
     ) {
       return;
     }
@@ -374,5 +375,5 @@ BetterLyrics.DOM = {
     songInfoWrapper.appendChild(titleElm);
     songInfoWrapper.appendChild(artistElm);
     mainPanel.appendChild(songInfoWrapper);
-  }
+  },
 };

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -129,7 +129,7 @@ BetterLyrics.DOM = {
 
         BetterLyrics.App.loaderAnimationEndTimeout = setTimeout(() => {
           loaderWrapper.dataset.animatingOut = false;
-          console.error("[BetterLyrics] Loader Animation Didn't End!")
+          BetterLyrics.Utils.log(BetterLyrics.Constants.LOADER_ANIMATION_END_FAILED);
         }, 1000);
       }
     } catch (err) {

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -74,10 +74,16 @@ BetterLyrics.Observer = {
         BetterLyrics.App.areLyricsLoaded = false;
 
         BetterLyrics.App.queueLyricInjection = true;
-
         BetterLyrics.App.queueAlbumArtInjection = true;
+        BetterLyrics.App.queueSongDetailsInjection = true;
       }
 
+      if (BetterLyrics.App.queueSongDetailsInjection
+          && detail.song && detail.artist
+          && document.getElementById("main-panel")) {
+        BetterLyrics.App.queueSongDetailsInjection = false;
+        BetterLyrics.DOM.injectSongAttributes(detail.song, detail.artist);
+      }
 
       if (BetterLyrics.App.queueAlbumArtInjection === true && BetterLyrics.App.shouldInjectAlbumArt === true) {
         BetterLyrics.App.queueAlbumArtInjection = false;

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -75,10 +75,13 @@ BetterLyrics.Observer = {
 
         BetterLyrics.App.queueLyricInjection = true;
 
-        BetterLyrics.Settings.onAlbumArtEnabled(
-          BetterLyrics.DOM.addAlbumArtToLayout,
-          BetterLyrics.DOM.removeAlbumArtFromLayout
-        );
+        BetterLyrics.App.queueAlbumArtInjection = true;
+      }
+
+
+      if (BetterLyrics.App.queueAlbumArtInjection === true && BetterLyrics.App.shouldInjectAlbumArt === true) {
+        BetterLyrics.App.queueAlbumArtInjection = false;
+        BetterLyrics.DOM.addAlbumArtToLayout(detail.videoId);
       }
 
       if (BetterLyrics.App.queueLyricInjection) {

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -94,18 +94,14 @@ BetterLyrics.Observer = {
         const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
         if (tabSelector) {
           BetterLyrics.App.queueLyricInjection = false;
-          if (tabSelector.getAttribute("aria-selected") === "true") {
-            BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_TAB_VISIBLE_LOG);
-            BetterLyrics.App.handleModifications(detail.song, detail.artist, detail.currentTime, detail.videoId);
-          } else {
+          if (tabSelector.getAttribute("aria-selected") !== "true") {
             BetterLyrics.Settings.onAutoSwitchEnabled(() => {
               tabSelector.click();
               BetterLyrics.Utils.log(BetterLyrics.Constants.AUTO_SWITCH_ENABLED_LOG);
-              BetterLyrics.App.handleModifications(detail.song, detail.artist, detail.currentTime, detail.videoId);
             });
-
-            BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_TAB_HIDDEN_LOG);
           }
+
+          BetterLyrics.App.handleModifications(detail.song, detail.artist, detail.currentTime, detail.videoId);
         }
       }
 

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -78,9 +78,12 @@ BetterLyrics.Observer = {
         BetterLyrics.App.queueSongDetailsInjection = true;
       }
 
-      if (BetterLyrics.App.queueSongDetailsInjection
-          && detail.song && detail.artist
-          && document.getElementById("main-panel")) {
+      if (
+        BetterLyrics.App.queueSongDetailsInjection &&
+        detail.song &&
+        detail.artist &&
+        document.getElementById("main-panel")
+      ) {
         BetterLyrics.App.queueSongDetailsInjection = false;
         BetterLyrics.DOM.injectSongAttributes(detail.song, detail.artist);
       }


### PR DESCRIPTION
- Fix potential races relating to album art (there may still be some lingering issues here that need testing to find)
- Re-add song details
- Load lyrics preemptively when they're cached
- Add emergency fallbacks if we don't get the loader animation end event. (prevents lyric ticking from appearing completely broken)
- Don't tick lyrics if they're not visible. (Fixes issues with not immediately scrolling to the correct position when the lyrics become visible again)