### PR TITLE
fix: extend LRC lyric duration by longest part start

### DIFF
--- a/src/modules/lyrics/providers/lrcUtils.ts
+++ b/src/modules/lyrics/providers/lrcUtils.ts
@@ -125,15 +125,15 @@ export function parseLRC(lrcText: string, songDuration: number): LyricsArray {
     if (index + 1 < result.length) {
       const nextLyric = result[index + 1];
       if (lyric.durationMs === 0) {
-        lyric.durationMs = nextLyric.startTimeMs - lyric.startTimeMs;
+        lyric.durationMs = Math.max(nextLyric.startTimeMs - lyric.startTimeMs, 0);
       }
       if (lyric.parts && lyric.parts.length > 0) {
-        let longestStart = nextLyric.startTimeMs;
-        lyric.parts.forEach(val => { longestStart = Math.max(longestStart, val.startTimeMs) });
+        let latestStart = nextLyric.startTimeMs;
+        lyric.parts.forEach(val => { latestStart = Math.max(latestStart, val.startTimeMs) });
 
         const lastPartInLyric = lyric.parts[lyric.parts.length - 1];
-        lastPartInLyric.durationMs = nextLyric.startTimeMs - lastPartInLyric.startTimeMs;
-        lyric.durationMs = Math.max(longestStart, 0) - lyric.startTimeMs;
+        lastPartInLyric.durationMs = Math.max(nextLyric.startTimeMs - lastPartInLyric.startTimeMs, 0);
+        lyric.durationMs = Math.max(latestStart - lyric.startTimeMs, 0) ;
       }
     } else {
       if (lyric.durationMs === 0) {


### PR DESCRIPTION
# Description

Extends a synced LRC lyric duration by their ~~last~~ longest part start time, only if its longer than the next lyric start time
> **EDIT: Maintainer suggested a better option to use longest part start time instead**

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.

> P.S: first time using PR title coded thingy, figured i'd use `style` cause it only changes the visual duration of the lyric lol
> edit: nevermind, gonna use `fix` anyway