### PR TITLE
Fix `lastEvent...` not resetting on song change, causing incorrect time offsets and random scrolls

### DIFF
--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -16,6 +16,7 @@ import { getLyrics, newSourceMap, providerPriority } from "./providers/shared";
 import type { YTLyricSourceResult } from "./providers/yt";
 import { getSongAlbum, getSongMetadata, type SegmentMap } from "./requestSniffer/requestSniffer";
 import { clearCache as clearTranslationCache } from "./translation";
+import { animEngineState } from "@modules/ui/animationEngine";
 
 const hideInstrumentalOnly = registerThemeSetting("blyrics-hide-instrumental-only", false, true);
 
@@ -116,6 +117,9 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
       AppState.areLyricsLoaded = false;
       AppState.areLyricsTicking = false;
       AppState.suppressZeroTime = 0;
+      animEngineState.lastEventCreationTime = -1;
+      animEngineState.lastPlayState = false;
+      animEngineState.lastTime = 0;
     }
 
     if (matchingSong) {

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -47,6 +47,9 @@ interface AnimEngineState {
   wasUserScrolling: boolean;
   lastTime: number;
   lastPlayState: boolean;
+  /**
+   * Take "-1" to mean that we have no sensible last event
+   */
   lastEventCreationTime: number;
   lastActiveElements: LineData[];
   queuedScroll: boolean;
@@ -73,7 +76,7 @@ export let animEngineState: AnimEngineState = {
   wasUserScrolling: false,
   lastTime: 0,
   lastPlayState: false,
-  lastEventCreationTime: 0,
+  lastEventCreationTime: -1,
   doneFirstInstantScroll: true,
   lastActiveElements: [],
   queuedScroll: false,
@@ -316,7 +319,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
   animEngineState.lastEventCreationTime = eventCreationTime;
 
   let timeOffset = now - eventCreationTime;
-  if (!isPlaying) {
+  if (!isPlaying || eventCreationTime === -1) {
     timeOffset = 0;
   }
 


### PR DESCRIPTION
### TL;DR

Fix a bug where stale animation engine state from a previous song could bleed into the next song's lyrics rendering.

### What changed?

The `animEngineState` fields `lastEventCreationTime`, `lastPlayState`, and `lastTime` are now reset when a new song's lyrics are created. Additionally, `lastEventCreationTime` is initialized to `-1` (instead of `0`) to signal "no valid prior event," and the time offset calculation in `animationEngine` now treats `-1` as a special sentinel value, forcing `timeOffset` to `0` in that case.

### How to test?

1. Play a song and let the lyrics load and animate.
2. Skip to a different song and observe that the lyrics animation starts cleanly without any leftover timing artifacts or incorrect offsets from the previous song.
3. Verify that pausing and resuming still behaves correctly, with no unintended time drift.

### Why make this change?

Previously, stale values in `animEngineState` persisted between songs, which could cause the animation engine to compute an incorrect `timeOffset` at the start of a new song — particularly because `lastEventCreationTime` defaulting to `0` could be mistaken for a valid prior event. Resetting this state on song change and using `-1` as an explicit "no prior event" sentinel ensures the animation engine starts fresh and accurately for each new track.