### PR TITLE
feat: passive autoscroll for unsynced lyrics

### DIFF
--- a/STYLING-SKILL.md
+++ b/STYLING-SKILL.md
@@ -112,6 +112,7 @@ blyrics-target-scroll-pos-ratio = 0.37;
 | `blyrics-target-scroll-pos-ratio` | `0.37` | Lyric position (0=top, 0.5=center, 1=bottom) |
 | `blyrics-long-word-threshold` | `1500` | Duration (ms) above which `data-long-word` is set |
 | `blyrics-hide-instrumental-only` | `false` | Treat "[Instrumental Only]" as no lyrics (enables fullscreen effect) |
+| `blyrics-passive-scroll-enabled` | `true` | Unsynced auto-scroll: enable/disable entirely (overrides user setting) |
 | `blyrics-passive-scroll-seconds-per-line` | `3.5` | Unsynced auto-scroll: seconds per line (scroll speed) |
 | `blyrics-passive-scroll-bottom-pause-s` | `1.5` | Unsynced auto-scroll: pause at bottom (s) |
 | `blyrics-passive-scroll-reset-duration-s` | `0.6` | Unsynced auto-scroll: scroll-back-to-top duration (s) |

--- a/STYLING-SKILL.md
+++ b/STYLING-SKILL.md
@@ -112,6 +112,10 @@ blyrics-target-scroll-pos-ratio = 0.37;
 | `blyrics-target-scroll-pos-ratio` | `0.37` | Lyric position (0=top, 0.5=center, 1=bottom) |
 | `blyrics-long-word-threshold` | `1500` | Duration (ms) above which `data-long-word` is set |
 | `blyrics-hide-instrumental-only` | `false` | Treat "[Instrumental Only]" as no lyrics (enables fullscreen effect) |
+| `blyrics-passive-scroll-seconds-per-line` | `3.5` | Unsynced auto-scroll: seconds per line (scroll speed) |
+| `blyrics-passive-scroll-bottom-pause-s` | `1.5` | Unsynced auto-scroll: pause at bottom (s) |
+| `blyrics-passive-scroll-reset-duration-s` | `0.6` | Unsynced auto-scroll: scroll-back-to-top duration (s) |
+| `blyrics-passive-scroll-top-pause-s` | `0.8` | Unsynced auto-scroll: pause at top (s) |
 
 **Scroll equation**: `--blyrics-lyric-scroll-duration` + 0.02s = `blyrics-early-scroll-consider-s` + `blyrics-queue-scroll-ms`
 

--- a/STYLING.md
+++ b/STYLING.md
@@ -250,6 +250,10 @@ The following options are avalible:
 | `blyrics-target-scroll-pos-ratio`     | `0.37`        | Position on the screen lyrics should be at. 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom. |
 | `blyrics-long-word-threshold`         | `1500`        | Duration threshold (in ms) above which words get `data-long-word="true"`. Useful for glow effects on held notes.                           |
 | `blyrics-hide-instrumental-only`      | `false`       | Treat "[Instrumental Only]" as no lyrics (enables fullscreen effect).                                                                      |
+| `blyrics-passive-scroll-seconds-per-line` | `3.5`     | For unsynced lyrics auto-scroll: seconds spent scrolling per lyric line. Controls overall scroll speed.                                    |
+| `blyrics-passive-scroll-bottom-pause-s`   | `1.5`     | For unsynced lyrics auto-scroll: seconds to pause at the bottom before scrolling back to top.                                              |
+| `blyrics-passive-scroll-reset-duration-s` | `0.6`     | For unsynced lyrics auto-scroll: seconds for the scroll-back-to-top animation.                                                             |
+| `blyrics-passive-scroll-top-pause-s`      | `0.8`     | For unsynced lyrics auto-scroll: seconds to pause at the top before scrolling down again.                                                  |
 
 ⁴Make sure that the following equation is met
 

