### PR TITLE
Fix trailing punctuation wrapping onto its own line in richsync lyrics

### DIFF
--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -187,6 +187,8 @@ export function processLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible
   injectLyrics(data, keepLoaderVisible, signal);
 }
 
+const TRAILING_ATTACHED_PUNCT_REGEX = /^[\p{Pe}\p{Pf}\p{Po}]+$/u;
+
 /**
  * Fallback for issue #307: split a part whose core text exceeds the wrap threshold into smaller
  * sub-parts at natural word boundaries (via Intl.Segmenter). This creates wrap opportunities for
@@ -202,6 +204,16 @@ function splitLongPart(part: LyricPart, threshold: number): LyricPart[] {
   } catch {
     segments = Array.from(part.words);
   }
+
+  // Combine punctuation with previous words
+  segments = segments.reduce((acc, curr) => {
+    if (acc.length > 0 && TRAILING_ATTACHED_PUNCT_REGEX.test(curr)) {
+      acc[acc.length - 1] += curr;
+    } else {
+      acc.push(curr);
+    }
+    return acc;
+  }, [] as string[]);
 
   const chunks: string[] = [];
   let current = "";


### PR DESCRIPTION
# Description

When splitting long lyric parts at word boundaries, trailing punctuation characters (closing brackets, final quotation marks, and other punctuation) were being placed as separate segments rather than being attached to the preceding word. This change combines any trailing punctuation segments with the previous word segment, ensuring punctuation stays visually attached to the word it belongs to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue (if applicable)

Fixes #307

## Screenshots (if applicable)

| Before | After |
| --- | --- |
| [Paste Image Here] | [Paste Image Here] |

## Checklist

- [ ] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.