### PR TITLE
Refactor lyric fectching

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,6 +35,7 @@
         "src/core/storage.js",
         "src/modules/lyrics/translation.js",
         "src/modules/lyrics/lyrics.js",
+        "src/modules/lyrics/providers.js",
         "src/modules/ui/dom.js",
         "src/modules/ui/observer.js",
         "src/modules/settings/settings.js",

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -46,7 +46,7 @@ BetterLyrics.Constants = {
     return `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=${lang}&dt=t&q=${encodeURIComponent(text)}`;
   },
   TRANSLATE_IN_ROMAJI: function (lang, text) {
-    return `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${lang}&tl=en&dt=t&dt=rm&q=${encodeURIComponent(text)}`;
+    return `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${lang}&tl=${lang}-Latn&dt=t&dt=rm&q=${encodeURIComponent(text)}`;
   },
 
   // Supported Languages

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -139,4 +139,6 @@ BetterLyrics.Constants = {
   LRCLIB_TIMEOUT_LOG: "[BetterLyrics] LRCLIB request timed out",
   NO_VALID_LRCLIB_LYRICS_LOG: "[BetterLyrics] No valid lyrics returned from LRCLIB",
   INVALID_CACHE_DATA_LOG: "[BetterLyrics] Invalid data structure in cache",
+
+  NO_LYRICS_TEXT: "No lyrics found for this song",
 };

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -141,4 +141,5 @@ BetterLyrics.Constants = {
   INVALID_CACHE_DATA_LOG: "[BetterLyrics] Invalid data structure in cache",
 
   NO_LYRICS_TEXT: "No lyrics found for this song",
+  MUSIC_NOTES: "♪𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲",
 };

--- a/src/index.css
+++ b/src/index.css
@@ -67,6 +67,10 @@
   z-index: 1;
 }
 
+.blyrics-hidden {
+  display: none !important;
+}
+
 .blyrics-container > div {
   cursor: pointer;
   padding-bottom: var(--blyrics-padding) !important;

--- a/src/index.css
+++ b/src/index.css
@@ -171,9 +171,8 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  margin-bottom: 4rem !important;
-  margin: 16px 0;
-  margin-top: 0 !important;
+  margin-top: 2rem;
+  margin-bottom: 4rem;
 }
 
 .blyrics-footer__discord {

--- a/src/index.js
+++ b/src/index.js
@@ -69,7 +69,7 @@ BetterLyrics.App = {
         document.addEventListener("DOMContentLoaded", this.modify.bind(this));
       }
     } catch (err) {
-      Utils.log(GENERAL_ERROR_LOG, err);
+      BetterLyrics.Utils.log(GENERAL_ERROR_LOG, err);
     }
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ BetterLyrics.App = {
   lang: "en",
   areLyricsTicking: false,
   areLyricsLoaded: false,
+  lyricInjectionFailed: false,
   lastVideoId: null,
   lastVideoDetails: null,
   lyricInjectionPromise: null,
@@ -49,8 +50,9 @@ BetterLyrics.App = {
           return BetterLyrics.DOM.tickLyrics(currentTime);
         })
         .catch(err => {
-          BetterLyrics.Utils.log(GENERAL_ERROR_LOG, err);
+          BetterLyrics.Utils.log(BetterLyrics.App.GENERAL_ERROR_LOG, err);
           BetterLyrics.App.areLyricsLoaded = false;
+          BetterLyrics.App.lyricInjectionFailed = true;
         });
     }
   },

--- a/src/index.js
+++ b/src/index.js
@@ -38,16 +38,16 @@ BetterLyrics.App = {
     );
   },
 