--- a/STYLING.md
+++ b/STYLING.md
@@ -250,6 +250,7 @@ The following options are avalible:
 | `blyrics-target-scroll-pos-ratio`     | `0.37`        | Position on the screen lyrics should be at. 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom. |
 | `blyrics-long-word-threshold`         | `1500`        | Duration threshold (in ms) above which words get `data-long-word="true"`. Useful for glow effects on held notes.                           |
 | `blyrics-hide-instrumental-only`      | `false`       | Treat "[Instrumental Only]" as no lyrics (enables fullscreen effect).                                                                      |
+| `blyrics-passive-scroll-enabled`          | `true`    | Enable/disable unsynced lyrics auto-scroll entirely. Overrides the user setting when set to `false`.                                       |
 | `blyrics-passive-scroll-seconds-per-line` | `3.5`     | For unsynced lyrics auto-scroll: seconds spent scrolling per lyric line. Controls overall scroll speed.                                    |
 | `blyrics-passive-scroll-bottom-pause-s`   | `1.5`     | For unsynced lyrics auto-scroll: seconds to pause at the bottom before scrolling back to top.                                              |
 | `blyrics-passive-scroll-reset-duration-s` | `0.6`     | For unsynced lyrics auto-scroll: seconds for the scroll-back-to-top animation.                                                             |

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -90,6 +90,10 @@
     "message": "Show stylized animations",
     "description": "Show stylized animations setting label"
   },
+  "options_display_passiveScroll": {
+    "message": "Auto-scroll unsynced lyrics",
+    "description": "Auto-scroll unsynced lyrics setting label"
+  },
 
   "options_language_displayLanguage": {
     "message": "Display Language",

--- a/src/core/appState.ts
+++ b/src/core/appState.ts
@@ -39,6 +39,7 @@ interface AppStateType {
   romanizationDisabledLanguages: string[];
   translationDisabledLanguages: string[];
   translationLanguage: string;
+  isPassiveScrollEnabled: boolean;
   hasPreloadedNextSong: boolean;
   currentInjectionId: number;
 }
@@ -63,6 +64,7 @@ export const AppState: AppStateType = {
   romanizationDisabledLanguages: [],
   translationDisabledLanguages: [],
   translationLanguage: "en",
+  isPassiveScrollEnabled: true,
   hasPreloadedNextSong: false,
   currentInjectionId: 0,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   handleSettings,
   hideCursorOnIdle,
   listenForPopupMessages,
+  loadPassiveScrollSetting,
   loadTranslationSettings,
   onAlbumArtEnabled,
 } from "@modules/settings/settings";
@@ -43,6 +44,7 @@ async function modify(): Promise<void> {
   handleSettings();
   setupWakeLockForFullscreen();
   loadTranslationSettings();
+  loadPassiveScrollSetting();
   subscribeToCustomStyles();
   await purgeExpiredKeys();
   await saveCacheInfo();

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -184,7 +184,7 @@ export function processLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible
   injectLyrics(data, keepLoaderVisible, signal);
 }
 
-function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTMLElement) {
+function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTMLDivElement) {
   // To add rtl elements in reverse to the dom
   let rtlBuffer: HTMLSpanElement[] = [];
   let isAllRtl = true;
@@ -255,7 +255,7 @@ function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTML
     });
   }
 
