### PR TITLE
fix: third possible property for romanized text

### DIFF
--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -71,10 +71,7 @@ export async function translateTextIntoRomaji(
   })
     .then(response => response.json())
     .then(data => {
-      let romanizedText = data[0][1][3];
-      if (romanizedText === undefined) {
-        romanizedText = data[0][1][2];
-      }
+      let romanizedText = data[0][1][3] || data[0][1][2] || data[0][2][3];
       if (text.trim().toLowerCase() === romanizedText.trim().toLowerCase() && text.trim() !== "") {
         return null;
       } else {


### PR DESCRIPTION
# Description

> Parts of code taken from #304 

A romanization could possibly be positioned anywhere within the Google Translate API, and just recently I played https://music.youtube.com/watch?v=5-AODkTJyJE and one of the lines that has a Japanese version of brackets somehow didn't have its own romanization

While inspecting, I found out that the romanized text are not located at both of the given property, but somehow placed in another index

Source lyrics from Musixmatch

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
