### PR TITLE
Lager Video Player

### DIFF
--- a/public/css/ytmusic.css
+++ b/public/css/ytmusic.css
@@ -193,6 +193,10 @@ ytmusic-player-page:not([is-mweb-modernization-enabled])[player-fullscreened] .a
   opacity: 0;
 }
 
+#side-panel {
+  min-width: 33em;
+}
+
 
 /* Media queries */
 @media (min-width: 936px) {


### PR DESCRIPTION
Another attempt add making the video player larger when a music video is playing.

Hopefully most yt's UI changes have propagated and we no longer have issues with that.

Screenshots of new UI in many different states (taken on a 1080p screen at 100% scaling:

<img width="2560" height="1290" alt="image" src="https://github.com/user-attachments/assets/3214db8c-5268-4c3c-9838-254bbf33bc6c" />

<img width="2560" height="1290" alt="image" src="https://github.com/user-attachments/assets/16162311-8d82-469c-80e0-32c4a7144b2d" />

<img width="2560" height="1449" alt="image" src="https://github.com/user-attachments/assets/24c26c7f-115c-43f6-93f4-3523e090636c" />

<img width="2560" height="1449" alt="image" src="https://github.com/user-attachments/assets/d1f99c6d-a0f5-4471-8410-e4692efae286" />

<img width="2560" height="1449" alt="image" src="https://github.com/user-attachments/assets/89bd04d9-00d7-4fbf-97d8-663a63973273" />

<img width="2560" height="1449" alt="image" src="https://github.com/user-attachments/assets/8a66155a-b3e4-4561-b813-82d276e4c96b" />

Verified that this doesn't break on small screen sizes and in the mobile UI unlike the first time around!