-  groupByWordAndInsert(lyricElement as HTMLDivElement, lyricElementsBuffer);
+  groupByWordAndInsert(lyricElement, lyricElementsBuffer);
 }
 
 function createBreakElem(lyricElement: HTMLElement, order: number) {
@@ -506,11 +506,10 @@ function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible = false
 
   AppState.lyricData = lyricsData;
 
-  if (!allZero) {
-    AppState.areLyricsTicking = true;
-    calculateLyricPositions();
-    getResizeObserver().observe(lyricsWrapper);
-  } else {
+  AppState.areLyricsTicking = true;
+  calculateLyricPositions();
+  getResizeObserver().observe(lyricsWrapper);
+  if (allZero) {
     log(SYNC_DISABLED_LOG);
   }
 

--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -192,6 +192,7 @@ export function listenForPopupMessages(): void {
       hideCursorOnIdle();
       handleSettings();
       loadTranslationSettings();
+      loadPassiveScrollSetting();
       AppState.shouldInjectAlbumArt = "Unknown";
       onAlbumArtEnabled(
         () => {
@@ -214,6 +215,12 @@ export function listenForPopupMessages(): void {
         sendResponse({ success: false });
       }
     }
+  });
+}
+
+export function loadPassiveScrollSetting(): void {
+  getStorage({ isPassiveScrollEnabled: true }, items => {
+    AppState.isPassiveScrollEnabled = items.isPassiveScrollEnabled;
   });
 }
 

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -12,7 +12,7 @@ import {
 } from "@constants";
 import { AppState } from "@core/appState";
 import { calculateLyricPositions, type LineData } from "@modules/lyrics/injectLyrics";
-import { hideAdOverlay, isAdPlaying, showAdOverlay } from "@modules/ui/dom";
+import { hideAdOverlay, isAdPlaying, isLoaderActive, showAdOverlay } from "@modules/ui/dom";
 import { log } from "@utils";
 import { ctx, resetDebugRender } from "./animationEngineDebug";
 import { registerThemeSetting } from "@modules/settings/themeOptions";
@@ -30,6 +30,13 @@ let observedTabRenderer: HTMLElement | null = null;
 
 // 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom
 export const SCROLL_POS_OFFSET_RATIO = registerThemeSetting("blyrics-target-scroll-pos-ratio", 0.37);
+
+export const ADD_EXTRA_PADDING_TOP = registerThemeSetting("blyrics-add-extra-top-padding", false);
+
+const PASSIVE_SECONDS_PER_LINE = registerThemeSetting("blyrics-passive-scroll-seconds-per-line", 3.5);
+const PASSIVE_BOTTOM_PAUSE_S = registerThemeSetting("blyrics-passive-scroll-bottom-pause-s", 1.5);
+const PASSIVE_RESET_DURATION_S = registerThemeSetting("blyrics-passive-scroll-reset-duration-s", 0.6);
+const PASSIVE_TOP_PAUSE_S = registerThemeSetting("blyrics-passive-scroll-top-pause-s", 0.8);
 
 interface AnimEngineState {
   skipScrolls: number;
@@ -53,6 +60,8 @@ interface AnimEngineState {
     centers: number[];
     lyricScrollTime: number;
   };
+  passiveScrollAccumulatedTime: number;
+  passiveLastWallTime: number;
 }
 
 export let animEngineState: AnimEngineState = {
@@ -74,6 +83,8 @@ export let animEngineState: AnimEngineState = {
     centers: [],
     lyricScrollTime: 0,
   },
+  passiveScrollAccumulatedTime: 0,
+  passiveLastWallTime: 0,
 };
 
 export function resetActiveAnimations(): void {
@@ -96,6 +107,8 @@ export function resetAnimEngineState(): void {
   animEngineState.lastScrollDebugContext.centers = [];
   animEngineState.doneFirstInstantScroll = false;
   animEngineState.queuedScroll = false;
+  animEngineState.passiveScrollAccumulatedTime = 0;
+  animEngineState.passiveLastWallTime = 0;
   cachedDurations.clear();
 }
 
@@ -118,6 +131,101 @@ function getCSSDurationInMs(lyricsElement: HTMLElement, property: string): numbe
   }
 
   return duration;
+}
+
+// -- Skip Scrolls Decay --------------------------
+
+function decaySkipScrolls(now: number): void {
+  let j = 0;
+  for (; j < animEngineState.skipScrollsDecayTimes.length; j++) {
+    if (animEngineState.skipScrollsDecayTimes[j] > now) {
+      break;
+    }
+  }
+  animEngineState.skipScrollsDecayTimes = animEngineState.skipScrollsDecayTimes.slice(j);
+  animEngineState.skipScrolls -= j;
+  if (animEngineState.skipScrolls < 1) {
+    animEngineState.skipScrolls = 1;
+  }
+}
+
+// -- Passive Scroll Engine --------------------------
+
+function passiveScrollEngine(isPlaying: boolean): void {
+  const lyricData = AppState.lyricData;
+  if (!lyricData) return;
+
+  if (isLoaderActive()) return;
+
+  const tabRenderer = document.querySelector(TAB_RENDERER_SELECTOR) as HTMLElement;
+  if (!tabRenderer) return;
+
+  const now = Date.now();
+
+  // -- Accumulate play time --------------------------
+  if (animEngineState.passiveLastWallTime > 0 && isPlaying) {
+    const wallDelta = (now - animEngineState.passiveLastWallTime) / 1000;
+    animEngineState.passiveScrollAccumulatedTime += Math.min(wallDelta, 0.5);
+  }
+  animEngineState.passiveLastWallTime = now;
+
+  // -- User scroll interruption --------------------------
+  if (animEngineState.scrollResumeTime > now) {
+    return;
+  }
+
+  if (animEngineState.wasUserScrolling) {
+    getResumeScrollElement().setAttribute("autoscroll-hidden", "true");
+    lyricData.lyricsContainer.classList.remove(USER_SCROLLING_CLASS);
+    animEngineState.wasUserScrolling = false;
+
+    // Re-sync accumulated time to current scroll position so scroll continues from where user left off
+    const maxScroll = tabRenderer.scrollHeight - tabRenderer.clientHeight;
+    if (maxScroll > 0) {
+      const ratio = tabRenderer.scrollTop / maxScroll;
+      const numLines = lyricData.lines.length;
+      const scrollDuration = numLines * PASSIVE_SECONDS_PER_LINE.getNumberValue();
+      animEngineState.passiveScrollAccumulatedTime = ratio * scrollDuration;
+    }
+  }
+
+  // -- Cycle calculation --------------------------
+  const numLines = lyricData.lines.length;
+  if (numLines === 0) return;
+
+  const scrollDuration = numLines * PASSIVE_SECONDS_PER_LINE.getNumberValue();
+  const bottomPause = PASSIVE_BOTTOM_PAUSE_S.getNumberValue();
+  const resetDuration = PASSIVE_RESET_DURATION_S.getNumberValue();
+  const topPause = PASSIVE_TOP_PAUSE_S.getNumberValue();
+  const cycleLength = scrollDuration + bottomPause + resetDuration + topPause;
+
+  const maxScroll = tabRenderer.scrollHeight - tabRenderer.clientHeight;
+  if (maxScroll <= 0) return;
+
+  const cycleTime = animEngineState.passiveScrollAccumulatedTime % cycleLength;
+
+  let targetScroll: number;
+  if (cycleTime < scrollDuration) {
+    // Phase 1: linear scroll down
+    targetScroll = (cycleTime / scrollDuration) * maxScroll;
+  } else if (cycleTime < scrollDuration + bottomPause) {
+    // Phase 2: hold at bottom
+    targetScroll = maxScroll;
+  } else if (cycleTime < scrollDuration + bottomPause + resetDuration) {
+    // Phase 3: ease-out scroll back to top
+    const resetProgress = (cycleTime - scrollDuration - bottomPause) / resetDuration;
+    const eased = 1 - (1 - resetProgress) * (1 - resetProgress);
+    targetScroll = maxScroll * (1 - eased);
+  } else {
+    // Phase 4: hold at top
+    targetScroll = 0;
+  }
+
+  tabRenderer.scrollTop = targetScroll;
+  animEngineState.skipScrolls += 1;
+  animEngineState.skipScrollsDecayTimes.push(now + 2000);
+
+  decaySkipScrolls(now);
 }
 
 /**
@@ -152,6 +260,16 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
   const now = Date.now();
   // const frameStart = performance.now();
   if (!AppState.areLyricsTicking || (currentTime === 0 && !isPlaying)) {
+    return;
+  }
+
+  if (AppState.lyricData?.syncType === "none") {
+    if (!animEngineState.lastPlayState && isPlaying) {
+      animEngineState.scrollResumeTime = 0;
+    }
+    animEngineState.lastPlayState = isPlaying;
+    if (!AppState.isPassiveScrollEnabled) return;
+    passiveScrollEngine(isPlaying);
     return;
   }
 
@@ -568,17 +686,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
       animEngineState.wasUserScrolling = false;
     }
 
-    let j = 0;
-    for (; j < animEngineState.skipScrollsDecayTimes.length; j++) {
-      if (animEngineState.skipScrollsDecayTimes[j] > now) {
-        break;
-      }
-    }
-    animEngineState.skipScrollsDecayTimes = animEngineState.skipScrollsDecayTimes.slice(j);
-    animEngineState.skipScrolls -= j;
-    if (animEngineState.skipScrolls < 1) {
-      animEngineState.skipScrolls = 1; // Always leave at least one for when the window is refocused.
-    }
+    decaySkipScrolls(now);
     // const frameTime = performance.now() - frameStart;
     // if (frameTime > 5) {
     //   console.warn("[BLyrics-diag] SLOW FRAME", { ms: frameTime.toFixed(1) });

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -33,6 +33,7 @@ export const SCROLL_POS_OFFSET_RATIO = registerThemeSetting("blyrics-target-scro
 
 export const ADD_EXTRA_PADDING_TOP = registerThemeSetting("blyrics-add-extra-top-padding", false);
 
+const PASSIVE_SCROLL_ENABLED = registerThemeSetting("blyrics-passive-scroll-enabled", true);
 const PASSIVE_SECONDS_PER_LINE = registerThemeSetting("blyrics-passive-scroll-seconds-per-line", 3.5);
 const PASSIVE_BOTTOM_PAUSE_S = registerThemeSetting("blyrics-passive-scroll-bottom-pause-s", 1.5);
 const PASSIVE_RESET_DURATION_S = registerThemeSetting("blyrics-passive-scroll-reset-duration-s", 0.6);
@@ -109,6 +110,7 @@ export function resetAnimEngineState(): void {
   animEngineState.queuedScroll = false;
   animEngineState.passiveScrollAccumulatedTime = 0;
   animEngineState.passiveLastWallTime = 0;
+  stopPassiveScrollLoop();
   cachedDurations.clear();
 }
 
@@ -151,9 +153,39 @@ function decaySkipScrolls(now: number): void {
 
 // -- Passive Scroll Engine --------------------------
 
+let passiveRAFId: number | null = null;
+
+function stopPassiveScrollLoop(): void {
+  if (passiveRAFId !== null) {
+    cancelAnimationFrame(passiveRAFId);
+    passiveRAFId = null;
+  }
+}
+
+function startPassiveScrollLoop(): void {
+  if (passiveRAFId !== null) return;
+  passiveRAFId = requestAnimationFrame(passiveScrollRAFLoop);
+}
+
+function passiveScrollRAFLoop(): void {
+  passiveRAFId = null;
+  if (
+    !AppState.isPassiveScrollEnabled ||
+    !PASSIVE_SCROLL_ENABLED.getBooleanValue() ||
+    AppState.lyricData?.syncType !== "none"
+  )
+    return;
+
+  passiveScrollEngine(animEngineState.lastPlayState);
+  passiveRAFId = requestAnimationFrame(passiveScrollRAFLoop);
+}
+
 function passiveScrollEngine(isPlaying: boolean): void {
   const lyricData = AppState.lyricData;
   if (!lyricData) return;
+
+  const tabSelector = lyricData.tabSelector;
+  if (!tabSelector || tabSelector.getAttribute("aria-selected") !== "true") return;
 
   if (isLoaderActive()) return;
 
@@ -221,11 +253,14 @@ function passiveScrollEngine(isPlaying: boolean): void {
     targetScroll = 0;
   }
 
+  const prevScrollTop = tabRenderer.scrollTop;
   tabRenderer.scrollTop = targetScroll;
-  animEngineState.skipScrolls += 1;
-  animEngineState.skipScrollsDecayTimes.push(now + 2000);
-
-  decaySkipScrolls(now);
+  // Only skip the next scroll event if scrollTop actually changed.
+  // When it doesn't change (pause phases, sub-pixel rounding), no programmatic
+  // scroll event fires — setting skipScrolls would eat user scroll events instead.
+  if (tabRenderer.scrollTop !== prevScrollTop) {
+    animEngineState.skipScrolls = 1;
+  }
 }
 
 /**
@@ -269,7 +304,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
     }
     animEngineState.lastPlayState = isPlaying;
     if (!AppState.isPassiveScrollEnabled) return;
-    passiveScrollEngine(isPlaying);
+    startPassiveScrollLoop();
     return;
   }
 

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -31,8 +31,6 @@ let observedTabRenderer: HTMLElement | null = null;
 // 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom
 export const SCROLL_POS_OFFSET_RATIO = registerThemeSetting("blyrics-target-scroll-pos-ratio", 0.37);
 
-const ADD_EXTRA_PADDING_TOP = registerThemeSetting("blyrics-add-extra-top-padding", false);
-
 const PASSIVE_SCROLL_ENABLED = registerThemeSetting("blyrics-passive-scroll-enabled", true);
 const PASSIVE_SECONDS_PER_LINE = registerThemeSetting("blyrics-passive-scroll-seconds-per-line", 3.5);
 const PASSIVE_BOTTOM_PAUSE_S = registerThemeSetting("blyrics-passive-scroll-bottom-pause-s", 1.5);

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -31,7 +31,7 @@ let observedTabRenderer: HTMLElement | null = null;
 // 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom
 export const SCROLL_POS_OFFSET_RATIO = registerThemeSetting("blyrics-target-scroll-pos-ratio", 0.37);
 
-export const ADD_EXTRA_PADDING_TOP = registerThemeSetting("blyrics-add-extra-top-padding", false);
+const ADD_EXTRA_PADDING_TOP = registerThemeSetting("blyrics-add-extra-top-padding", false);
 
 const PASSIVE_SCROLL_ENABLED = registerThemeSetting("blyrics-passive-scroll-enabled", true);
 const PASSIVE_SECONDS_PER_LINE = registerThemeSetting("blyrics-passive-scroll-seconds-per-line", 3.5);

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -226,7 +226,7 @@ export function lyricReloader(): void {
         setTimeout(() => {
           tabRenderer.scrollTop = scrollPositions[i];
           // Don't start ticking until we set the height
-          AppState.areLyricsTicking = AppState.areLyricsLoaded && AppState.lyricData?.syncType !== "none" && i === 1;
+          AppState.areLyricsTicking = AppState.areLyricsLoaded && i === 1;
         }, 0);
         currentTab = i;
 
@@ -399,12 +399,14 @@ export function scrollEventHandler(): void {
     if (animEngineState.scrollResumeTime < Date.now()) {
       log(PAUSING_LYRICS_SCROLL_LOG);
     }
-    animEngineState.scrollResumeTime = Date.now() + 25000;
-    if (!animEngineState.wasUserScrolling) {
+    const isPassive = AppState.lyricData?.syncType === "none";
+    animEngineState.scrollResumeTime = Date.now() + (isPassive ? 5000 : 25000);
+    animEngineState.wasUserScrolling = true;
+
+    if (!isPassive) {
       getResumeScrollElement().removeAttribute("autoscroll-hidden");
       const lyricsElement = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement;
       lyricsElement.classList.add(USER_SCROLLING_CLASS);
-      animEngineState.wasUserScrolling = true;
     }
   }
 }

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -187,7 +187,7 @@ export function disableInertWhenFullscreen(): void {
             if (tabSelector && tabSelector.getAttribute("aria-selected") !== "true") {
               tabSelector.click();
               currentTab = 1;
-              if (AppState.areLyricsLoaded && AppState.lyricData?.syncType !== "none") {
+              if (AppState.areLyricsLoaded) {
                 AppState.areLyricsTicking = true;
               }
             }
@@ -403,11 +403,9 @@ export function scrollEventHandler(): void {
     animEngineState.scrollResumeTime = Date.now() + (isPassive ? 5000 : 25000);
     animEngineState.wasUserScrolling = true;
 
-    if (!isPassive) {
-      getResumeScrollElement().removeAttribute("autoscroll-hidden");
-      const lyricsElement = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement;
-      lyricsElement.classList.add(USER_SCROLLING_CLASS);
-    }
+    getResumeScrollElement().removeAttribute("autoscroll-hidden");
+    const lyricsElement = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement;
+    lyricsElement.classList.add(USER_SCROLLING_CLASS);
   }
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -143,6 +143,13 @@
 							<span class="checkmark"></span>
 						</label>
 					</div>
+					<div class="container">
+						<span>__MSG_options_display_passiveScroll__</span>
+						<label>
+							<input type="checkbox" id="isPassiveScrollEnabled">
+							<span class="checkmark"></span>
+						</label>
+					</div>
 				</div>
 			</div>
 			<div class="tab-content" id="language-content">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -13,6 +13,7 @@ interface Options {
   isAlbumArtEnabled: boolean;
   isFullScreenDisabled: boolean;
   isStylizedAnimationsEnabled: boolean;
+  isPassiveScrollEnabled: boolean;
   isTranslateEnabled: boolean;
   translationLanguage: string;
   isCursorAutoHideEnabled: boolean;
@@ -46,6 +47,7 @@ const getOptionsFromForm = (): Options => {
     isAlbumArtEnabled: (document.getElementById("albumArt") as HTMLInputElement).checked,
     isFullScreenDisabled: (document.getElementById("isFullScreenDisabled") as HTMLInputElement).checked,
     isStylizedAnimationsEnabled: (document.getElementById("isStylizedAnimationsEnabled") as HTMLInputElement).checked,
+    isPassiveScrollEnabled: (document.getElementById("isPassiveScrollEnabled") as HTMLInputElement).checked,
     isTranslateEnabled: (document.getElementById("translate") as HTMLInputElement).checked,
     translationLanguage: (document.getElementById("translationLanguage") as HTMLInputElement).value,
     isCursorAutoHideEnabled: (document.getElementById("cursorAutoHide") as HTMLInputElement).checked,
@@ -186,6 +188,7 @@ const restoreOptions = (): void => {
     isCursorAutoHideEnabled: true,
     isFullScreenDisabled: false,
     isStylizedAnimationsEnabled: true,
+    isPassiveScrollEnabled: true,
     isTranslateEnabled: false,
     translationLanguage: "en",
     isRomanizationEnabled: false,
@@ -221,6 +224,7 @@ const setOptionsInForm = (items: Options): void => {
   (document.getElementById("isFullScreenDisabled") as HTMLInputElement).checked = items.isFullScreenDisabled;
   (document.getElementById("isStylizedAnimationsEnabled") as HTMLInputElement).checked =
     items.isStylizedAnimationsEnabled;
+  (document.getElementById("isPassiveScrollEnabled") as HTMLInputElement).checked = items.isPassiveScrollEnabled;
   (document.getElementById("translate") as HTMLInputElement).checked = items.isTranslateEnabled;
   (document.getElementById("translationLanguage") as HTMLInputElement).value = items.translationLanguage;
   (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked = items.isRomanizationEnabled;


### PR DESCRIPTION
## Description

- Add passive auto-scroll for unsynced (plain) lyrics
- Expose a new "Auto-scroll unsynced lyrics" toggle in Display settings (enabled by default)
- Support CSS knobs for scroll speed, pause durations, and reset timing

## Related Issue 

#431 
