### PR TITLE
Show plain lyrics when synced lyrics are unavailable

### DIFF
--- a/src/modules/lyrics/lyrics.js
+++ b/src/modules/lyrics/lyrics.js
@@ -408,7 +408,7 @@ BetterLyrics.Lyrics = {
       line.dataset.duration = lineData.duration;
       line.style.setProperty("--blyrics-duration", item.durationMs + "ms");
 
-      if (!allZero) {
+      if (!allZero && !data.isPlainLyrics) {
         line.setAttribute(
           "onClick",
           `const player = document.getElementById("movie_player"); player.seekTo(${
@@ -507,7 +507,7 @@ BetterLyrics.Lyrics = {
       BetterLyrics.DOM.addFooter(data.source, data.sourceHref);
     }
 
-    if (!allZero) {
+    if (!allZero && !data.isPlainLyrics) {
       BetterLyrics.App.lyricData = lyricsData;
       BetterLyrics.App.areLyricsTicking = true;
     } else {


### PR DESCRIPTION
# Description

This update ensures that plain lyrics are displayed when synced lyrics are not available. Previously, the app showed "No lyrics found for this song" even when plain lyrics existed. With this fix, plain lyrics are now shown as a fallback.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Screenshots (if applicable)

#### If we just have the plain text and not the sync lyrics we are showing the “No lyrics found for this song”:

![image](https://github.com/user-attachments/assets/0ba183f0-78b0-4265-a2e8-6de603c1677f)

![image](https://github.com/user-attachments/assets/c13f5189-4fa2-4e07-a452-dde8ac56196e)

![image](https://github.com/user-attachments/assets/f6fa3f55-f311-4692-ad4b-9abd25ebe794)

#### The improvement is to show the plain lyrics when the syncedLyrics isn’t available:

![image](https://github.com/user-attachments/assets/669a256b-a57f-4358-802b-ff99f2475f18)


## Checklist

- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one phrase about this update.

> Plain lyrics are now shown as a fallback when synced lyrics are not available.