### PR TITLE
fix: seek by passing primitive instead of object

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -99,7 +99,7 @@ window.addEventListener("unload", stopLyricsTick);
 
 document.addEventListener("blyrics-seek-to", event => {
   const player = document.getElementById("movie_player");
-  const seekTime = event.detail?.time ?? 0;
+  const seekTime = event.detail ?? 0;
   if (player && seekTime >= 0) {
     player.seekTo(seekTime, true);
     player.playVideo();

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -300,7 +300,7 @@ export function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible 
         const seekTime = lyricItem.startTimeMs / 1000;
         instrumentalElement.addEventListener("click", () => {
           log(LOG_PREFIX, `Seeking to ${seekTime.toFixed(2)}s`);
-          document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: { time: seekTime } }));
+          document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: seekTime }));
           animEngineState.scrollResumeTime = 0;
         });
       }
@@ -423,7 +423,7 @@ export function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible 
         }
 
         log(LOG_PREFIX, `Seeking to ${seekTime.toFixed(2)}s`);
-        document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: { time: seekTime } }));
+        document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: seekTime }));
         animEngineState.scrollResumeTime = 0;
       });
     } else {


### PR DESCRIPTION
# Description

Firefox blocks cross-compartment property access on `CustomEvent` details (cuz ofc they do) 
