### PR TITLE
fix: infinite save loop

### DIFF
--- a/src/options/editor/features/themes.ts
+++ b/src/options/editor/features/themes.ts
@@ -145,7 +145,6 @@ export function hideThemeName(): void {
 
 export function onChange(_state: string) {
   if (editorStateManager.getIsProgrammaticChange()) {
-    debounceSave();
     return;
   }
 


### PR DESCRIPTION
# Description

Fix infinite save loop when both popup and standalone CSS editors are open simultaneously. The issue was caused by `onChange` calling `debounceSave()` even for programmatic changes (like storage sync/theme selection), creating a feedback loop between editors. Now programmatic changes are properly ignored since they either come from storage (no re-save needed) or have explicit save calls (theme application).
