### PR TITLE
fix(options): exempt provider checkbox from drag and press scale

### DIFF
--- a/src/options/options.css
+++ b/src/options/options.css
@@ -893,7 +893,7 @@ hr {
     user-select: none;
 }
 
-.sortable-item:active {
+.sortable-item:active:not(:has(.checkbox-container:active)) {
     cursor: grabbing;
     transform: scale(0.98);
     background: rgba(255, 255, 255, 0.08);

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -548,6 +548,8 @@ document.addEventListener("DOMContentLoaded", () => {
     animation: 150,
     ghostClass: "dragging",
     forceFallback: true,
+    filter: ".checkbox-container",
+    preventOnFilter: false,
     onUpdate: saveOptions,
   });
 


### PR DESCRIPTION
## Overview

- Clicking a provider toggle in the Source panel was triggering SortableJS drag and a row scale-down instead of toggling the checkbox.