-  handleModifications: function (song, artist, currentTime, videoId, duration, audioTrackData) {
+  handleModifications: function (detail) {
     if (BetterLyrics.App.lyricInjectionPromise) {
       BetterLyrics.App.lyricInjectionPromise.then(() => {
         BetterLyrics.App.lyricInjectionPromise = null;
-        BetterLyrics.App.handleModifications(song, artist, currentTime, videoId, duration, audioTrackData);
+        BetterLyrics.App.handleModifications(detail);
       });
     } else {
-      BetterLyrics.App.lyricInjectionPromise = BetterLyrics.Lyrics.createLyrics(song, artist, videoId, duration, audioTrackData)
+      BetterLyrics.App.lyricInjectionPromise = BetterLyrics.Lyrics.createLyrics(detail)
         .then(() => {
-          return BetterLyrics.DOM.tickLyrics(currentTime);
+          return BetterLyrics.DOM.tickLyrics(detail.currentTime);
         })
         .catch(err => {
           BetterLyrics.Utils.log(BetterLyrics.App.GENERAL_ERROR_LOG, err);

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ BetterLyrics.App = {
     BetterLyrics.Settings.listenForPopupMessages();
     BetterLyrics.Observer.lyricReloader();
     BetterLyrics.Observer.initializeLyrics();
+    BetterLyrics.LyricProviders.initProviders();
 
     BetterLyrics.Utils.log(
       BetterLyrics.Constants.INITIALIZE_LOG,
@@ -36,19 +37,19 @@ BetterLyrics.App = {
     );
   },
 
-  handleModifications: function (song, artist, currentTime, videoId) {
+  handleModifications: function (song, artist, currentTime, videoId, duration) {
     if (BetterLyrics.App.lyricInjectionPromise) {
       BetterLyrics.App.lyricInjectionPromise.then(() => {
         BetterLyrics.App.lyricInjectionPromise = null;
-        BetterLyrics.App.handleModifications(song, artist, currentTime, videoId);
+        BetterLyrics.App.handleModifications(song, artist, currentTime, videoId, duration);
       });
     } else {
-      BetterLyrics.App.lyricInjectionPromise = BetterLyrics.Lyrics.createLyrics(song, artist, videoId)
+      BetterLyrics.App.lyricInjectionPromise = BetterLyrics.Lyrics.createLyrics(song, artist, videoId, duration)
         .then(() => {
           return BetterLyrics.DOM.tickLyrics(currentTime);
         })
         .catch(err => {
-          BetterLyrics.Utils.log(BetterLyrics.Constants.GENERAL_ERROR_LOG, err);
+          BetterLyrics.Utils.log(GENERAL_ERROR_LOG, err);
           BetterLyrics.App.areLyricsLoaded = false;
         });
     }
@@ -66,7 +67,7 @@ BetterLyrics.App = {
         document.addEventListener("DOMContentLoaded", this.modify.bind(this));
       }
     } catch (err) {
-      BetterLyrics.Utils.log(BetterLyrics.Constants.GENERAL_ERROR_LOG, err);
+      Utils.log(GENERAL_ERROR_LOG, err);
     }
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -38,14 +38,14 @@ BetterLyrics.App = {
     );
   },
 
-  handleModifications: function (song, artist, currentTime, videoId, duration) {
+  handleModifications: function (song, artist, currentTime, videoId, duration, audioTrackData) {
     if (BetterLyrics.App.lyricInjectionPromise) {
       BetterLyrics.App.lyricInjectionPromise.then(() => {
         BetterLyrics.App.lyricInjectionPromise = null;
-        BetterLyrics.App.handleModifications(song, artist, currentTime, videoId, duration);
+        BetterLyrics.App.handleModifications(song, artist, currentTime, videoId, duration, audioTrackData);
       });
     } else {
-      BetterLyrics.App.lyricInjectionPromise = BetterLyrics.Lyrics.createLyrics(song, artist, videoId, duration)
+      BetterLyrics.App.lyricInjectionPromise = BetterLyrics.Lyrics.createLyrics(song, artist, videoId, duration, audioTrackData)
         .then(() => {
           return BetterLyrics.DOM.tickLyrics(currentTime);
         })

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ BetterLyrics.App = {
   shouldInjectAlbumArt: "Unknown",
   queueSongDetailsInjection: false,
   loaderAnimationEndTimeout: null,
+  requestCache: null,
 
   modify: function () {
     BetterLyrics.Utils.setUpLog();
@@ -69,7 +70,7 @@ BetterLyrics.App = {
         document.addEventListener("DOMContentLoaded", this.modify.bind(this));
       }
     } catch (err) {
-      BetterLyrics.Utils.log(GENERAL_ERROR_LOG, err);
+      BetterLyrics.Utils.log(BetterLyrics.GENERAL_ERROR_LOG, err);
     }
   },
 };

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -14,22 +14,20 @@ BetterLyrics.Lyrics = {
     const spinner = document.querySelector("#tab-renderer > tp-yt-paper-spinner-lite");
     let waitForLoaderPromise;
     if (spinner) {
-      waitForLoaderPromise = new Promise((resolve, reject) => {
+      waitForLoaderPromise = new Promise(resolve => {
         if (spinner.style.display !== "none") {
           resolve(true);
           return;
         }
-        let observer = new MutationObserver(mutations => {
+        let observer = new MutationObserver(() => {
           observer.disconnect();
           resolve(true);
-        })
+        });
         observer.observe(spinner, {
-          attributes: true
+          attributes: true,
         });
       });
     }
-
-
 
     // Try to get lyrics from cache with validation
     const cacheKey = `blyrics_${videoId}`;
@@ -99,7 +97,7 @@ BetterLyrics.Lyrics = {
 
         if (lyrics && Array.isArray(lyrics.lyrics) && lyrics.lyrics.length > 0) {
           if (!ytLyrics) {
-            ytLyrics = await BetterLyrics.LyricProviders.ytLyrics(waitForLoaderPromise)
+            ytLyrics = await BetterLyrics.LyricProviders.ytLyrics(waitForLoaderPromise);
           }
 
           // TODO compare ytLyrics w/ the returned lyrics and reject if they don't match.
@@ -111,7 +109,7 @@ BetterLyrics.Lyrics = {
     }
 
     if (!ytLyrics) {
-      ytLyrics = await BetterLyrics.LyricProviders.ytLyrics(waitForLoaderPromise)
+      ytLyrics = await BetterLyrics.LyricProviders.ytLyrics(waitForLoaderPromise);
     }
 
     if (!lyrics) {
@@ -130,7 +128,6 @@ BetterLyrics.Lyrics = {
   },
 
   processLyrics: function (data) {
-
     BetterLyrics.App.lang = data.language;
     BetterLyrics.DOM.setRtlAttributes(data.isRtlLanguage);
 
@@ -144,19 +141,19 @@ BetterLyrics.Lyrics = {
 
     const ytMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR)?.parentElement;
     if (ytMusicLyrics) {
-      ytMusicLyrics.classList.add("blyrics-hidden")
+      ytMusicLyrics.classList.add("blyrics-hidden");
     }
 
     const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
     if (existingLyrics) {
       for (let lyrics of existingLyrics) {
-        lyrics.classList.add("blyrics-hidden")
+        lyrics.classList.add("blyrics-hidden");
       }
     }
 
     const existingFooter = document.getElementsByClassName(BetterLyrics.Constants.YT_MUSIC_FOOTER_CLASS)[0];
     if (existingFooter) {
-      existingFooter.classList.add("blyrics-hidden")
+      existingFooter.classList.add("blyrics-hidden");
     }
 
     try {

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -55,39 +55,26 @@ BetterLyrics.Lyrics = {
     for (let provider of BetterLyrics.LyricProviders.providersList) {
       try {
         lyrics = await provider(song, artist, duration);
-        break;
+        if (lyrics) {
+          break;
+        }
       } catch (err) {
         BetterLyrics.Utils.log(err);
       }
     }
 
-    const hasYtMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR);
-    console.log(hasYtMusicLyrics);
-    if (hasYtMusicLyrics &&
-      hasYtMusicLyrics.innerText !== "Lyrics not available" &&
-      hasYtMusicLyrics.parentElement.style.display === "none") {
-
-      BetterLyrics.Utils.log(BetterLyrics.Constants.YT_MUSIC_LYRICS_AVAILABLE_LOG);
-      const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
-      console.log(existingLyrics);
-    }
-
     if (!lyrics) {
-      BetterLyrics.DOM.injectError();
+      throw new Error(BetterLyrics.Constants.NO_LYRICS_FOUND_LOG);
     }
 
     this.cacheAndProcessLyrics(cacheKey, lyrics);
   },
 
   cacheAndProcessLyrics: function (cacheKey, data) {
-    try {
-      const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
-      BetterLyrics.Storage.setTransientStorage(cacheKey, JSON.stringify(data), oneWeekInMs);
-      BetterLyrics.Lyrics.processLyrics(data);
-    } catch (error) {
-      BetterLyrics.Utils.log(BetterLyrics.Constants.CACHE_PROCESS_ERROR_LOG, error);
-      setTimeout(BetterLyrics.DOM.injectError, 500);
-    }
+    const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
+    BetterLyrics.Storage.setTransientStorage(cacheKey, JSON.stringify(data), oneWeekInMs);
+    BetterLyrics.Lyrics.processLyrics(data);
+
   },
 
   processLyrics: function (data) {
@@ -99,9 +86,7 @@ BetterLyrics.Lyrics = {
 
     if (!lyrics || lyrics.length === 0) {
       console.log(data);
-      BetterLyrics.Utils.log(BetterLyrics.Constants.NO_LYRICS_FOUND_LOG);
-      setTimeout(BetterLyrics.DOM.injectError, 500);
-      return;
+      throw new Error(BetterLyrics.Constants.NO_LYRICS_FOUND_LOG);
     }
 
     BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_FOUND_LOG);
@@ -268,11 +253,10 @@ BetterLyrics.Lyrics = {
 
     if (!allZero) {
       BetterLyrics.Lyrics.setupLyricsCheckInterval();
-      BetterLyrics.App.areLyricsLoaded = true;
     } else {
       BetterLyrics.Utils.log(BetterLyrics.Constants.SYNC_DISABLED_LOG);
-      BetterLyrics.App.areLyricsLoaded = true;
     }
+    BetterLyrics.App.areLyricsLoaded = true;
   },
   setupLyricsCheckInterval: function () {
     BetterLyrics.App.areLyricsTicking = true;

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -1,5 +1,5 @@
 BetterLyrics.Lyrics = {
-  createLyrics: async function (song, artist, videoId, duration) {
+  createLyrics: async function (song, artist, videoId, duration, audioTrackData) {
     if (!videoId || typeof videoId !== "string") {
       BetterLyrics.Utils.log(BetterLyrics.Constants.SERVER_ERROR_LOG, "Invalid video id");
       return;
@@ -54,8 +54,8 @@ BetterLyrics.Lyrics = {
     let lyrics;
     for (let provider of BetterLyrics.LyricProviders.providersList) {
       try {
-        lyrics = await provider(song, artist, duration);
-        if (lyrics) {
+        lyrics = await provider(song, artist, duration, videoId, audioTrackData);
+        if (lyrics && Array.isArray(lyrics.lyrics) && lyrics.lyrics.length > 0) {
           break;
         }
       } catch (err) {

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -78,7 +78,6 @@ BetterLyrics.Lyrics = {
 
   processLyrics: function (data) {
     const lyrics = data.lyrics;
-    console.log(lyrics);
 
     BetterLyrics.App.lang = data.language;
     BetterLyrics.DOM.setRtlAttributes(data.isRtlLanguage);

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -74,7 +74,6 @@ BetterLyrics.Lyrics = {
     const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
     BetterLyrics.Storage.setTransientStorage(cacheKey, JSON.stringify(data), oneWeekInMs);
     BetterLyrics.Lyrics.processLyrics(data);
-
   },
 
   processLyrics: function (data) {

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -146,7 +146,9 @@ BetterLyrics.Lyrics = {
   injectLyrics: function (lyrics) {
     BetterLyrics.DOM.cleanup();
     let lyricsWrapper = BetterLyrics.DOM.createLyricsWrapper();
-    BetterLyrics.DOM.addFooter();
+    if (lyrics[0].words !== BetterLyrics.Constants.NO_LYRICS_TEXT) {
+      BetterLyrics.DOM.addFooter();
+    }
 
     try {
       lyricsWrapper.innerHTML = "";

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -1,5 +1,11 @@
 BetterLyrics.Lyrics = {
-  createLyrics: async function (song, artist, videoId, duration, audioTrackData) {
+  createLyrics: async function (detail) {
+    let song = detail.song;
+    let artist = detail.artist;
+    const videoId = detail.videoId;
+    const duration = detail.duration;
+    const audioTrackData = detail.audioTrackData;
+
     if (!videoId || typeof videoId !== "string") {
       BetterLyrics.Utils.log(BetterLyrics.Constants.SERVER_ERROR_LOG, "Invalid video id");
       return;

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -214,10 +214,12 @@ BetterLyrics.Lyrics = {
         }
         const translationResult = await BetterLyrics.Translation.translateText(text, "en");
         BetterLyrics.App.lang = translationResult.originalLanguage;
-        BetterLyrics.Utils.log("[BetterLyrics] Lang was missing. Determined it is: " + translationResult.originalLanguage);
+        BetterLyrics.Utils.log(
+          "[BetterLyrics] Lang was missing. Determined it is: " + translationResult.originalLanguage
+        );
       }
       return resolve(BetterLyrics.App.lang);
-    })
+    });
 
     lyrics.forEach(item => {
       let line = document.createElement("div");
@@ -246,7 +248,7 @@ BetterLyrics.Lyrics = {
         line.appendChild(span);
       });
 
-      langPromise.then((source_language) => {
+      langPromise.then(source_language => {
         BetterLyrics.Translation.onRomanizationEnabled(
           async () => {
             let romanizedLine = document.createElement("span");
@@ -287,7 +289,8 @@ BetterLyrics.Lyrics = {
                 }
               }
             });
-          });
+          }
+        );
 
         try {
           document.getElementsByClassName(BetterLyrics.Constants.LYRICS_CLASS)[0].appendChild(line);

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -83,11 +83,11 @@ BetterLyrics.Lyrics = {
   },
 
   processLyrics: function (data) {
-    const lyrics = data.lyrics;
 
     BetterLyrics.App.lang = data.language;
     BetterLyrics.DOM.setRtlAttributes(data.isRtlLanguage);
 
+    const lyrics = data.lyrics;
     if (!lyrics || lyrics.length === 0) {
       console.log(data);
       throw new Error(BetterLyrics.Constants.NO_LYRICS_FOUND_LOG);
@@ -142,16 +142,17 @@ BetterLyrics.Lyrics = {
       });
     }
 
-    BetterLyrics.Lyrics.injectLyrics(lyrics);
+    BetterLyrics.Lyrics.injectLyrics(data);
 
     BetterLyrics.App.lyricsObserver = observer;
   },
 
-  injectLyrics: function (lyrics) {
+  injectLyrics: function (data) {
+    const lyrics = data.lyrics;
     BetterLyrics.DOM.cleanup();
     let lyricsWrapper = BetterLyrics.DOM.createLyricsWrapper();
     if (lyrics[0].words !== BetterLyrics.Constants.NO_LYRICS_TEXT) {
-      BetterLyrics.DOM.addFooter();
+      BetterLyrics.DOM.addFooter(data.source, data.sourceHref);
     }
 
     try {
@@ -177,6 +178,9 @@ BetterLyrics.Lyrics = {
     });
 
     const allZero = lyrics.every(item => item.startTimeMs === "0");
+    if (lyrics[lyrics.length - 1].words === "") {
+      lyrics.pop();
+    }
 
     lyrics.forEach(item => {
       let line = document.createElement("div");

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -1,13 +1,12 @@
 BetterLyrics.LyricProviders = {
   providersList: [],
 
-  bLyrics: async function(song, artist, duration) {
+  bLyrics: async function (song, artist, duration) {
     // Fetch from the primary API if cache is empty or invalid
     const url = new URL(BetterLyrics.Constants.LYRICS_API_URL);
     url.searchParams.append("s", song);
     url.searchParams.append("a", artist);
     url.searchParams.append("d", duration);
-
 
     const response = await fetch(url.toString(), { signal: AbortSignal.timeout(10000) });
 
@@ -24,7 +23,7 @@ BetterLyrics.LyricProviders = {
     return data;
   },
 
-  lyricLib: async function(song, artist, duration) {
+  lyricLib: async function (song, artist, duration) {
     const url = new URL(BetterLyrics.Constants.LRCLIB_API_URL);
     url.searchParams.append("track_name", song);
     url.searchParams.append("artist_name", artist);
@@ -34,7 +33,7 @@ BetterLyrics.LyricProviders = {
       headers: {
         "Lrclib-Client": BetterLyrics.Constants.LRCLIB_CLIENT_HEADER,
       },
-      signal: AbortSignal.timeout(10000)
+      signal: AbortSignal.timeout(10000),
     });
 
     if (!response.ok) {
@@ -45,13 +44,13 @@ BetterLyrics.LyricProviders = {
 
     if (data && data.syncedLyrics && typeof data.duration === "number") {
       BetterLyrics.Utils.log(BetterLyrics.Constants.LRCLIB_LYRICS_FOUND_LOG);
-      return {lyrics: BetterLyrics.LyricProviders.parseLRCLIBLyrics(data.syncedLyrics, data.duration)};
+      return { lyrics: BetterLyrics.LyricProviders.parseLRCLIBLyrics(data.syncedLyrics, data.duration) };
     } else {
       throw new Error(BetterLyrics.Constants.NO_LRCLIB_LYRICS_FOUND_LOG);
     }
   },
 
-  parseLRCLIBLyrics: function(syncedLyrics, duration) {
+  parseLRCLIBLyrics: function (syncedLyrics, duration) {
     const lines = syncedLyrics.split("\n");
     const lyricsArray = [];
 
@@ -88,14 +87,15 @@ BetterLyrics.LyricProviders = {
 
     return lyricsArray;
   },
-  ytLyrics: async function(song, artist, duration){
-
+  ytLyrics: async function (song, artist, duration) {
     let lyricText;
 
     const hasYtMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR);
-    if (hasYtMusicLyrics &&
+    if (
+      hasYtMusicLyrics &&
       hasYtMusicLyrics.innerText === "Lyrics not available" &&
-      hasYtMusicLyrics.parentElement.style.display !== "none") {
+      hasYtMusicLyrics.parentElement.style.display !== "none"
+    ) {
       lyricText = BetterLyrics.Constants.NO_LYRICS_TEXT;
     } else {
       const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
@@ -103,20 +103,21 @@ BetterLyrics.LyricProviders = {
     }
 
     const lyricsArray = [];
-    lyricText.split("\n").forEach(
-      words => {
-        lyricsArray.push({
-          startTimeMs: "0",
-          words: words,
-          durationMs: "0",
-        });
-      }
-    )
+    lyricText.split("\n").forEach(words => {
+      lyricsArray.push({
+        startTimeMs: "0",
+        words: words,
+        durationMs: "0",
+      });
+    });
 
-    return {lyrics: lyricsArray};
-
+    return { lyrics: lyricsArray };
   },
-  initProviders: function (){
-    BetterLyrics.LyricProviders.providersList = [BetterLyrics.LyricProviders.bLyrics, BetterLyrics.LyricProviders.lyricLib, BetterLyrics.LyricProviders.ytLyrics];
-  }
-}
+  initProviders: function () {
+    BetterLyrics.LyricProviders.providersList = [
+      BetterLyrics.LyricProviders.bLyrics,
+      BetterLyrics.LyricProviders.lyricLib,
+      BetterLyrics.LyricProviders.ytLyrics,
+    ];
+  },
+};

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -217,7 +217,17 @@ BetterLyrics.LyricProviders = {
       for (let segsKey in event.segs) {
         words += event.segs[segsKey].utf8;
       }
-
+      words = words.replaceAll("\n", " ");
+      for (let c of BetterLyrics.Constants.MUSIC_NOTES) {
+        words = words.trim();
+        if (words.startsWith(c)) {
+          words = words.substring(1);
+        }
+        if (words.endsWith(c)) {
+          words = words.substring(0, words.length - 1);
+        }
+      }
+      words = words.trim();
       lyricsArray.push({
         startTimeMs: event.tStartMs,
         words: words,

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -43,7 +43,6 @@ BetterLyrics.LyricProviders = {
    * @property {string} captionsInitialState
    */
 
-
   providersList: [],
 
   bLyrics: async function (song, artist, duration) {
@@ -132,7 +131,7 @@ BetterLyrics.LyricProviders = {
 
     return lyricsArray;
   },
-  ytLyrics: async function (song, artist, duration) {
+  ytLyrics: async function (_song, _artist, _duration) {
     let lyricText;
 
     const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
@@ -166,7 +165,7 @@ BetterLyrics.LyricProviders = {
   /**
    * @type{function(song: string, artist: string, duration:number, videoId: string, audioTrackData:audioTrackData)}
    */
-  ytCaptions: async function(song, artist, duration, videoId, audioTrackData) {
+  ytCaptions: async function (_song, _artist, _duration, _videoId, audioTrackData) {
     if (audioTrackData.captionTracks.length === 0) {
       return;
     }
@@ -175,6 +174,7 @@ BetterLyrics.LyricProviders = {
       langCode = audioTrackData.captionTracks[0].languageCode;
     } else {
       // Try and determine the language by finding an auto generated track
+      // TODO: This sucks as a method
       for (let captionTracksKey in audioTrackData.captionTracks) {
         let data = audioTrackData.captionTracks[captionTracksKey];
         if (data.displayName.includes("auto-generated")) {
@@ -185,7 +185,7 @@ BetterLyrics.LyricProviders = {
     }
 
     if (!langCode) {
-      console.log(audioTrackData);
+      BetterLyrics.Utils.log(audioTrackData);
       throw new Error("Found Caption Tracks, but couldn't determine the default");
     }
 
@@ -199,7 +199,7 @@ BetterLyrics.LyricProviders = {
     }
 
     if (!captionsUrl) {
-      console.log(audioTrackData);
+      BetterLyrics.Utils.log(audioTrackData);
       throw new Error("Only found auto generated lyrics, not using");
     }
 
@@ -207,13 +207,12 @@ BetterLyrics.LyricProviders = {
     captionsUrl.searchParams.set("fmt", "json3");
 
     let captionData = await fetch(captionsUrl, {
-      method: "GET"
-    }).then(response => response.json())
-    console.log(captionData);
+      method: "GET",
+    }).then(response => response.json());
 
     let lyricsArray = [];
 
-    captionData.events.forEach((event) => {
+    captionData.events.forEach(event => {
       let words = "";
       for (let segsKey in event.segs) {
         words += event.segs[segsKey].utf8;
@@ -225,7 +224,6 @@ BetterLyrics.LyricProviders = {
         durationMs: event.dDurationMs,
       });
     });
-
     return { lyrics: lyricsArray, language: langCode };
   },
   initProviders: function () {

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -89,8 +89,18 @@ BetterLyrics.LyricProviders = {
     return lyricsArray;
   },
   ytLyrics: async function(song, artist, duration){
-    const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
-    const lyricText = existingLyrics[0].innerText;
+
+    let lyricText;
+
+    const hasYtMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR);
+    if (hasYtMusicLyrics &&
+      hasYtMusicLyrics.innerText === "Lyrics not available" &&
+      hasYtMusicLyrics.parentElement.style.display !== "none") {
+      lyricText = BetterLyrics.Constants.NO_LYRICS_TEXT;
+    } else {
+      const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
+      lyricText = existingLyrics[0].innerText;
+    }
 
     const lyricsArray = [];
     lyricText.split("\n").forEach(

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -65,7 +65,7 @@ BetterLyrics.LyricProviders = {
     }
 
     data.source = "boidu.dev";
-    data.sourceHref = "https://better-lyrics.boidu.dev"
+    data.sourceHref = "https://better-lyrics.boidu.dev";
 
     return data;
   },
@@ -94,7 +94,7 @@ BetterLyrics.LyricProviders = {
       return {
         lyrics: BetterLyrics.LyricProviders.parseLRCLIBLyrics(data.syncedLyrics, data.duration),
         source: "LRCLib",
-        sourceHref: "https://lrclib.net/"
+        sourceHref: "https://lrclib.net/",
       };
     } else {
       throw new Error(BetterLyrics.Constants.NO_LRCLIB_LYRICS_FOUND_LOG);
@@ -145,7 +145,7 @@ BetterLyrics.LyricProviders = {
       throw new Error("Lyrics not ready yet!");
     }
 
-    const delay = (ms) => new Promise((resolve, reject) => setTimeout(() => resolve(false), ms));
+    const delay = ms => new Promise(resolve => setTimeout(() => resolve(false), ms));
 
     if (await Promise.race([delay(2000), waitForLoaderPromise])) {
       BetterLyrics.Utils.log("Found Loader, waiting for completion");
@@ -153,19 +153,19 @@ BetterLyrics.LyricProviders = {
       BetterLyrics.Utils.log("Timed out waiting for loader");
     }
 
-    let waitForLoaderFinishPromise = new Promise((resolve, reject) => {
+    let waitForLoaderFinishPromise = new Promise(resolve => {
       if (spinner.style.display === "none") {
         resolve(true);
         return;
       }
-      let observer = new MutationObserver(mutations => {
+      let observer = new MutationObserver(() => {
         if (spinner.style.display === "none") {
           observer.disconnect();
           resolve(true);
         }
-      })
+      });
       observer.observe(spinner, {
-        attributes: true
+        attributes: true,
       });
     });
 
@@ -182,9 +182,10 @@ BetterLyrics.LyricProviders = {
       throw new Error("Lyrics aren't ready yet");
     }
 
-
-    if (!document.querySelector("#tab-renderer > ytmusic-section-list-renderer") ||
-      document.querySelector("#tab-renderer > ytmusic-section-list-renderer").style.display === "none") {
+    if (
+      !document.querySelector("#tab-renderer > ytmusic-section-list-renderer") ||
+      document.querySelector("#tab-renderer > ytmusic-section-list-renderer").style.display === "none"
+    ) {
       lyricText = BetterLyrics.Constants.NO_LYRICS_TEXT;
     } else {
       let existingLyrics;
@@ -197,7 +198,9 @@ BetterLyrics.LyricProviders = {
       lyricText = existingLyrics.innerText;
     }
 
-    const source = document.querySelector("#contents > ytmusic-description-shelf-renderer > yt-formatted-string.footer.style-scope.ytmusic-description-shelf-renderer");
+    const source = document.querySelector(
+      "#contents > ytmusic-description-shelf-renderer > yt-formatted-string.footer.style-scope.ytmusic-description-shelf-renderer"
+    );
     let sourceText;
     if (!source) {
       sourceText = "Unknown";
@@ -219,7 +222,7 @@ BetterLyrics.LyricProviders = {
       source: sourceText + " (via YT)",
       sourceHref: "",
       cacheAllowed: false,
-      text: lyricText
+      text: lyricText,
     };
   },
 

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -90,6 +90,11 @@ BetterLyrics.LyricProviders = {
   ytLyrics: async function (song, artist, duration) {
     let lyricText;
 
+    const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
+    if (tabSelector.getAttribute("aria-selected") !== "true") {
+      throw new Error("Lyrics Tab Not Visible");
+    }
+
     const hasYtMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR);
     if (
       hasYtMusicLyrics &&

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -1,0 +1,94 @@
+BetterLyrics.LyricProviders = {
+  providersList: [],
+
+  bLyrics: async function(song, artist, duration) {
+    // Fetch from the primary API if cache is empty or invalid
+    const url = new URL(BetterLyrics.Constants.LYRICS_API_URL);
+    url.searchParams.append("s", song);
+    url.searchParams.append("a", artist);
+    url.searchParams.append("d", duration);
+
+
+    const response = await fetch(url.toString(), { signal: AbortSignal.timeout(10000) });
+
+    if (!response.ok) {
+      throw new Error(`${BetterLyrics.Constants.HTTP_ERROR_LOG} ${response.status}`);
+    }
+
+    const data = await response.json();
+    // Validate API response structure
+    if (!data || (!Array.isArray(data.lyrics) && !data.syncedLyrics)) {
+      throw new Error("Invalid API response structure");
+    }
+
+    return data;
+  },
+
+  lyricLib: async function(song, artist, duration) {
+    const url = new URL(BetterLyrics.Constants.LRCLIB_API_URL);
+    url.searchParams.append("track_name", song);
+    url.searchParams.append("artist_name", artist);
+    url.searchParams.append("duration", duration);
+
+    const response = await fetch(url.toString(), {
+      headers: {
+        "Lrclib-Client": BetterLyrics.Constants.LRCLIB_CLIENT_HEADER,
+      },
+      signal: AbortSignal.timeout(10000)
+    });
+
+    if (!response.ok) {
+      throw new Error(BetterLyrics.Constants.HTTP_ERROR_LOG + response.status);
+    }
+
+    const data = await response.json();
+
+    if (data && data.syncedLyrics && typeof data.duration === "number") {
+      BetterLyrics.Utils.log(BetterLyrics.Constants.LRCLIB_LYRICS_FOUND_LOG);
+      return {lyrics: BetterLyrics.LyricProviders.parseLRCLIBLyrics(data.syncedLyrics, data.duration)};
+    } else {
+      throw new Error(BetterLyrics.Constants.NO_LRCLIB_LYRICS_FOUND_LOG);
+    }
+  },
+
+  parseLRCLIBLyrics: function(syncedLyrics, duration) {
+    const lines = syncedLyrics.split("\n");
+    const lyricsArray = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const match = line.match(/^\[(\d{2}):(\d{2}\.\d{2})\](.*)/);
+      if (match) {
+        const minutes = parseInt(match[1]);
+        const seconds = parseFloat(match[2]);
+        const words = match[3].trim();
+        const startTimeMs = Math.floor((minutes * 60 + seconds) * 1000);
+
+        lyricsArray.push({
+          startTimeMs: startTimeMs.toString(),
+          words: words,
+          durationMs: "0", // Will calculate later
+        });
+      }
+    }
+
+    // Calculate durationMs for each lyric line
+    for (let i = 0; i < lyricsArray.length; i++) {
+      if (i < lyricsArray.length - 1) {
+        const nextStartTimeMs = parseInt(lyricsArray[i + 1].startTimeMs);
+        const currentStartTimeMs = parseInt(lyricsArray[i].startTimeMs);
+        lyricsArray[i].durationMs = (nextStartTimeMs - currentStartTimeMs).toString();
+      } else {
+        // For the last line, use the total duration
+        const totalDurationMs = duration * 1000;
+        const currentStartTimeMs = parseInt(lyricsArray[i].startTimeMs);
+        lyricsArray[i].durationMs = (totalDurationMs - currentStartTimeMs).toString();
+      }
+    }
+
+    return lyricsArray;
+  },
+  initProviders: function (){
+    BetterLyrics.LyricProviders.providersList = [BetterLyrics.LyricProviders.bLyrics, BetterLyrics.LyricProviders.lyricLib];
+  }
+}

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -88,7 +88,25 @@ BetterLyrics.LyricProviders = {
 
     return lyricsArray;
   },
+  ytLyrics: async function(song, artist, duration){
+    const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
+    const lyricText = existingLyrics[0].innerText;
+
+    const lyricsArray = [];
+    lyricText.split("\n").forEach(
+      words => {
+        lyricsArray.push({
+          startTimeMs: "0",
+          words: words,
+          durationMs: "0",
+        });
+      }
+    )
+
+    return {lyrics: lyricsArray};
+
+  },
   initProviders: function (){
-    BetterLyrics.LyricProviders.providersList = [BetterLyrics.LyricProviders.bLyrics, BetterLyrics.LyricProviders.lyricLib];
+    BetterLyrics.LyricProviders.providersList = [BetterLyrics.LyricProviders.bLyrics, BetterLyrics.LyricProviders.lyricLib, BetterLyrics.LyricProviders.ytLyrics];
   }
 }

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -135,9 +135,11 @@ BetterLyrics.LyricProviders = {
     let lyricText;
 
     const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
-    if (tabSelector.getAttribute("aria-selected") !== "true") {
-      throw new Error("Lyrics Tab Not Visible");
+    const spinner = document.querySelector("#tab-renderer > tp-yt-paper-spinner-lite");
+    if (tabSelector.getAttribute("aria-selected") !== "true" || !spinner || spinner.style.display === "") {
+      throw new Error("Lyrics aren't ready yet");
     }
+
 
     const hasYtMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR);
     if (

--- a/src/modules/lyrics/providers.js
+++ b/src/modules/lyrics/providers.js
@@ -64,6 +64,9 @@ BetterLyrics.LyricProviders = {
       throw new Error("Invalid API response structure");
     }
 
+    data.source = "boidu.dev";
+    data.sourceHref = "https://better-lyrics.boidu.dev"
+
     return data;
   },
 
@@ -88,7 +91,11 @@ BetterLyrics.LyricProviders = {
 
     if (data && data.syncedLyrics && typeof data.duration === "number") {
       BetterLyrics.Utils.log(BetterLyrics.Constants.LRCLIB_LYRICS_FOUND_LOG);
-      return { lyrics: BetterLyrics.LyricProviders.parseLRCLIBLyrics(data.syncedLyrics, data.duration) };
+      return {
+        lyrics: BetterLyrics.LyricProviders.parseLRCLIBLyrics(data.syncedLyrics, data.duration),
+        source: "LRCLib",
+        sourceHref: "https://lrclib.net/"
+      };
     } else {
       throw new Error(BetterLyrics.Constants.NO_LRCLIB_LYRICS_FOUND_LOG);
     }
@@ -153,6 +160,14 @@ BetterLyrics.LyricProviders = {
       lyricText = existingLyrics[0].innerText;
     }
 
+    const source = document.querySelector("#contents > ytmusic-description-shelf-renderer > yt-formatted-string.footer.style-scope.ytmusic-description-shelf-renderer");
+    let sourceText;
+    if (!source) {
+      sourceText = "Unknown";
+    } else {
+      sourceText = source.innerText.substring(8);
+    }
+
     const lyricsArray = [];
     lyricText.split("\n").forEach(words => {
       lyricsArray.push({
@@ -162,7 +177,11 @@ BetterLyrics.LyricProviders = {
       });
     });
 
-    return { lyrics: lyricsArray };
+    return {
+      lyrics: lyricsArray,
+      source: sourceText + " (via YT)",
+      sourceHref: ""
+    };
   },
   /**
    * @type{function(song: string, artist: string, duration:number, videoId: string, audioTrackData:audioTrackData)}
@@ -236,7 +255,7 @@ BetterLyrics.LyricProviders = {
         durationMs: event.dDurationMs,
       });
     });
-    return { lyrics: lyricsArray, language: langCode };
+    return { lyrics: lyricsArray, language: langCode, source: "Youtube Captions", sourceHref: "" };
   },
   initProviders: function () {
     BetterLyrics.LyricProviders.providersList = [

--- a/src/modules/lyrics/translation.js
+++ b/src/modules/lyrics/translation.js
@@ -1,5 +1,5 @@
 BetterLyrics.Translation = {
-  translateText: function (text, targetLanguage) {
+  translateText: async function (text, targetLanguage) {
     let url = BetterLyrics.Constants.TRANSLATE_LYRICS_URL(targetLanguage, text);
 
     return fetch(url)

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -159,54 +159,6 @@ BetterLyrics.DOM = {
       BetterLyrics.Utils.log(err);
     }
   },
-
-  injectError: function () {
-    BetterLyrics.DOM.cleanup();
-    const message = "No lyrics found for this song.";
-
-    try {
-      const hasYtMusicLyrics = document.querySelector(BetterLyrics.Constants.NO_LYRICS_TEXT_SELECTOR);
-
-      if (hasYtMusicLyrics) {
-        if (
-          hasYtMusicLyrics.innerText === "Lyrics not available" &&
-          hasYtMusicLyrics.parentElement.style.display !== "none"
-        ) {
-          let lyricsWrapper = document.getElementById(BetterLyrics.Constants.LYRICS_WRAPPER_ID);
-
-          if (!lyricsWrapper) {
-            lyricsWrapper = BetterLyrics.DOM.createLyricsWrapper();
-          }
-
-          const errorContainer = document.createElement("div");
-          errorContainer.className = BetterLyrics.Constants.ERROR_LYRICS_CLASS;
-          errorContainer.innerText = message;
-
-          if (lyricsWrapper) {
-            lyricsWrapper.innerHTML = "";
-          }
-
-          lyricsWrapper.appendChild(errorContainer);
-          BetterLyrics.DOM.flushLoader();
-
-          return;
-        }
-      }
-      BetterLyrics.Utils.log(BetterLyrics.Constants.YT_MUSIC_LYRICS_AVAILABLE_LOG);
-      const existingLyrics = document.getElementsByClassName(BetterLyrics.Constants.DESCRIPTION_CLASS);
-      const existingFooter = document.getElementsByClassName(BetterLyrics.Constants.YT_MUSIC_FOOTER_CLASS)[0];
-      if (existingLyrics && existingFooter) {
-        for (let lyrics of existingLyrics) {
-          lyrics.classList.add("blyrics--fallback");
-        }
-        existingFooter.classList.add("blyrics--fallback");
-      }
-      BetterLyrics.DOM.flushLoader();
-    } catch (err) {
-      BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_WRAPPER_NOT_VISIBLE_LOG);
-      BetterLyrics.Utils.log(err);
-    }
-  },
   /** @type {MutationObserver | null} */
   backgroundChangeObserver: null,
   addAlbumArtToLayout: function () {

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -102,6 +102,8 @@ BetterLyrics.DOM = {
       if (!loaderWrapper) {
         loaderWrapper = document.createElement("div");
         loaderWrapper.id = BetterLyrics.Constants.LYRICS_LOADER_ID;
+      } else if (loaderWrapper.hasAttribute("active")) {
+        return;
       }
 
       tabRenderer.prepend(loaderWrapper);

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -53,7 +53,7 @@ BetterLyrics.DOM = {
 
       const footerLink = document.createElement("a");
       footerLink.target = "_blank";
-      footerLink.id = "betterLyricsFooterLink"
+      footerLink.id = "betterLyricsFooterLink";
 
       footerContainer.appendChild(footerLink);
 

--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -16,15 +16,22 @@ BetterLyrics.DOM = {
     return wrapper;
   },
 
-  addFooter: function () {
-    if (document.getElementsByClassName(BetterLyrics.Constants.FOOTER_CLASS).length > 0) {
-      return;
+  /**
+   * @param source : {string}
+   * @param sourceHref : {string}
+   */
+  addFooter: function (source, sourceHref) {
+    if (document.getElementsByClassName(BetterLyrics.Constants.FOOTER_CLASS).length === 0) {
+      const tabRenderer = document.querySelector(BetterLyrics.Constants.TAB_RENDERER_SELECTOR);
+      const footer = document.createElement("div");
+      footer.classList.add(BetterLyrics.Constants.FOOTER_CLASS);
+      tabRenderer.appendChild(footer);
+      BetterLyrics.DOM.createFooter();
     }
-    const tabRenderer = document.querySelector(BetterLyrics.Constants.TAB_RENDERER_SELECTOR);
-    const footer = document.createElement("div");
-    footer.classList.add(BetterLyrics.Constants.FOOTER_CLASS);
-    tabRenderer.appendChild(footer);
-    BetterLyrics.DOM.createFooter();
+
+    let footerLink = document.getElementById("betterLyricsFooterLink");
+    footerLink.textContent = source;
+    footerLink.href = sourceHref;
   },
 
   createFooter: function () {
@@ -45,9 +52,8 @@ BetterLyrics.DOM = {
       footerContainer.appendChild(document.createTextNode("Source: "));
 
       const footerLink = document.createElement("a");
-      footerLink.href = "https://better-lyrics.boidu.dev";
       footerLink.target = "_blank";
-      footerLink.textContent = "boidu.dev";
+      footerLink.id = "betterLyricsFooterLink"
 
       footerContainer.appendChild(footerLink);
 

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -117,7 +117,8 @@ BetterLyrics.Observer = {
             detail.artist,
             detail.currentTime,
             detail.videoId,
-            detail.duration
+            detail.duration,
+            detail.audioTrackData
           );
         }
       }

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -56,7 +56,7 @@ BetterLyrics.Observer = {
         currentVideoDetails !== BetterLyrics.App.lastVideoDetails
       ) {
         try {
-          if (currentVideoId === BetterLyrics.App.lastVideoId && BetterLyrics.App.areLyricsTicking) {
+          if (currentVideoId === BetterLyrics.App.lastVideoId && BetterLyrics.App.areLyricsLoaded) {
             console.log(BetterLyrics.Constants.SKIPPING_LOAD_WITH_META);
             return; // We already loaded this video
           }
@@ -93,10 +93,11 @@ BetterLyrics.Observer = {
         BetterLyrics.DOM.addAlbumArtToLayout();
       }
 
-      if (BetterLyrics.App.queueLyricInjection) {
+      if (BetterLyrics.App.queueLyricInjection || BetterLyrics.App.lyricInjectionFailed) {
         const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
         if (tabSelector) {
           BetterLyrics.App.queueLyricInjection = false;
+          BetterLyrics.App.lyricInjectionFailed = false;
           if (tabSelector.getAttribute("aria-selected") !== "true") {
             BetterLyrics.Settings.onAutoSwitchEnabled(() => {
               tabSelector.click();

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -104,7 +104,7 @@ BetterLyrics.Observer = {
             });
           }
 
-          BetterLyrics.App.handleModifications(detail.song, detail.artist, detail.currentTime, detail.videoId);
+          BetterLyrics.App.handleModifications(detail.song, detail.artist, detail.currentTime, detail.videoId, detail.duration);
         }
       }
 

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -112,14 +112,7 @@ BetterLyrics.Observer = {
             });
           }
 
-          BetterLyrics.App.handleModifications(
-            detail.song,
-            detail.artist,
-            detail.currentTime,
-            detail.videoId,
-            detail.duration,
-            detail.audioTrackData
-          );
+          BetterLyrics.App.handleModifications(detail);
         }
       }
 

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -105,7 +105,13 @@ BetterLyrics.Observer = {
             });
           }
 
-          BetterLyrics.App.handleModifications(detail.song, detail.artist, detail.currentTime, detail.videoId, detail.duration);
+          BetterLyrics.App.handleModifications(
+            detail.song,
+            detail.artist,
+            detail.currentTime,
+            detail.videoId,
+            detail.duration
+          );
         }
       }
 

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -93,6 +93,13 @@ BetterLyrics.Observer = {
         BetterLyrics.DOM.addAlbumArtToLayout();
       }
 
+      if (BetterLyrics.App.lyricInjectionFailed) {
+        const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
+        if (tabSelector && tabSelector.getAttribute("aria-selected") !== "true") {
+          BetterLyrics.App.lyricInjectionFailed = false; //ignore failure b/c the tab isn't visible
+        }
+      }
+
       if (BetterLyrics.App.queueLyricInjection || BetterLyrics.App.lyricInjectionFailed) {
         const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
         if (tabSelector) {

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -7,14 +7,6 @@ BetterLyrics.Observer = {
       }, 1000);
       return;
     }
-    if (tabSelector.hasAttribute("disabled")) {
-      tabSelector.removeAttribute("disabled");
-      tabSelector.setAttribute("aria-disabled", "false");
-      BetterLyrics.Settings.onAutoSwitchEnabled(() => {
-        tabSelector.click();
-        BetterLyrics.Utils.log(BetterLyrics.Constants.AUTO_SWITCH_ENABLED_LOG);
-      });
-    }
     let observer = new MutationObserver(function (mutations) {
       mutations.forEach(function (mutation) {
         if (mutation.attributeName === "disabled") {
@@ -111,7 +103,6 @@ BetterLyrics.Observer = {
               BetterLyrics.Utils.log(BetterLyrics.Constants.AUTO_SWITCH_ENABLED_LOG);
             });
           }
-
           BetterLyrics.App.handleModifications(detail);
         }
       }

--- a/src/script.js
+++ b/src/script.js
@@ -11,9 +11,10 @@ const startLyricsTick = () => {
       try {
         const currentTime = player.getCurrentTime();
         const { video_id, title, author } = player.getVideoData();
+        const duration = player.getDuration();
         document.dispatchEvent(
           new CustomEvent("blyrics-send-player-time", {
-            detail: { currentTime: currentTime, videoId: video_id, song: title, artist: author },
+            detail: { currentTime: currentTime, videoId: video_id, song: title, artist: author, duration: duration },
           })
         );
       } catch (e) {

--- a/src/script.js
+++ b/src/script.js
@@ -2,6 +2,14 @@
 
 let tickLyricsInterval;
 
+// Get all player methods (paste in broswer console)
+// for(i in document.getElementById("movie_player")) {
+//     if (typeof document.getElementById("movie_player")[i] === 'function' && i.includes("get")) {
+//             console.log(i + ": " + JSON.stringify(document.getElementById("movie_player")[i](), null, 2));
+//     } else {
+//         console.log(i);
+//     }
+// }
 const startLyricsTick = () => {
   stopLyricsTick();
 
@@ -11,10 +19,11 @@ const startLyricsTick = () => {
       try {
         const currentTime = player.getCurrentTime();
         const { video_id, title, author } = player.getVideoData();
+        const audioTrackData = player.getAudioTrack();
         const duration = player.getDuration();
         document.dispatchEvent(
           new CustomEvent("blyrics-send-player-time", {
-            detail: { currentTime: currentTime, videoId: video_id, song: title, artist: author, duration: duration },
+            detail: { currentTime: currentTime, videoId: video_id, song: title, artist: author, duration: duration, audioTrackData: audioTrackData },
           })
         );
       } catch (e) {

--- a/src/script.js
+++ b/src/script.js
@@ -23,7 +23,14 @@ const startLyricsTick = () => {
         const duration = player.getDuration();
         document.dispatchEvent(
           new CustomEvent("blyrics-send-player-time", {
-            detail: { currentTime: currentTime, videoId: video_id, song: title, artist: author, duration: duration, audioTrackData: audioTrackData },
+            detail: {
+              currentTime: currentTime,
+              videoId: video_id,
+              song: title,
+              artist: author,
+              duration: duration,
+              audioTrackData: audioTrackData,
+            },
           })
         );
       } catch (e) {


### PR DESCRIPTION
- Refactor lyric fetching so that it is easier to add more sources for lyrics. 
- Add duration filtering for songs to improve the likelihood that we'll get the correct song. 
  - This currently works for lyricLib, BetterLyrics API will still need its own updates
    - Currently passing the duration under the `d` search param
- When both lyricLib and BetterLyrics don't have lyrics, inject the yt lyrics into our ui instead of falling back to yt's ui 