### PR TITLE
Hide the autoscroll resume button when it shouldn't be visible

### DIFF
--- a/src/modules/ui/dom.js
+++ b/src/modules/ui/dom.js
@@ -268,6 +268,7 @@ BetterLyrics.DOM = {
     if (existingFooter && existingFooter.classList.contains("blyrics--fallback")) {
       existingFooter.classList.remove("blyrics--fallback");
     }
+    BetterLyrics.DOM.getResumeScrollElement().setAttribute("autoscroll-hidden", "true");
 
     BetterLyrics.DOM.clearLyrics();
   },
@@ -461,6 +462,7 @@ BetterLyrics.DOM = {
       elem.setAttribute("autoscroll-hidden", "true");
       elem.addEventListener("click", () => {
         BetterLyrics.DOM.scrollResumeTime = 0;
+        elem.setAttribute("autoscroll-hidden", "true");
       });
 
       document.querySelector("#side-panel > tp-yt-paper-tabs").after(wrapper);

--- a/src/modules/ui/observer.js
+++ b/src/modules/ui/observer.js
@@ -27,6 +27,7 @@ BetterLyrics.Observer = {
 
     if (tab1 !== undefined && tab2 !== undefined && tab3 !== undefined) {
       tab2.addEventListener("click", function () {
+        BetterLyrics.DOM.getResumeScrollElement().classList.remove("blyrics-hidden");
         if (!BetterLyrics.App.areLyricsLoaded) {
           BetterLyrics.Utils.log(BetterLyrics.Constants.LYRICS_TAB_CLICKED_LOG);
           BetterLyrics.DOM.cleanup();
@@ -34,6 +35,10 @@ BetterLyrics.Observer = {
           BetterLyrics.App.reloadLyrics();
         }
       });
+
+      let hideAutoscrollResume = () => BetterLyrics.DOM.getResumeScrollElement().classList.add("blyrics-hidden");
+      tab1.addEventListener("click", hideAutoscrollResume);
+      tab3.addEventListener("click", hideAutoscrollResume);
     } else {
       setTimeout(() => BetterLyrics.Observer.lyricReloader(), 1000);
     }


### PR DESCRIPTION
Hide the element when the user switches to another tab & hide it when we run the cleanup function.
