### PR TITLE
Feat/unison dock

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -94,37 +94,57 @@
     "message": "Auto-scroll unsynced lyrics",
     "description": "Auto-scroll unsynced lyrics setting label"
   },
-  "options_display_pinUnisonActions": {
-    "message": "Pin Unison actions",
-    "description": "Toggle label for the floating Unison upvote/downvote/report dock"
+  "options_display_unisonActions": {
+    "message": "Unison Actions",
+    "description": "Display-section row label for the Unison Actions modal trigger"
   },
-  "options_display_pinUnisonActionsPosition": {
-    "message": "Pin position",
-    "description": "Label for the position selector of the Unison pinned dock"
+  "options_unisonModal_title": {
+    "message": "Unison Actions",
+    "description": "Title of the Unison Actions modal"
   },
-  "options_display_pinUnisonActionsPosition_topLeft": {
+  "options_unisonModal_showPinned": {
+    "message": "Show pinned actions",
+    "description": "Toggle label inside the Unison Actions modal for the floating dock"
+  },
+  "options_unisonModal_showPinned_hint": {
+    "message": "A floating control to upvote, downvote, or report Unison lyrics",
+    "description": "Hint text under the Show pinned actions toggle"
+  },
+  "options_unisonModal_autoHide": {
+    "message": "Auto-hide in fullscreen",
+    "description": "Toggle label inside the Unison Actions modal for auto-hiding the dock when idle in fullscreen"
+  },
+  "options_unisonModal_autoHide_hint": {
+    "message": "Hide the floating control when you are idle in fullscreen mode",
+    "description": "Hint text under the Auto-hide in fullscreen toggle"
+  },
+  "options_unisonModal_position": {
+    "message": "Position",
+    "description": "Label above the visual position picker in the Unison Actions modal"
+  },
+  "options_unisonModal_position_topLeft": {
     "message": "Top left",
-    "description": "Top-left option for Unison pinned dock position"
+    "description": "Tooltip for the top-left cell in the Unison position picker"
   },
-  "options_display_pinUnisonActionsPosition_topCenter": {
+  "options_unisonModal_position_topCenter": {
     "message": "Top center",
-    "description": "Top-center option for Unison pinned dock position"
+    "description": "Tooltip for the top-center cell in the Unison position picker"
   },
-  "options_display_pinUnisonActionsPosition_topRight": {
+  "options_unisonModal_position_topRight": {
     "message": "Top right",
-    "description": "Top-right option for Unison pinned dock position"
+    "description": "Tooltip for the top-right cell in the Unison position picker"
   },
-  "options_display_pinUnisonActionsPosition_bottomLeft": {
+  "options_unisonModal_position_bottomLeft": {
     "message": "Bottom left",
-    "description": "Bottom-left option for Unison pinned dock position"
+    "description": "Tooltip for the bottom-left cell in the Unison position picker"
   },
-  "options_display_pinUnisonActionsPosition_bottomCenter": {
+  "options_unisonModal_position_bottomCenter": {
     "message": "Bottom center",
-    "description": "Bottom-center option for Unison pinned dock position"
+    "description": "Tooltip for the bottom-center cell in the Unison position picker"
   },
-  "options_display_pinUnisonActionsPosition_bottomRight": {
+  "options_unisonModal_position_bottomRight": {
     "message": "Bottom right",
-    "description": "Bottom-right option for Unison pinned dock position"
+    "description": "Tooltip for the bottom-right cell in the Unison position picker"
   },
 
   "options_language_displayLanguage": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -94,6 +94,38 @@
     "message": "Auto-scroll unsynced lyrics",
     "description": "Auto-scroll unsynced lyrics setting label"
   },
+  "options_display_pinUnisonActions": {
+    "message": "Pin Unison actions",
+    "description": "Toggle label for the floating Unison upvote/downvote/report dock"
+  },
+  "options_display_pinUnisonActionsPosition": {
+    "message": "Pin position",
+    "description": "Label for the position selector of the Unison pinned dock"
+  },
+  "options_display_pinUnisonActionsPosition_topLeft": {
+    "message": "Top left",
+    "description": "Top-left option for Unison pinned dock position"
+  },
+  "options_display_pinUnisonActionsPosition_topCenter": {
+    "message": "Top center",
+    "description": "Top-center option for Unison pinned dock position"
+  },
+  "options_display_pinUnisonActionsPosition_topRight": {
+    "message": "Top right",
+    "description": "Top-right option for Unison pinned dock position"
+  },
+  "options_display_pinUnisonActionsPosition_bottomLeft": {
+    "message": "Bottom left",
+    "description": "Bottom-left option for Unison pinned dock position"
+  },
+  "options_display_pinUnisonActionsPosition_bottomCenter": {
+    "message": "Bottom center",
+    "description": "Bottom-center option for Unison pinned dock position"
+  },
+  "options_display_pinUnisonActionsPosition_bottomRight": {
+    "message": "Bottom right",
+    "description": "Bottom-right option for Unison pinned dock position"
+  },
 
   "options_language_displayLanguage": {
     "message": "Display Language",

--- a/public/css/blyrics/components.css
+++ b/public/css/blyrics/components.css
@@ -285,6 +285,14 @@
 	height: 16px;
 }
 
+.blyrics-footer__vote svg path[fill-opacity] {
+	transition: fill-opacity 0.2s ease;
+}
+
+.blyrics-footer__vote--active svg path[fill-opacity] {
+	fill-opacity: 1;
+}
+
 .blyrics-footer__vote:hover {
 	background-color: var(--blyrics-vote-hover-color);
 }
@@ -404,7 +412,10 @@
 	z-index: 50;
 	pointer-events: none;
 	transform: translateY(var(--dock-y-shift, 0));
-	transition: transform 125ms cubic-bezier(0.4, 0, 0.2, 1);
+	transition:
+		transform 125ms cubic-bezier(0.4, 0, 0.2, 1),
+		top 280ms cubic-bezier(0.4, 0, 0.2, 1),
+		left 280ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 #side-panel:has(.autoscroll-resume-button:not([autoscroll-hidden="true"])) .blyrics-unison-dock[data-position="top-center"] {
@@ -424,23 +435,25 @@
 
 .blyrics-unison-dock[data-position="top-right"] {
 	top: 64px;
-	right: 0;
+	left: 100%;
+	--dock-tx: -100%;
 }
 
 .blyrics-unison-dock[data-position="bottom-left"] {
-	bottom: 16px;
+	top: calc(100% - 64px);
 	left: 0;
 }
 
 .blyrics-unison-dock[data-position="bottom-center"] {
-	bottom: 16px;
+	top: calc(100% - 64px);
 	left: 50%;
 	--dock-tx: -50%;
 }
 
 .blyrics-unison-dock[data-position="bottom-right"] {
-	bottom: 16px;
-	right: 0;
+	top: calc(100% - 64px);
+	left: 100%;
+	--dock-tx: -100%;
 }
 
 .blyrics-unison-dock__inner {
@@ -469,7 +482,8 @@
 	height: 32px;
 }
 
-.blyrics-unison-dock--hidden .blyrics-unison-dock__inner {
+.blyrics-unison-dock--hidden .blyrics-unison-dock__inner,
+#layout[player-fullscreened]:not([blyrics-dfs]) .blyrics-unison-dock--idle-hidden .blyrics-unison-dock__inner {
 	transform: translateX(var(--dock-tx, 0)) scale(0.85);
 	opacity: 0;
 	filter: blur(8px);

--- a/public/css/blyrics/components.css
+++ b/public/css/blyrics/components.css
@@ -395,6 +395,87 @@
 	background-color: hsla(0, 0%, 100%, 0.08);
 }
 
+#side-panel:has(.blyrics-unison-dock) {
+	position: relative;
+}
+
+.blyrics-unison-dock {
+	position: absolute;
+	z-index: 50;
+	pointer-events: none;
+	transform: translateY(var(--dock-y-shift, 0));
+	transition: transform 125ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+#side-panel:has(.autoscroll-resume-button:not([autoscroll-hidden="true"])) .blyrics-unison-dock[data-position="top-center"] {
+	--dock-y-shift: 72px;
+}
+
+.blyrics-unison-dock[data-position="top-left"] {
+	top: 64px;
+	left: 0;
+}
+
+.blyrics-unison-dock[data-position="top-center"] {
+	top: 64px;
+	left: 50%;
+	--dock-tx: -50%;
+}
+
+.blyrics-unison-dock[data-position="top-right"] {
+	top: 64px;
+	right: 0;
+}
+
+.blyrics-unison-dock[data-position="bottom-left"] {
+	bottom: 16px;
+	left: 0;
+}
+
+.blyrics-unison-dock[data-position="bottom-center"] {
+	bottom: 16px;
+	left: 50%;
+	--dock-tx: -50%;
+}
+
+.blyrics-unison-dock[data-position="bottom-right"] {
+	bottom: 16px;
+	right: 0;
+}
+
+.blyrics-unison-dock__inner {
+	pointer-events: auto;
+	background-color: hsla(0, 0%, 100%, 0.04);
+	box-shadow:
+		rgba(0, 0, 0, 0.3) 0 10px 24px -6px,
+		inset rgba(255, 255, 255, 0.1) 0 1px 0 0;
+	backdrop-filter: blur(12px);
+	border-radius: 14px;
+	padding: 8px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	transform: translateX(var(--dock-tx, 0)) scale(1);
+	opacity: 1;
+	filter: blur(0);
+	transition:
+		transform 320ms cubic-bezier(0.4, 0, 0.2, 1),
+		opacity 320ms cubic-bezier(0.4, 0, 0.2, 1),
+		filter 320ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.blyrics-unison-dock__inner .blyrics-footer__vote {
+	width: 32px;
+	height: 32px;
+}
+
+.blyrics-unison-dock--hidden .blyrics-unison-dock__inner {
+	transform: translateX(var(--dock-tx, 0)) scale(0.85);
+	opacity: 0;
+	filter: blur(8px);
+	pointer-events: none;
+}
+
 .blyrics-footer__trust-tier[data-tier="new"] {
 	color: hsl(220, 70%, 75%);
 	background-color: hsla(220, 70%, 60%, 0.15);

--- a/public/css/blyrics/modal.css
+++ b/public/css/blyrics/modal.css
@@ -7,7 +7,6 @@
 	align-items: center;
 	justify-content: center;
 	position: fixed;
-	transition: 0.2s;
 	top: 0;
 	bottom: 0;
 	right: 0;

--- a/public/css/ytmusic/fullscreen.css
+++ b/public/css/ytmusic/fullscreen.css
@@ -203,3 +203,13 @@ ytmusic-app-layout[player-fullscreened]:not([blyrics-dfs]) > [slot="player-bar"]
   animation: none !important;
   width: 100%;
 }
+
+/* Top-anchored Unison dock: tab header is hidden in fullscreen, so no 48px buffer needed */
+#layout[player-fullscreened]:not([blyrics-dfs]) .blyrics-unison-dock[data-position^="top-"] {
+  top: 16px;
+}
+
+/* Shift bottom-anchored Unison dock above the player bar when it shows in fullscreen */
+#layout[player-fullscreened]:not([blyrics-dfs])[show-fullscreen-controls] .blyrics-unison-dock[data-position^="bottom-"] {
+  --dock-y-shift: -88px;
+}

--- a/public/css/ytmusic/fullscreen.css
+++ b/public/css/ytmusic/fullscreen.css
@@ -213,3 +213,8 @@ ytmusic-app-layout[player-fullscreened]:not([blyrics-dfs]) > [slot="player-bar"]
 #layout[player-fullscreened]:not([blyrics-dfs])[show-fullscreen-controls] .blyrics-unison-dock[data-position^="bottom-"] {
   --dock-y-shift: -88px;
 }
+
+/* Top-center autoscroll-button shift is smaller in fullscreen (no tab header) */
+#layout[player-fullscreened]:not([blyrics-dfs]) #side-panel:has(.autoscroll-resume-button:not([autoscroll-hidden="true"])) .blyrics-unison-dock[data-position="top-center"] {
+  --dock-y-shift: 52px;
+}

--- a/public/css/ytmusic/general.css
+++ b/public/css/ytmusic/general.css
@@ -105,6 +105,10 @@ ytmusic-message-renderer.ytmusic-tab-renderer {
   display: none !important;
 }
 
+#side-panel:has(#tab-renderer:not([page-type="MUSIC_PAGE_TYPE_TRACK_LYRICS"])) .blyrics-unison-dock {
+  display: none !important;
+}
+
 ytmusic-player-page:not([is-mweb-modernization-enabled])[blyrics-video-mode]
 .side-panel.ytmusic-player-page {
   margin: 0 0 0 calc(var(--ytmusic-player-page-content-gap) / 2);

--- a/src/core/appState.ts
+++ b/src/core/appState.ts
@@ -1,4 +1,4 @@
-import { GENERAL_ERROR_LOG } from "@constants";
+import { GENERAL_ERROR_LOG, UNISON_DOCK_DEFAULT_POSITION } from "@constants";
 import type { LyricsData } from "@modules/lyrics/injectLyrics";
 import { createLyrics } from "@modules/lyrics/lyrics";
 import type { UnisonData } from "@modules/lyrics/providers/unison";
@@ -45,6 +45,7 @@ interface AppStateType {
   currentInjectionId: number;
   isUnisonPinnedDockEnabled: boolean;
   unisonPinnedDockPosition: string;
+  isUnisonAutoHideInFullscreenEnabled: boolean;
   currentUnisonData: UnisonData | null;
 }
 
@@ -71,8 +72,9 @@ export const AppState: AppStateType = {
   isPassiveScrollEnabled: true,
   hasPreloadedNextSong: false,
   currentInjectionId: 0,
-  isUnisonPinnedDockEnabled: false,
-  unisonPinnedDockPosition: "bottom-right",
+  isUnisonPinnedDockEnabled: true,
+  unisonPinnedDockPosition: UNISON_DOCK_DEFAULT_POSITION,
+  isUnisonAutoHideInFullscreenEnabled: true,
   currentUnisonData: null,
 };
 

--- a/src/core/appState.ts
+++ b/src/core/appState.ts
@@ -1,6 +1,7 @@
 import { GENERAL_ERROR_LOG } from "@constants";
 import type { LyricsData } from "@modules/lyrics/injectLyrics";
 import { createLyrics } from "@modules/lyrics/lyrics";
+import type { UnisonData } from "@modules/lyrics/providers/unison";
 import { flushLoader } from "@modules/ui/dom";
 import { log } from "@utils";
 
@@ -42,6 +43,9 @@ interface AppStateType {
   isPassiveScrollEnabled: boolean;
   hasPreloadedNextSong: boolean;
   currentInjectionId: number;
+  isUnisonPinnedDockEnabled: boolean;
+  unisonPinnedDockPosition: string;
+  currentUnisonData: UnisonData | null;
 }
 
 export const AppState: AppStateType = {
@@ -67,6 +71,9 @@ export const AppState: AppStateType = {
   isPassiveScrollEnabled: true,
   hasPreloadedNextSong: false,
   currentInjectionId: 0,
+  isUnisonPinnedDockEnabled: false,
+  unisonPinnedDockPosition: "bottom-right",
+  currentUnisonData: null,
 };
 
 export function reloadLyrics(): void {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -16,6 +16,7 @@ export const USER_SCROLLING_CLASS = "blyrics-user-scrolling" as const;
 export const TRANSLATED_LYRICS_CLASS = "blyrics--translated" as const;
 export const ROMANIZED_LYRICS_CLASS = "blyrics--romanized" as const;
 export const FOOTER_CLASS = "blyrics-footer" as const;
+export const UNISON_DOCK_CLASS = "blyrics-unison-dock" as const;
 export const MODAL_OVERLAY_CLASS = "blyrics-modal-overlay" as const;
 export const MODAL_CLASS = "blyrics-modal" as const;
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -17,6 +17,7 @@ export const TRANSLATED_LYRICS_CLASS = "blyrics--translated" as const;
 export const ROMANIZED_LYRICS_CLASS = "blyrics--romanized" as const;
 export const FOOTER_CLASS = "blyrics-footer" as const;
 export const UNISON_DOCK_CLASS = "blyrics-unison-dock" as const;
+export const UNISON_DOCK_DEFAULT_POSITION = "bottom-right" as const;
 export const MODAL_OVERLAY_CLASS = "blyrics-modal-overlay" as const;
 export const MODAL_CLASS = "blyrics-modal" as const;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   listenForPopupMessages,
   loadPassiveScrollSetting,
   loadTranslationSettings,
+  loadUnisonPinnedDockSettings,
   onAlbumArtEnabled,
 } from "@modules/settings/settings";
 import { injectHeadTags, reloadAlbumArt, setupAdObserver } from "@modules/ui/dom";
@@ -45,6 +46,7 @@ async function modify(): Promise<void> {
   setupWakeLockForFullscreen();
   loadTranslationSettings();
   loadPassiveScrollSetting();
+  loadUnisonPinnedDockSettings();
   subscribeToCustomStyles();
   await purgeExpiredKeys();
   await saveCacheInfo();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { setupRequestSniffer } from "@modules/lyrics/requestSniffer/requestSniff
 import {
   handleSettings,
   hideCursorOnIdle,
+  hideDockOnIdleInFullscreen,
   listenForPopupMessages,
   loadPassiveScrollSetting,
   loadTranslationSettings,
@@ -46,7 +47,7 @@ async function modify(): Promise<void> {
   setupWakeLockForFullscreen();
   loadTranslationSettings();
   loadPassiveScrollSetting();
-  loadUnisonPinnedDockSettings();
+  loadUnisonPinnedDockSettings(hideDockOnIdleInFullscreen);
   subscribeToCustomStyles();
   await purgeExpiredKeys();
   await saveCacheInfo();

--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -4,7 +4,7 @@ import { clearCache, compileRicsToStyles, getStorage } from "@core/storage";
 import { log, setUpLog } from "@core/utils";
 import { calculateLyricPositions } from "@modules/lyrics/injectLyrics";
 import { clearCache as clearTranslationCache } from "@modules/lyrics/translation";
-import { reloadAlbumArt } from "@modules/ui/dom";
+import { mountUnisonDock, reloadAlbumArt, unmountUnisonDock, updateUnisonDockPosition } from "@modules/ui/dom";
 import { applyCustomStyles, getAndApplyCustomStyles } from "@modules/ui/styleInjector";
 
 let hasInitializedMessageListener = false;
@@ -193,6 +193,7 @@ export function listenForPopupMessages(): void {
       handleSettings();
       loadTranslationSettings();
       loadPassiveScrollSetting();
+      loadUnisonPinnedDockSettings(syncUnisonDock);
       AppState.shouldInjectAlbumArt = "Unknown";
       onAlbumArtEnabled(
         () => {
@@ -222,6 +223,25 @@ export function loadPassiveScrollSetting(): void {
   getStorage({ isPassiveScrollEnabled: true }, items => {
     AppState.isPassiveScrollEnabled = items.isPassiveScrollEnabled;
   });
+}
+
+export function loadUnisonPinnedDockSettings(callback?: () => void): void {
+  getStorage({ isUnisonPinnedDockEnabled: false, unisonPinnedDockPosition: "bottom-right" }, items => {
+    AppState.isUnisonPinnedDockEnabled = items.isUnisonPinnedDockEnabled;
+    AppState.unisonPinnedDockPosition = items.unisonPinnedDockPosition;
+    callback?.();
+  });
+}
+
+function syncUnisonDock(): void {
+  if (!AppState.isUnisonPinnedDockEnabled) {
+    unmountUnisonDock();
+    return;
+  }
+  if (AppState.currentUnisonData) {
+    mountUnisonDock(AppState.currentUnisonData, AppState.unisonPinnedDockPosition);
+    updateUnisonDockPosition(AppState.unisonPinnedDockPosition);
+  }
 }
 
 /**

--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -1,4 +1,4 @@
-import { LOG_PREFIX_CONTENT, LYRICS_DISABLED_ATTR } from "@constants";
+import { LOG_PREFIX_CONTENT, LYRICS_DISABLED_ATTR, UNISON_DOCK_CLASS, UNISON_DOCK_DEFAULT_POSITION } from "@constants";
 import { AppState, reloadLyrics } from "@core/appState";
 import { clearCache, compileRicsToStyles, getStorage } from "@core/storage";
 import { log, setUpLog } from "@core/utils";
@@ -193,7 +193,10 @@ export function listenForPopupMessages(): void {
       handleSettings();
       loadTranslationSettings();
       loadPassiveScrollSetting();
-      loadUnisonPinnedDockSettings(syncUnisonDock);
+      loadUnisonPinnedDockSettings(() => {
+        syncUnisonDock();
+        hideDockOnIdleInFullscreen();
+      });
       AppState.shouldInjectAlbumArt = "Unknown";
       onAlbumArtEnabled(
         () => {
@@ -226,11 +229,19 @@ export function loadPassiveScrollSetting(): void {
 }
 
 export function loadUnisonPinnedDockSettings(callback?: () => void): void {
-  getStorage({ isUnisonPinnedDockEnabled: false, unisonPinnedDockPosition: "bottom-right" }, items => {
-    AppState.isUnisonPinnedDockEnabled = items.isUnisonPinnedDockEnabled;
-    AppState.unisonPinnedDockPosition = items.unisonPinnedDockPosition;
-    callback?.();
-  });
+  getStorage(
+    {
+      isUnisonPinnedDockEnabled: true,
+      unisonPinnedDockPosition: UNISON_DOCK_DEFAULT_POSITION,
+      isUnisonAutoHideInFullscreenEnabled: true,
+    },
+    items => {
+      AppState.isUnisonPinnedDockEnabled = items.isUnisonPinnedDockEnabled;
+      AppState.unisonPinnedDockPosition = items.unisonPinnedDockPosition;
+      AppState.isUnisonAutoHideInFullscreenEnabled = items.isUnisonAutoHideInFullscreenEnabled;
+      callback?.();
+    }
+  );
 }
 
 function syncUnisonDock(): void {
@@ -242,6 +253,53 @@ function syncUnisonDock(): void {
     mountUnisonDock(AppState.currentUnisonData, AppState.unisonPinnedDockPosition);
     updateUnisonDockPosition(AppState.unisonPinnedDockPosition);
   }
+}
+
+const DOCK_IDLE_HIDDEN_CLASS = `${UNISON_DOCK_CLASS}--idle-hidden`;
+
+let dockIdleTimer: number | null = null;
+let dockMouseListener: ((this: Document, ev: MouseEvent) => any) | null = null;
+
+function setDockIdleHidden(hidden: boolean): void {
+  for (const dock of Array.from(document.getElementsByClassName(UNISON_DOCK_CLASS))) {
+    dock.classList.toggle(DOCK_IDLE_HIDDEN_CLASS, hidden);
+  }
+}
+
+export function hideDockOnIdleInFullscreen(): void {
+  if (dockMouseListener) {
+    document.removeEventListener("mousemove", dockMouseListener);
+    dockMouseListener = null;
+  }
+  if (dockIdleTimer) {
+    window.clearTimeout(dockIdleTimer);
+    dockIdleTimer = null;
+  }
+  setDockIdleHidden(false);
+
+  if (!AppState.isUnisonAutoHideInFullscreenEnabled) return;
+
+  let dockVisible = true;
+
+  function hideDock() {
+    dockIdleTimer = null;
+    if (!dockVisible) return;
+    if (!document.getElementById("layout")?.hasAttribute("player-fullscreened")) return;
+    setDockIdleHidden(true);
+    dockVisible = false;
+  }
+
+  function handleMouseMove() {
+    if (dockIdleTimer) window.clearTimeout(dockIdleTimer);
+    if (!dockVisible) {
+      setDockIdleHidden(false);
+      dockVisible = true;
+    }
+    dockIdleTimer = window.setTimeout(hideDock, 3000);
+  }
+
+  dockMouseListener = handleMouseMove;
+  document.addEventListener("mousemove", handleMouseMove);
 }
 
 /**

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -41,12 +41,13 @@ import { byId, deleteVote, type UnisonData, vote } from "../lyrics/providers/uni
 import { scrollEventHandler } from "./observer";
 import { showReportModal } from "./reportLyrics";
 
-const votedIcons = {
-  upvote: `<svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20" fill="currentColor"><path d="M9.221 1.795a1 1 0 011.109-.656l1.04.173a4 4 0 013.252 4.784L14 9h4.061a3.664 3.664 0 013.576 2.868A3.68 3.68 0 0121 14.85l.02.087A3.815 3.815 0 0120 18.5v.043l-.01.227a2.82 2.82 0 01-.135.663l-.106.282A3.754 3.754 0 0116.295 22h-3.606l-.392-.007a12.002 12.002 0 01-5.223-1.388l-.343-.189-.27-.154a2.005 2.005 0 00-.863-.26l-.13-.004H3.5a1.5 1.5 0 01-1.5-1.5V12.5A1.5 1.5 0 013.5 11h1.79l.157-.013a1 1 0 00.724-.512l.063-.145 2.987-8.535Zm-1.1 9.196A3 3 0 015.29 13H4v4.998h1.468a4 4 0 011.986.528l.27.155.285.157A10 10 0 0012.69 20h3.606c.754 0 1.424-.483 1.663-1.2l.03-.126a.819.819 0 00.012-.131v-.872l.587-.586c.388-.388.577-.927.523-1.465l-.038-.23-.02-.087-.21-.9.55-.744A1.663 1.663 0 0018.061 11H14a2.002 2.002 0 01-1.956-2.418l.623-2.904a2 2 0 00-1.626-2.392l-.21-.035-2.71 7.741Z"></path></svg>`,
-  upvoted: `<svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20" fill="currentColor"><path d="M10.72 2.18a3.263 3.263 0 012.352 4.063l-.708 2.476a1 1 0 00.962 1.275h5.29c.848 0 1.624.48 2.003 1.238l.179.359a1.785 1.785 0 01-.6 2.279.446.446 0 00-.198.37v.07c0 .124.041.246.116.346a2.375 2.375 0 01-.41 3.278l-.5.399a.38.38 0 00-.123.416l.07.206c.217.653.1 1.372-.313 1.923a2.8 2.8 0 01-2.24 1.12l-3.914-.002a12 12 0 01-5.952-1.584l-.272-.155a2.002 2.002 0 00-.993-.265H3a1 1 0 01-1-1v-5.996a1 1 0 011.002-1L5.789 12a1 1 0 00.945-.67l3.02-8.628a.816.816 0 01.967-.523Z"></path></svg>`,
-  downvote: `<svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20" fill="currentColor"><path d="m11.31 2 .392.007c1.824.06 3.61.534 5.223 1.388l.343.189.27.154c.264.152.56.24.863.26l.13.004H20.5a1.5 1.5 0 011.5 1.5V11.5a1.5 1.5 0 01-1.5 1.5h-1.79l-.158.013a1 1 0 00-.723.512l-.064.145-2.987 8.535a1 1 0 01-1.109.656l-1.04-.174a4 4 0 01-3.251-4.783L10 15H5.938a3.664 3.664 0 01-3.576-2.868A3.682 3.682 0 013 9.15l-.02-.088A3.816 3.816 0 014 5.5v-.043l.008-.227a2.86 2.86 0 01.136-.664l.107-.28A3.754 3.754 0 017.705 2h3.605ZM7.705 4c-.755 0-1.425.483-1.663 1.2l-.032.126a.818.818 0 00-.01.131v.872l-.587.586a1.816 1.816 0 00-.524 1.465l.038.23.02.087.21.9-.55.744a1.686 1.686 0 00-.321 1.18l.029.177c.17.76.844 1.302 1.623 1.302H10a2.002 2.002 0 011.956 2.419l-.623 2.904-.034.208a2.002 2.002 0 001.454 2.139l.206.045.21.035 2.708-7.741A3.001 3.001 0 0118.71 11H20V6.002h-1.47c-.696 0-1.38-.183-1.985-.528l-.27-.155-.285-.157A10.002 10.002 0 0011.31 4H7.705Z"></path></svg>`,
-  downvoted: `<svg xmlns="http://www.w3.org/2000/svg" height="20" viewBox="0 0 24 24" width="20" fill="currentColor"><path d="M11.313 2.002c2.088 0 4.14.546 5.953 1.583l.273.156a2 2 0 00.993.264H21a1 1 0 011 1V11a1 1 0 01-1.002 1l-2.787-.005a1 1 0 00-.946.67l-3.02 8.628a.815.815 0 01-.966.522 3.262 3.262 0 01-2.35-4.062l.707-2.477a1 1 0 00-.961-1.274h-5.29a2.24 2.24 0 01-2.004-1.238l-.18-.359a1.784 1.784 0 01.601-2.278.446.446 0 00.198-.37v-.07a.578.578 0 00-.116-.347 2.374 2.374 0 01.412-3.278l.498-.399a.379.379 0 00.123-.415l-.07-.207a2.1 2.1 0 01.313-1.923A2.798 2.798 0 017.4 2l3.913.002Z"></path></svg>`,
+const voteIcons = {
+  upvote: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><g fill="none"><path fill="currentColor" fill-opacity=".16" d="M7.895 7.69c-.294.3-.598.534-.895.71v12.334l8.509 1.223a4.1 4.1 0 0 0 2.82-.616a4.26 4.26 0 0 0 1.756-2.335l1.763-5.753a3.48 3.48 0 0 0-.497-3.04a3.36 3.36 0 0 0-1.183-1.023a3.3 3.3 0 0 0-1.509-.367h-3.633a9.7 9.7 0 0 0 .496-1.706a9 9 0 0 0 .164-1.706c0-.904-.352-1.772-.979-2.412C14.081 2.36 13.231 2 12.345 2s-1.736.36-2.362 1a3.45 3.45 0 0 0-.979 2.411c0 .597-.324 1.478-1.109 2.28"/><path stroke="currentColor" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M7.895 7.69c-.294.3-.598.534-.895.71v12.334l8.509 1.223a4.1 4.1 0 0 0 2.82-.616a4.26 4.26 0 0 0 1.756-2.335l1.763-5.753a3.48 3.48 0 0 0-.497-3.04a3.36 3.36 0 0 0-1.183-1.023a3.3 3.3 0 0 0-1.509-.367h-3.633a9.7 9.7 0 0 0 .496-1.706a9 9 0 0 0 .164-1.706c0-.904-.352-1.772-.979-2.412C14.081 2.36 13.231 2 12.345 2s-1.736.36-2.362 1a3.45 3.45 0 0 0-.979 2.411c0 .597-.324 1.478-1.109 2.28ZM6.2 7H2.8a.8.8 0 0 0-.8.8v13.4a.8.8 0 0 0 .8.8h3.4a.8.8 0 0 0 .8-.8V7.8a.8.8 0 0 0-.8-.8Z"/></g></svg>`,
+  downvote: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20"><g fill="none"><path fill="currentColor" fill-opacity=".16" d="M7.895 16.31A4.4 4.4 0 0 0 7 15.6V3.266l8.509-1.223a4.1 4.1 0 0 1 2.82.616a4.25 4.25 0 0 1 1.756 2.335l1.763 5.753a3.48 3.48 0 0 1-.497 3.04c-.31.43-.716.781-1.183 1.023a3.3 3.3 0 0 1-1.509.367h-3.633q.326.83.496 1.706a9 9 0 0 1 .164 1.706c0 .904-.352 1.772-.979 2.412c-.626.64-1.476.999-2.362.999s-1.736-.36-2.362-1a3.45 3.45 0 0 1-.979-2.411c0-.598-.324-1.478-1.109-2.28"/><path stroke="currentColor" stroke-linejoin="round" stroke-miterlimit="10" stroke-width="1.5" d="M7.895 16.31A4.4 4.4 0 0 0 7 15.6V3.266l8.509-1.223a4.1 4.1 0 0 1 2.82.616a4.25 4.25 0 0 1 1.756 2.335l1.763 5.753a3.48 3.48 0 0 1-.497 3.04c-.31.43-.716.781-1.183 1.023a3.3 3.3 0 0 1-1.509.367h-3.633q.326.83.496 1.706a9 9 0 0 1 .164 1.706c0 .904-.352 1.772-.979 2.412c-.626.64-1.476.999-2.362.999s-1.736-.36-2.362-1a3.45 3.45 0 0 1-.979-2.411c0-.598-.324-1.478-1.109-2.28ZM6.2 17H2.8a.8.8 0 0 1-.8-.8V2.8a.8.8 0 0 1 .8-.8h3.4a.8.8 0 0 1 .8.8v13.4a.8.8 0 0 1-.8.8Z"/></g></svg>`,
+  report: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="20" height="20"><g fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="4"><path fill="currentColor" fill-opacity=".16" d="M36 35H12V21c0-6.627 5.373-12 12-12s12 5.373 12 12z"/><path stroke-linecap="round" d="M8 42h32M4 13l3 1m6-10l1 3m-4 3L7 7"/></g></svg>`,
 };
+
+const VOTE_ACTIVE_CLASS = `${FOOTER_CLASS}__vote--active`;
 
 const syncTypeIcons: Record<SyncType, string> = {
   syllable: `<svg width="14" height="14" viewBox="0 0 1024 1024" fill="currentColor" xmlns="http://www.w3.org/2000/svg"><rect x="636" y="239" width="389.981" height="233.271" rx="48" fill-opacity="0.5"/><path d="M0 335C0 289.745 0 267.118 14.0589 253.059C28.1177 239 50.7452 239 96 239H213C243.17 239 258.255 239 267.627 248.373C277 257.745 277 272.83 277 303V408C277 438.17 277 453.255 267.627 462.627C258.255 472 243.17 472 213 472H96C50.7452 472 28.1177 472 14.0589 457.941C0 443.882 0 421.255 0 376V335Z"/><path d="M337 304C337 273.83 337 258.745 346.373 249.373C355.745 240 370.83 240 401 240H460C505.255 240 527.882 240 541.941 254.059C556 268.118 556 290.745 556 336V377C556 422.255 556 444.882 541.941 458.941C527.882 473 505.255 473 460 473H401C370.83 473 355.745 473 346.373 463.627C337 454.255 337 439.17 337 409V304Z" fill-opacity="0.5"/><rect y="552.271" width="1024" height="233" rx="48" fill-opacity="0.5"/></svg>`,
@@ -72,9 +73,8 @@ function parseSvgString(svgString: string): SVGElement | null {
   return null;
 }
 
-function setVoteIcon(button: HTMLElement, svgString: string): void {
+function appendIconTo(button: HTMLElement, svgString: string): void {
   const svg = parseSvgString(svgString);
-  button.replaceChildren();
   if (svg) button.appendChild(svg);
 }
 
@@ -264,10 +264,10 @@ let unisonDockObserver: IntersectionObserver | null = null;
 
 function refreshUnisonControls(unisonData: UnisonData): void {
   for (const btn of unisonControlsRegistry.upvotes) {
-    setVoteIcon(btn, unisonData.vote === 1 ? votedIcons.upvoted : votedIcons.upvote);
+    btn.classList.toggle(VOTE_ACTIVE_CLASS, unisonData.vote === 1);
   }
   for (const btn of unisonControlsRegistry.downvotes) {
-    setVoteIcon(btn, unisonData.vote === -1 ? votedIcons.downvoted : votedIcons.downvote);
+    btn.classList.toggle(VOTE_ACTIVE_CLASS, unisonData.vote === -1);
   }
   for (const refs of unisonControlsRegistry.scoreLineRefs) {
     setScoreLine(refs, unisonData.effectiveScore, unisonData.votes);
@@ -298,9 +298,8 @@ function buildUnisonVoteButton(unisonData: UnisonData, voteValue: 1 | -1): HTMLB
   const btn = document.createElement("button");
   btn.className = `${FOOTER_CLASS}__vote`;
 
-  const activeIcon = voteValue === 1 ? votedIcons.upvoted : votedIcons.downvoted;
-  const inactiveIcon = voteValue === 1 ? votedIcons.upvote : votedIcons.downvote;
-  setVoteIcon(btn, unisonData.vote === voteValue ? activeIcon : inactiveIcon);
+  appendIconTo(btn, voteValue === 1 ? voteIcons.upvote : voteIcons.downvote);
+  if (unisonData.vote === voteValue) btn.classList.add(VOTE_ACTIVE_CLASS);
 
   const registry = voteValue === 1 ? unisonControlsRegistry.upvotes : unisonControlsRegistry.downvotes;
   registry.push(btn);
@@ -491,20 +490,7 @@ function createReportButton(lyricsId: number): HTMLButtonElement {
     showReportModal(lyricsId);
   });
 
-  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("viewBox", "0 0 18 18");
-  svg.setAttribute("fill", "currentColor");
-  svg.setAttribute("width", "20");
-  svg.setAttribute("height", "20");
-
-  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  path.setAttribute(
-    "d",
-    "m3 2.25-.11.055c-.392.196-.64.597-.64 1.036v12.41a.75.75 0 101.5 0v-4.87a5.451 5.451 0 014.687.087L9 11.25l.357.166A6.701 6.701 0 0015 11.25l.11-.055c.343-.171.575-.5.628-.873l.012-.163V3.344a.908.908 0 00-1.313-.812 5.45 5.45 0 01-4.874 0L9 2.25a6.7 6.7 0 00-6 0Zm5.33 1.342.564.282a6.95 6.95 0 005.356.356v5.715a5.2 5.2 0 01-4.58-.037l-.564-.282A6.95 6.95 0 003.75 9.27V3.555a5.2 5.2 0 014.58.037Z"
-  );
-
-  svg.appendChild(path);
-  button.appendChild(svg);
+  appendIconTo(button, voteIcons.report);
   return button;
 }
 

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -21,6 +21,7 @@ import {
   type SyncType,
   TAB_RENDERER_SELECTOR,
   TRANSLATED_LYRICS_CLASS,
+  UNISON_DOCK_CLASS,
 } from "@constants";
 import { AppState } from "@core/appState";
 import { t } from "@core/i18n";
@@ -242,8 +243,100 @@ export function addFooter(
   }
 
   if (source === "Unison" && unisonData) {
+    AppState.currentUnisonData = unisonData;
     footer.appendChild(createUnisonFooterCard(unisonData));
+    if (AppState.isUnisonPinnedDockEnabled) {
+      mountUnisonDock(unisonData, AppState.unisonPinnedDockPosition);
+    }
+  } else {
+    AppState.currentUnisonData = null;
+    unmountUnisonDock();
   }
+}
+
+const unisonControlsRegistry = {
+  upvotes: [] as HTMLButtonElement[],
+  downvotes: [] as HTMLButtonElement[],
+  scoreLineRefs: [] as ScoreLineRefs[],
+};
+
+let unisonDockObserver: IntersectionObserver | null = null;
+
+function refreshUnisonControls(unisonData: UnisonData): void {
+  for (const btn of unisonControlsRegistry.upvotes) {
+    setVoteIcon(btn, unisonData.vote === 1 ? votedIcons.upvoted : votedIcons.upvote);
+  }
+  for (const btn of unisonControlsRegistry.downvotes) {
+    setVoteIcon(btn, unisonData.vote === -1 ? votedIcons.downvoted : votedIcons.downvote);
+  }
+  for (const refs of unisonControlsRegistry.scoreLineRefs) {
+    setScoreLine(refs, unisonData.effectiveScore, unisonData.votes);
+  }
+}
+
+function clearUnisonControlsRegistry(): void {
+  unisonControlsRegistry.upvotes.length = 0;
+  unisonControlsRegistry.downvotes.length = 0;
+  unisonControlsRegistry.scoreLineRefs.length = 0;
+}
+
+type VoteUpdateData = NonNullable<Awaited<ReturnType<typeof byId>>>;
+
+function applyServerVoteData(unisonData: UnisonData, data: VoteUpdateData): void {
+  unisonData.effectiveScore = data.effectiveScore;
+  unisonData.votes = data.voteCount;
+  unisonData.vote = data.userVote;
+  refreshUnisonControls(unisonData);
+}
+
+function setOptimisticVote(unisonData: UnisonData, value: 1 | -1 | null): void {
+  unisonData.vote = value;
+  refreshUnisonControls(unisonData);
+}
+
+function buildUnisonVoteButton(unisonData: UnisonData, voteValue: 1 | -1): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.className = `${FOOTER_CLASS}__vote`;
+
+  const activeIcon = voteValue === 1 ? votedIcons.upvoted : votedIcons.downvoted;
+  const inactiveIcon = voteValue === 1 ? votedIcons.upvote : votedIcons.downvote;
+  setVoteIcon(btn, unisonData.vote === voteValue ? activeIcon : inactiveIcon);
+
+  const registry = voteValue === 1 ? unisonControlsRegistry.upvotes : unisonControlsRegistry.downvotes;
+  registry.push(btn);
+
+  btn.addEventListener("click", async e => {
+    e.stopPropagation();
+    const wasActive = unisonData.vote === voteValue;
+
+    if (wasActive) {
+      setOptimisticVote(unisonData, null);
+      const res = await deleteVote(unisonData.lyricsId);
+      if (!res.ok && res.status !== 404) {
+        setOptimisticVote(unisonData, voteValue);
+        return;
+      }
+      const data = await byId(unisonData.lyricsId);
+      if (data) applyServerVoteData(unisonData, data);
+      return;
+    }
+
+    const prevVote = unisonData.vote;
+    setOptimisticVote(unisonData, voteValue);
+    const res = await vote(unisonData.lyricsId, voteValue === 1);
+    if (!res.ok && res.status !== 409) {
+      setOptimisticVote(unisonData, prevVote);
+      return;
+    }
+    const data = await byId(unisonData.lyricsId);
+    if (!data) {
+      setOptimisticVote(unisonData, prevVote);
+      return;
+    }
+    applyServerVoteData(unisonData, data);
+  });
+
+  return btn;
 }
 
 function createUnisonFooterCard(unisonData: UnisonData): HTMLElement {
@@ -266,94 +359,12 @@ function createUnisonFooterCard(unisonData: UnisonData): HTMLElement {
   const actionRow = document.createElement("div");
   actionRow.className = `${FOOTER_CLASS}__unison-actions`;
 
-  const unisonUpvote = document.createElement("button");
-  unisonUpvote.className = `${FOOTER_CLASS}__vote`;
-  setVoteIcon(unisonUpvote, unisonData.vote === 1 ? votedIcons.upvoted : votedIcons.upvote);
-
-  const unisonDownvote = document.createElement("button");
-  unisonDownvote.className = `${FOOTER_CLASS}__vote`;
-  setVoteIcon(unisonDownvote, unisonData.vote === -1 ? votedIcons.downvoted : votedIcons.downvote);
+  const unisonUpvote = buildUnisonVoteButton(unisonData, 1);
+  const unisonDownvote = buildUnisonVoteButton(unisonData, -1);
 
   const { scoreLine, scoreLineRefs } = createScoreLine();
+  unisonControlsRegistry.scoreLineRefs.push(scoreLineRefs);
   setScoreLine(scoreLineRefs, unisonData.effectiveScore, unisonData.votes);
-
-  unisonUpvote.addEventListener("click", async e => {
-    e.stopPropagation();
-    if (unisonData.vote === 1) {
-      setVoteIcon(unisonUpvote, votedIcons.upvote);
-      const res = await deleteVote(unisonData.lyricsId);
-      if (!res.ok && res.status !== 404) {
-        setVoteIcon(unisonUpvote, votedIcons.upvoted);
-        return;
-      }
-
-      let data = await byId(unisonData.lyricsId);
-      if (data) {
-        unisonData.effectiveScore = data.effectiveScore;
-        unisonData.votes = data.voteCount;
-        unisonData.vote = data.userVote;
-        setScoreLine(scoreLineRefs, data.effectiveScore, data.voteCount);
-      }
-    } else {
-      setVoteIcon(unisonUpvote, votedIcons.upvoted);
-      const res = await vote(unisonData.lyricsId, true);
-      if (!res.ok && res.status !== 409) {
-        setVoteIcon(unisonUpvote, votedIcons.upvote);
-        return;
-      }
-      setVoteIcon(unisonDownvote, votedIcons.downvote);
-
-      let data = await byId(unisonData.lyricsId);
-      if (!data) {
-        setVoteIcon(unisonUpvote, votedIcons.upvote);
-        return;
-      }
-
-      unisonData.effectiveScore = data.effectiveScore;
-      unisonData.votes = data.voteCount;
-      unisonData.vote = data.userVote;
-      setScoreLine(scoreLineRefs, data.effectiveScore, data.voteCount);
-    }
-  });
-
-  unisonDownvote.addEventListener("click", async e => {
-    e.stopPropagation();
-    if (unisonData.vote === -1) {
-      setVoteIcon(unisonDownvote, votedIcons.downvote);
-      const res = await deleteVote(unisonData.lyricsId);
-      if (!res.ok && res.status !== 404) {
-        setVoteIcon(unisonDownvote, votedIcons.downvoted);
-        return;
-      }
-
-      let data = await byId(unisonData.lyricsId);
-      if (data) {
-        unisonData.effectiveScore = data.effectiveScore;
-        unisonData.votes = data.voteCount;
-        unisonData.vote = data.userVote;
-        setScoreLine(scoreLineRefs, data.effectiveScore, data.voteCount);
-      }
-    } else {
-      setVoteIcon(unisonDownvote, votedIcons.downvoted);
-      const res = await vote(unisonData.lyricsId, false);
-      if (!res.ok && res.status !== 409) {
-        setVoteIcon(unisonDownvote, votedIcons.downvote);
-        return;
-      }
-      setVoteIcon(unisonUpvote, votedIcons.upvote);
-
-      let data = await byId(unisonData.lyricsId);
-      if (!data) {
-        setVoteIcon(unisonDownvote, votedIcons.downvote);
-        return;
-      }
-
-      unisonData.effectiveScore = data.effectiveScore;
-      unisonData.votes = data.voteCount;
-      unisonData.vote = data.userVote;
-      setScoreLine(scoreLineRefs, data.effectiveScore, data.voteCount);
-    }
-  });
 
   const unisonReport = createReportButton(unisonData.lyricsId);
 
@@ -375,6 +386,55 @@ function createUnisonFooterCard(unisonData: UnisonData): HTMLElement {
   });
 
   return unisonContainer;
+}
+
+export function mountUnisonDock(unisonData: UnisonData, position: string): void {
+  if (document.getElementsByClassName(UNISON_DOCK_CLASS).length > 0) {
+    return;
+  }
+  const sidePanel = document.querySelector("#side-panel");
+  if (!sidePanel) return;
+
+  const dock = document.createElement("div");
+  dock.className = UNISON_DOCK_CLASS;
+  dock.dataset.position = position;
+
+  const inner = document.createElement("div");
+  inner.className = `${UNISON_DOCK_CLASS}__inner`;
+
+  inner.appendChild(buildUnisonVoteButton(unisonData, 1));
+  inner.appendChild(buildUnisonVoteButton(unisonData, -1));
+  inner.appendChild(createReportButton(unisonData.lyricsId));
+
+  dock.appendChild(inner);
+  sidePanel.appendChild(dock);
+
+  const card = document.querySelector<HTMLElement>(`.${FOOTER_CLASS}__unison-card`);
+  if (card) {
+    unisonDockObserver = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          dock.classList.toggle(`${UNISON_DOCK_CLASS}--hidden`, entry.isIntersecting);
+        }
+      },
+      { threshold: 0.4 }
+    );
+    unisonDockObserver.observe(card);
+  }
+}
+
+export function unmountUnisonDock(): void {
+  if (unisonDockObserver) {
+    unisonDockObserver.disconnect();
+    unisonDockObserver = null;
+  }
+  const dock = document.getElementsByClassName(UNISON_DOCK_CLASS)[0];
+  if (dock) dock.remove();
+}
+
+export function updateUnisonDockPosition(position: string): void {
+  const dock = document.getElementsByClassName(UNISON_DOCK_CLASS)[0] as HTMLElement | undefined;
+  if (dock) dock.dataset.position = position;
 }
 
 function createSubmitterBlock(submitter: NonNullable<UnisonData["submitter"]>): HTMLElement {
@@ -988,6 +1048,10 @@ export function cleanup(): void {
   if (blyricsFooter) {
     blyricsFooter.remove();
   }
+
+  unmountUnisonDock();
+  clearUnisonControlsRegistry();
+  AppState.currentUnisonData = null;
 
   getResumeScrollElement().setAttribute("autoscroll-hidden", "true");
 

--- a/src/modules/ui/reportLyrics.ts
+++ b/src/modules/ui/reportLyrics.ts
@@ -3,6 +3,31 @@ import { t } from "@/core/i18n";
 import { report, UnisonReportReason } from "../lyrics/providers/unison";
 
 let selected: string | null = null;
+let isClosing = false;
+let escapeHandler: ((e: KeyboardEvent) => void) | null = null;
+
+const ANIM_DURATION = 200;
+const ANIM_EASING = "cubic-bezier(0.22, 1, 0.36, 1)";
+
+const OVERLAY_KEYFRAMES: Keyframe[] = [{ opacity: 0 }, { opacity: 1 }];
+const MODAL_KEYFRAMES: Keyframe[] = [
+  { opacity: 0, transform: "scale(0.95) translateY(16px)" },
+  { opacity: 1, transform: "scale(1) translateY(0)" },
+];
+
+function animateModal(overlay: HTMLElement, modal: HTMLElement | null, direction: PlaybackDirection) {
+  const opts: KeyframeAnimationOptions = {
+    duration: ANIM_DURATION,
+    easing: ANIM_EASING,
+    fill: direction === "reverse" ? "forwards" : "backwards",
+    direction,
+  };
+  const pending: Promise<unknown>[] = [overlay.animate(OVERLAY_KEYFRAMES, opts).finished];
+  if (modal) {
+    pending.push(modal.animate(MODAL_KEYFRAMES, opts).finished);
+  }
+  return Promise.all(pending);
+}
 
 function addRadioCheckbox(modal: HTMLElement, id: string, text: string) {
   if (!modal) {
@@ -144,13 +169,40 @@ export function showReportModal(lyricsId: number) {
   modal.appendChild(footer);
   overlay.appendChild(modal);
   app.appendChild(overlay);
+
+  escapeHandler = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.stopPropagation();
+      e.preventDefault();
+      closeReportModal();
+    }
+  };
+  document.addEventListener("keydown", escapeHandler, { capture: true });
+
+  animateModal(overlay, modal, "normal");
 }
 
-function closeReportModal() {
-  selected = null;
-  const overlay = document.getElementsByClassName(MODAL_OVERLAY_CLASS)[0];
+async function closeReportModal() {
+  if (isClosing) {
+    return;
+  }
+  const overlay = document.getElementsByClassName(MODAL_OVERLAY_CLASS)[0] as HTMLElement | undefined;
   if (!overlay) {
     return;
   }
+
+  isClosing = true;
+  selected = null;
+  overlay.style.pointerEvents = "none";
+
+  if (escapeHandler) {
+    document.removeEventListener("keydown", escapeHandler, { capture: true });
+    escapeHandler = null;
+  }
+
+  const modal = overlay.querySelector(`.${MODAL_CLASS}`) as HTMLElement | null;
+  await animateModal(overlay, modal, "reverse");
+
   overlay.remove();
+  isClosing = false;
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1827,6 +1827,129 @@ input.cm-textfield:focus-visible {
 	background: rgb(220, 38, 38);
 }
 
+/* -- Unison Actions Modal --------------------------*/
+
+.unison-modal-row {
+	align-items: center;
+}
+
+.unison-modal-row__text {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 0;
+}
+
+.modal-row-hint {
+	font-size: 0.6875rem;
+	color: rgba(255, 255, 255, 0.4);
+	margin: 0;
+}
+
+.position-section {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.position-section__label {
+	font-size: 0.8125rem;
+	font-weight: 500;
+	color: rgba(255, 255, 255, 0.92);
+}
+
+.position-picker {
+	display: flex;
+	justify-content: center;
+	padding: 0.5rem 0;
+}
+
+.position-frame {
+	width: 192px;
+	height: 192px;
+	border-radius: 16px;
+	border: 1px solid rgba(255, 255, 255, 0.14);
+	padding: 4px;
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	grid-template-rows: repeat(3, 1fr);
+	gap: 4px;
+}
+
+.position-cell {
+	border-radius: 4px;
+	background: rgba(255, 255, 255, 0.04);
+	cursor: pointer;
+	display: grid;
+	place-items: center;
+	transition: background 0.15s ease;
+}
+
+.position-cell::before {
+	content: "";
+	width: 8px;
+	height: 8px;
+	border-radius: 50%;
+	background: rgba(255, 255, 255, 0.28);
+	transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.position-cell:hover {
+	background: rgba(255, 255, 255, 0.09);
+}
+
+.position-cell:hover::before {
+	background: rgba(255, 255, 255, 0.55);
+}
+
+.position-cell[data-selected="true"] {
+	background: hsla(232, 84%, 70%, 0.18);
+}
+
+.position-cell[data-selected="true"]::before {
+	background: hsl(232, 84%, 70%);
+	transform: scale(1.3);
+}
+
+.position-cell[data-pos="top-left"] {
+	grid-row: 1;
+	grid-column: 1;
+	border-top-left-radius: 12px;
+}
+
+.position-cell[data-pos="top-center"] {
+	grid-row: 1;
+	grid-column: 2;
+}
+
+.position-cell[data-pos="top-right"] {
+	grid-row: 1;
+	grid-column: 3;
+	border-top-right-radius: 12px;
+}
+
+.position-cell[data-pos="bottom-left"] {
+	grid-row: 3;
+	grid-column: 1;
+	border-bottom-left-radius: 12px;
+}
+
+.position-cell[data-pos="bottom-center"] {
+	grid-row: 3;
+	grid-column: 2;
+}
+
+.position-cell[data-pos="bottom-right"] {
+	grid-row: 3;
+	grid-column: 3;
+	border-bottom-right-radius: 12px;
+}
+
+#unison-actions-modal-body[data-pinned-disabled="true"] .unison-modal-row--dependent {
+	opacity: 0.45;
+	pointer-events: none;
+}
+
 /* -- Language Exclusions Modal (shared search + pills) --------------------------*/
 
 .lang-search-container {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -151,24 +151,13 @@
 						</label>
 					</div>
 					<div class="container">
-						<span>__MSG_options_display_pinUnisonActions__</span>
-						<label>
-							<input type="checkbox" id="isUnisonPinnedDockEnabled">
-							<span class="checkmark"></span>
-						</label>
-					</div>
-					<div class="container">
-						<span>__MSG_options_display_pinUnisonActionsPosition__</span>
-						<div class="select">
-							<select id="unisonPinnedDockPosition">
-								<option value="top-left">__MSG_options_display_pinUnisonActionsPosition_topLeft__</option>
-								<option value="top-center">__MSG_options_display_pinUnisonActionsPosition_topCenter__</option>
-								<option value="top-right">__MSG_options_display_pinUnisonActionsPosition_topRight__</option>
-								<option value="bottom-left">__MSG_options_display_pinUnisonActionsPosition_bottomLeft__</option>
-								<option value="bottom-center">__MSG_options_display_pinUnisonActionsPosition_bottomCenter__</option>
-								<option value="bottom-right">__MSG_options_display_pinUnisonActionsPosition_bottomRight__</option>
-							</select>
-						</div>
+						<span>__MSG_options_display_unisonActions__</span>
+						<button class="small-btn" id="unison-actions-btn">
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+								<path fill-rule="evenodd" d="M11.828 2.25c-.916 0-1.699.663-1.85 1.567l-.091.549a.798.798 0 0 1-.517.608 7.45 7.45 0 0 0-.478.198.798.798 0 0 1-.796-.064l-.453-.324a1.875 1.875 0 0 0-2.416.2l-.243.243a1.875 1.875 0 0 0-.2 2.416l.324.453a.798.798 0 0 1 .064.796 7.448 7.448 0 0 0-.198.478.798.798 0 0 1-.608.517l-.55.092a1.875 1.875 0 0 0-1.566 1.849v.344c0 .916.663 1.699 1.567 1.85l.549.091c.281.047.508.25.608.517.06.162.127.321.198.478a.798.798 0 0 1-.064.796l-.324.453a1.875 1.875 0 0 0 .2 2.416l.243.243c.648.648 1.67.733 2.416.2l.453-.324a.798.798 0 0 1 .796-.064c.157.071.316.137.478.198.267.1.47.327.517.608l.092.55c.15.903.932 1.566 1.849 1.566h.344c.916 0 1.699-.663 1.85-1.567l.091-.549a.798.798 0 0 1 .517-.608 7.52 7.52 0 0 0 .478-.198.798.798 0 0 1 .796.064l.453.324a1.875 1.875 0 0 0 2.416-.2l.243-.243c.648-.648.733-1.67.2-2.416l-.324-.453a.798.798 0 0 1-.064-.796c.071-.157.137-.316.198-.478.1-.267.327-.47.608-.517l.55-.091a1.875 1.875 0 0 0 1.566-1.85v-.344c0-.916-.663-1.699-1.567-1.85l-.549-.091a.798.798 0 0 1-.608-.517 7.507 7.507 0 0 0-.198-.478.798.798 0 0 1 .064-.796l.324-.453a1.875 1.875 0 0 0-.2-2.416l-.243-.243a1.875 1.875 0 0 0-2.416-.2l-.453.324a.798.798 0 0 1-.796.064 7.462 7.462 0 0 0-.478-.198.798.798 0 0 1-.517-.608l-.091-.55a1.875 1.875 0 0 0-1.85-1.566h-.344ZM12 15.75a3.75 3.75 0 1 0 0-7.5 3.75 3.75 0 0 0 0 7.5Z" clip-rule="evenodd"></path>
+							</svg>
+							<span>__MSG_options_manage__</span>
+						</button>
 					</div>
 				</div>
 			</div>
@@ -530,6 +519,55 @@
 
 				<div class="modal-footer">
 					<button id="lang-exclusions-reset-btn" class="modal-btn modal-btn-secondary">__MSG_options_resetToDefault__</button>
+				</div>
+			</div>
+		</div>
+
+		<div id="unison-actions-modal-overlay" class="modal-overlay">
+			<div class="modal unison-actions-modal">
+				<div class="modal-header">
+					<h3 class="modal-title">__MSG_options_unisonModal_title__</h3>
+					<button id="unison-actions-modal-close" class="modal-close-btn" aria-label="Close">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+							<path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"></path>
+						</svg>
+					</button>
+				</div>
+
+				<div class="modal-body" id="unison-actions-modal-body">
+					<div class="container unison-modal-row">
+						<div class="unison-modal-row__text">
+							<span>__MSG_options_unisonModal_showPinned__</span>
+							<p class="modal-row-hint">__MSG_options_unisonModal_showPinned_hint__</p>
+						</div>
+						<label>
+							<input type="checkbox" id="isUnisonPinnedDockEnabled">
+							<span class="checkmark"></span>
+						</label>
+					</div>
+					<div class="container unison-modal-row unison-modal-row--dependent">
+						<div class="unison-modal-row__text">
+							<span>__MSG_options_unisonModal_autoHide__</span>
+							<p class="modal-row-hint">__MSG_options_unisonModal_autoHide_hint__</p>
+						</div>
+						<label>
+							<input type="checkbox" id="isUnisonAutoHideInFullscreenEnabled">
+							<span class="checkmark"></span>
+						</label>
+					</div>
+					<div class="position-section unison-modal-row--dependent">
+						<span class="position-section__label">__MSG_options_unisonModal_position__</span>
+						<div class="position-picker">
+							<div class="position-frame" id="unison-position-frame">
+								<div class="position-cell" data-pos="top-left" title="__MSG_options_unisonModal_position_topLeft__"></div>
+								<div class="position-cell" data-pos="top-center" title="__MSG_options_unisonModal_position_topCenter__"></div>
+								<div class="position-cell" data-pos="top-right" title="__MSG_options_unisonModal_position_topRight__"></div>
+								<div class="position-cell" data-pos="bottom-left" title="__MSG_options_unisonModal_position_bottomLeft__"></div>
+								<div class="position-cell" data-pos="bottom-center" title="__MSG_options_unisonModal_position_bottomCenter__"></div>
+								<div class="position-cell" data-pos="bottom-right" title="__MSG_options_unisonModal_position_bottomRight__"></div>
+							</div>
+						</div>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -150,6 +150,26 @@
 							<span class="checkmark"></span>
 						</label>
 					</div>
+					<div class="container">
+						<span>__MSG_options_display_pinUnisonActions__</span>
+						<label>
+							<input type="checkbox" id="isUnisonPinnedDockEnabled">
+							<span class="checkmark"></span>
+						</label>
+					</div>
+					<div class="container">
+						<span>__MSG_options_display_pinUnisonActionsPosition__</span>
+						<div class="select">
+							<select id="unisonPinnedDockPosition">
+								<option value="top-left">__MSG_options_display_pinUnisonActionsPosition_topLeft__</option>
+								<option value="top-center">__MSG_options_display_pinUnisonActionsPosition_topCenter__</option>
+								<option value="top-right">__MSG_options_display_pinUnisonActionsPosition_topRight__</option>
+								<option value="bottom-left">__MSG_options_display_pinUnisonActionsPosition_bottomLeft__</option>
+								<option value="bottom-center">__MSG_options_display_pinUnisonActionsPosition_bottomCenter__</option>
+								<option value="bottom-right">__MSG_options_display_pinUnisonActionsPosition_bottomRight__</option>
+							</select>
+						</div>
+					</div>
 				</div>
 			</div>
 			<div class="tab-content" id="language-content">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -1,6 +1,6 @@
 // Function to save user options
 
-import { LOG_PREFIX, ROMANIZATION_LANGUAGES } from "@constants";
+import { LOG_PREFIX, ROMANIZATION_LANGUAGES, UNISON_DOCK_DEFAULT_POSITION } from "@constants";
 import { getLanguageDisplayName, initI18n, loadLocaleOverride, SUPPORTED_LOCALES, t } from "@core/i18n";
 import { exportIdentity, getIdentity, importIdentity, type KeyIdentity } from "@core/keyIdentity";
 import Sortable from "sortablejs";
@@ -24,6 +24,7 @@ interface Options {
   uiLanguage: string;
   isUnisonPinnedDockEnabled: boolean;
   unisonPinnedDockPosition: string;
+  isUnisonAutoHideInFullscreenEnabled: boolean;
 }
 
 const saveOptions = (): void => {
@@ -59,9 +60,17 @@ const getOptionsFromForm = (): Options => {
     translationDisabledLanguages: translationDisabledLanguages,
     uiLanguage: (document.getElementById("uiLanguage") as HTMLSelectElement).value,
     isUnisonPinnedDockEnabled: (document.getElementById("isUnisonPinnedDockEnabled") as HTMLInputElement).checked,
-    unisonPinnedDockPosition: (document.getElementById("unisonPinnedDockPosition") as HTMLSelectElement).value,
+    unisonPinnedDockPosition: getSelectedUnisonPosition(),
+    isUnisonAutoHideInFullscreenEnabled: (
+      document.getElementById("isUnisonAutoHideInFullscreenEnabled") as HTMLInputElement
+    ).checked,
   };
 };
+
+function getSelectedUnisonPosition(): string {
+  const selected = document.querySelector<HTMLElement>("#unison-position-frame .position-cell[data-selected='true']");
+  return selected?.dataset.pos ?? UNISON_DOCK_DEFAULT_POSITION;
+}
 
 // Function to save options to Chrome storage
 const saveOptionsToStorage = (options: Options): void => {
@@ -215,13 +224,15 @@ const restoreOptions = (): void => {
     romanizationDisabledLanguages: [],
     translationDisabledLanguages: [],
     uiLanguage: "auto",
-    isUnisonPinnedDockEnabled: false,
-    unisonPinnedDockPosition: "bottom-right",
+    isUnisonPinnedDockEnabled: true,
+    unisonPinnedDockPosition: UNISON_DOCK_DEFAULT_POSITION,
+    isUnisonAutoHideInFullscreenEnabled: true,
   };
 
   chrome.storage.sync.get(defaultOptions, setOptionsInForm);
 
   document.getElementById("clear-cache")!.addEventListener("click", () => clearTransientLyrics());
+  setupUnisonActionsModal();
 };
 
 // Function to set options in form elements
@@ -239,7 +250,10 @@ const setOptionsInForm = (items: Options): void => {
   (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked = items.isRomanizationEnabled;
   (document.getElementById("uiLanguage") as HTMLSelectElement).value = items.uiLanguage;
   (document.getElementById("isUnisonPinnedDockEnabled") as HTMLInputElement).checked = items.isUnisonPinnedDockEnabled;
-  (document.getElementById("unisonPinnedDockPosition") as HTMLSelectElement).value = items.unisonPinnedDockPosition;
+  (document.getElementById("isUnisonAutoHideInFullscreenEnabled") as HTMLInputElement).checked =
+    items.isUnisonAutoHideInFullscreenEnabled;
+  setUnisonPositionInForm(items.unisonPinnedDockPosition);
+  syncUnisonModalDependentState(items.isUnisonPinnedDockEnabled);
   romanizationDisabledLanguages = items.romanizationDisabledLanguages || [];
   translationDisabledLanguages = items.translationDisabledLanguages || [];
   updateExclusionsConfigVisibility();
@@ -907,4 +921,60 @@ function filterLanguagePills(containerId: string, query: string): void {
     const matches = langName.includes(normalizedQuery) || langCode.includes(normalizedQuery);
     pill.classList.toggle("lang-pill-hidden", !matches);
   });
+}
+
+function setUnisonPositionInForm(position: string): void {
+  const frame = document.getElementById("unison-position-frame");
+  if (!frame) return;
+  frame.querySelectorAll<HTMLElement>(".position-cell").forEach(cell => {
+    if (cell.dataset.pos === position) {
+      cell.dataset.selected = "true";
+    } else {
+      delete cell.dataset.selected;
+    }
+  });
+}
+
+function syncUnisonModalDependentState(enabled: boolean): void {
+  const body = document.getElementById("unison-actions-modal-body");
+  if (!body) return;
+  body.dataset.pinnedDisabled = enabled ? "false" : "true";
+}
+
+function setupUnisonActionsModal(): void {
+  const openBtn = document.getElementById("unison-actions-btn");
+  const overlay = document.getElementById("unison-actions-modal-overlay");
+  const closeBtn = document.getElementById("unison-actions-modal-close");
+  const frame = document.getElementById("unison-position-frame");
+  const pinnedToggle = document.getElementById("isUnisonPinnedDockEnabled") as HTMLInputElement | null;
+  const autoHideToggle = document.getElementById("isUnisonAutoHideInFullscreenEnabled") as HTMLInputElement | null;
+
+  if (!openBtn || !overlay || !closeBtn || !frame || !pinnedToggle || !autoHideToggle) return;
+
+  const closeModal = (): void => overlay.classList.remove("active");
+
+  openBtn.addEventListener("click", () => overlay.classList.add("active"));
+  closeBtn.addEventListener("click", closeModal);
+
+  overlay.addEventListener("click", e => {
+    if (e.target === overlay) closeModal();
+  });
+
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape" && overlay.classList.contains("active")) closeModal();
+  });
+
+  frame.addEventListener("click", e => {
+    const cell = (e.target as HTMLElement).closest<HTMLElement>(".position-cell");
+    if (!cell?.dataset.pos) return;
+    setUnisonPositionInForm(cell.dataset.pos);
+    saveOptions();
+  });
+
+  pinnedToggle.addEventListener("change", () => {
+    syncUnisonModalDependentState(pinnedToggle.checked);
+    saveOptions();
+  });
+
+  autoHideToggle.addEventListener("change", saveOptions);
 }

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -22,6 +22,8 @@ interface Options {
   romanizationDisabledLanguages: string[];
   translationDisabledLanguages: string[];
   uiLanguage: string;
+  isUnisonPinnedDockEnabled: boolean;
+  unisonPinnedDockPosition: string;
 }
 
 const saveOptions = (): void => {
@@ -56,6 +58,8 @@ const getOptionsFromForm = (): Options => {
     romanizationDisabledLanguages: romanizationDisabledLanguages,
     translationDisabledLanguages: translationDisabledLanguages,
     uiLanguage: (document.getElementById("uiLanguage") as HTMLSelectElement).value,
+    isUnisonPinnedDockEnabled: (document.getElementById("isUnisonPinnedDockEnabled") as HTMLInputElement).checked,
+    unisonPinnedDockPosition: (document.getElementById("unisonPinnedDockPosition") as HTMLSelectElement).value,
   };
 };
 
@@ -211,6 +215,8 @@ const restoreOptions = (): void => {
     romanizationDisabledLanguages: [],
     translationDisabledLanguages: [],
     uiLanguage: "auto",
+    isUnisonPinnedDockEnabled: false,
+    unisonPinnedDockPosition: "bottom-right",
   };
 
   chrome.storage.sync.get(defaultOptions, setOptionsInForm);
@@ -232,6 +238,8 @@ const setOptionsInForm = (items: Options): void => {
   (document.getElementById("translationLanguage") as HTMLInputElement).value = items.translationLanguage;
   (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked = items.isRomanizationEnabled;
   (document.getElementById("uiLanguage") as HTMLSelectElement).value = items.uiLanguage;
+  (document.getElementById("isUnisonPinnedDockEnabled") as HTMLInputElement).checked = items.isUnisonPinnedDockEnabled;
+  (document.getElementById("unisonPinnedDockPosition") as HTMLSelectElement).value = items.unisonPinnedDockPosition;
   romanizationDisabledLanguages = items.romanizationDisabledLanguages || [];
   translationDisabledLanguages = items.translationDisabledLanguages || [];
   updateExclusionsConfigVisibility();


### PR DESCRIPTION
# Overview

- Add a floating dock that pins Unison vote/report buttons inside the side panel for the duration of a Unison-sourced song
- Dock supports 6 anchor positions, auto-hides when the in-page footer card is ≥40% visible (IntersectionObserver), and auto-hides on mouse idle in fullscreen (3s timer, mirrors cursor auto-hide)
- New "Unison Actions" modal in the popup consolidates dock toggle, fullscreen auto-hide toggle, and a visual position picker; replaces two prior Display-section rows
- Vote/report icons rewritten as duotone SVGs with a single shared shape per direction; active state flips fill-opacity from 0.16 to 1 via CSS transition (no DOM swap)
- Shared `unisonControlsRegistry` keeps footer-card and dock buttons in sync via `refreshUnisonControls` for optimistic + server-confirmed vote state

