### PR TITLE
Draft PR: Support scroll pausing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,7 @@
   line-height: var(--blyrics-line-height);
   position: relative !important;
   z-index: 1;
+  transition: top 0.3s ease-in-out 0s;
 }
 
 .blyrics-hidden {
@@ -85,9 +86,9 @@
   padding-top: var(--blyrics-padding) !important;
 }
 
-.blyrics-container > div:last-child {
-  padding-bottom: 0 !important;
-}
+/*.blyrics-container > div:last-child {*/
+/*  padding-bottom: 0 !important;*/
+/*}*/
 
 .blyrics-container > div.blyrics--active {
   transform: scale(var(--blyrics-active-scale));
@@ -176,7 +177,7 @@
   align-items: center;
   gap: 1rem;
   margin-top: 2rem;
-  margin-bottom: 4rem;
+  margin-bottom: 6rem;
 }
 
 .blyrics-footer__discord {

--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -122,7 +122,7 @@ BetterLyrics.Lyrics = {
   cacheAndProcessLyrics: function (cacheKey, data) {
     if (data.cacheAllowed === undefined || data.cacheAllowed) {
       const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
-      BetterLyrics.Storage.setTransientStorage(cacheKey, JSON.stringify(data), oneWeekInMs);
+      //BetterLyrics.Storage.setTransientStorage(cacheKey, JSON.stringify(data), oneWeekInMs);
     }
     BetterLyrics.Lyrics.processLyrics(data);
   },
@@ -170,9 +170,6 @@ BetterLyrics.Lyrics = {
     const lyrics = data.lyrics;
     BetterLyrics.DOM.cleanup();
     let lyricsWrapper = BetterLyrics.DOM.createLyricsWrapper();
-    if (lyrics[0].words !== BetterLyrics.Constants.NO_LYRICS_TEXT) {
-      BetterLyrics.DOM.addFooter(data.source, data.sourceHref);
-    }
 
     try {
       lyricsWrapper.innerHTML = "";
@@ -291,14 +288,18 @@ BetterLyrics.Lyrics = {
             });
           }
         );
-
-        try {
-          document.getElementsByClassName(BetterLyrics.Constants.LYRICS_CLASS)[0].appendChild(line);
-        } catch (_err) {
-          BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_WRAPPER_NOT_VISIBLE_LOG);
-        }
       });
+
+      try {
+        document.getElementsByClassName(BetterLyrics.Constants.LYRICS_CLASS)[0].appendChild(line);
+      } catch (_err) {
+        BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_WRAPPER_NOT_VISIBLE_LOG);
+      }
     });
+
+    if (lyrics[0].words !== BetterLyrics.Constants.NO_LYRICS_TEXT) {
+      BetterLyrics.DOM.addFooter(data.source, data.sourceHref);
+    }
 
     if (!allZero) {
       BetterLyrics.Lyrics.setupLyricsCheckInterval();

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -110,4 +110,24 @@ BetterLyrics.Observer = {
       BetterLyrics.DOM.tickLyrics(detail.currentTime);
     });
   },
+  scrollEventHandler: () => {
+    const tabSelector = document.getElementsByClassName(BetterLyrics.Constants.TAB_HEADER_CLASS)[1];
+    if (tabSelector.getAttribute("aria-selected") !== "true") {
+      return;
+    }
+
+    const tabRenderer = document.querySelector(BetterLyrics.Constants.TAB_RENDERER_SELECTOR);
+    if (tabRenderer.scrollTop > BetterLyrics.DOM.maxScroll) {
+      tabRenderer.scrollTop = BetterLyrics.DOM.maxScroll;
+    } else if (tabRenderer.scrollTop < BetterLyrics.DOM.minScroll) {
+      tabRenderer.scrollTop = BetterLyrics.DOM.minScroll;
+    }
+
+    if (BetterLyrics.DOM.skipScrolls > 0) {
+      BetterLyrics.DOM.skipScrolls--;
+      return;
+    }
+    BetterLyrics.DOM.scrollResumeTime = Date.now() + 6000;
+    console.log("user scrolled");
+  },
 };


### PR DESCRIPTION
Move the lyrics wrapper instead of scrolling so that we can detect when the user scrolls.
Now using css transitions to smoothly move the lyrics instead of scrolling.

