### PR TITLE
fix: apply built-in theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "better-lyrics",
-    "version": "2.0.5.6",
+    "version": "2.0.5.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "better-lyrics",
-            "version": "2.0.5.6",
+            "version": "2.0.5.7",
             "license": "GPL-3.0",
             "dependencies": {
                 "@codemirror/commands": "^6.9.0",
@@ -30,12 +30,13 @@
                 "@types/chrome": "^0.1.24",
                 "@types/codemirror": "^5.60.16",
                 "@types/jsdom": "^27.0.0",
+                "@types/node": "^24.10.1",
                 "@types/sortablejs": "^1.15.8",
                 "@typescript/lib-dom": "npm:@types/web@^0.0.280",
                 "axios": "^1.13.1",
                 "jsdom": "^27.1.0",
                 "tsx": "^4.20.6",
-                "typescript": "^5.9.2"
+                "typescript": "^5.9.3"
             }
         },
         "node_modules/@acemir/cssom": {
@@ -3015,11 +3016,12 @@
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
         },
         "node_modules/@types/node": {
-            "version": "22.18.11",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.11.tgz",
-            "integrity": "sha512-Gd33J2XIrXurb+eT2ktze3rJAfAp9ZNjlBdh4SVgyrKEOADwCbdUDaK7QgJno8Ue4kcajscsKqu6n8OBG3hhCQ==",
+            "version": "24.10.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+            "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+            "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.21.0"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/node-forge": {
@@ -4901,6 +4903,21 @@
                 "@types/filesystem": "*",
                 "@types/har-format": "*"
             }
+        },
+        "node_modules/extension/node_modules/@types/node": {
+            "version": "22.19.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+            "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/extension/node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -8371,9 +8388,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-            "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
@@ -8385,9 +8402,10 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+            "license": "MIT"
         },
         "node_modules/universalify": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -52,11 +52,12 @@
         "@types/chrome": "^0.1.24",
         "@types/codemirror": "^5.60.16",
         "@types/jsdom": "^27.0.0",
+        "@types/node": "^24.10.1",
         "@types/sortablejs": "^1.15.8",
         "@typescript/lib-dom": "npm:@types/web@^0.0.280",
         "axios": "^1.13.1",
         "jsdom": "^27.1.0",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.2"
+        "typescript": "^5.9.3"
     }
 }

--- a/src/options/editor/core/state.ts
+++ b/src/options/editor/core/state.ts
@@ -16,6 +16,7 @@ export class EditorStateManager {
   private isCustomTheme = false;
   private saveCount = 0;
   private isUserTyping = false;
+  private isProgrammaticChange = false;
   private saveTimeout: number | null = null;
   private saveCustomThemeTimeout: number | null = null;
 
@@ -65,6 +66,10 @@ export class EditorStateManager {
 
   setIsUserTyping(value: boolean): void {
     this.isUserTyping = value;
+  }
+
+  getIsProgrammaticChange(): boolean {
+    return this.isProgrammaticChange;
   }
 
   getSaveTimeout(): number | null {
@@ -158,6 +163,7 @@ export class EditorStateManager {
 
     console.log(`[EditorStateManager] Setting editor content from: ${source} (${css.length} bytes)`);
 
+    this.isProgrammaticChange = true;
     this.editor.dispatch({
       changes: {
         from: 0,
@@ -165,6 +171,7 @@ export class EditorStateManager {
         insert: css,
       },
     });
+    this.isProgrammaticChange = false;
 
     console.log(`[EditorStateManager] Editor content set successfully from: ${source}`);
   }

--- a/src/options/editor/features/themes.ts
+++ b/src/options/editor/features/themes.ts
@@ -144,6 +144,11 @@ export function hideThemeName(): void {
 }
 
 export function onChange(_state: string) {
+  if (editorStateManager.getIsProgrammaticChange()) {
+    debounceSave();
+    return;
+  }
+
   editorStateManager.setIsUserTyping(true);
 
   const themeName = editorStateManager.getCurrentThemeName();


### PR DESCRIPTION
# Description

Fix theme selector resetting to "Choose a theme" after selection When selecting a built-in theme, the selector would briefly show the theme name then revert to "Choose a theme" even though the theme was correctly applied.

## Cause

The editor's `onChange` handler treated programmatic content changes (theme loading) as user typing, which triggered a debounced save that removed `themeName` from storage after 1 second.

## Fix
Added `isProgrammaticChange` flag to `EditorStateManager` that's set during `setEditorContent()`. The onChange handler now skips the theme-reset logic when this flag is true.