### PR TITLE
Fix qq lyric rendering

### DIFF
--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -260,10 +260,11 @@ function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTML
   const wrapThreshold = longWordWrapThreshold.getNumberValue();
 
   parts.forEach(originalPart => {
-    // Separate leading / trailing whitespace from the part's core text. Whitespace is not emitted
+    // Separate leading whitespace from the part's core text. Whitespace is not emitted
     // as DOM content; it becomes a class on the preceding span so CSS can re-add spacing in a way
     // that disappears cleanly at line / row ends.
-    const match = originalPart.words.match(/^(\s*)([\s\S]*?)(\s*)$/u);
+    // Trailing whitespace isn't removed at this stage and is used to insert the appropriate classes later
+    const match = originalPart.words.match(/^(\s*)([\s\S]*?)$/u);
     const leadingWs = match?.[1] ?? "";
     const core = match?.[2] ?? originalPart.words;
     if (core.length === 0) {


### PR DESCRIPTION
# Description

Trailing whitespace is no longer stripped from lyric parts during the initial regex match in `createLyricsLine`. Previously, both leading and trailing whitespace were removed at this stage, but trailing whitespace is now preserved so it can be used downstream to apply the appropriate CSS classes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issue (if applicable)

Fixes # (issue)

## Checklist

- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.