### PR TITLE
fix(ttml): handle TTML without head element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,13 @@
                 "@codemirror/view": "^6.41.1",
                 "@formkit/auto-animate": "^0.9.0",
                 "@fsegurai/codemirror-theme-material-dark": "^6.2.5",
-                "codemirror-lang-rics": "^0.3.20",
+                "codemirror-lang-rics": "^0.3.21",
                 "dompurify": "^3.4.0",
                 "extension": "2.1.3",
                 "fast-xml-parser": "^5.7.3",
                 "fflate": "^0.8.2",
                 "marked": "^18.0.2",
-                "rics": "^0.3.20",
+                "rics": "^0.3.21",
                 "sortablejs": "^1.15.7"
             },
             "devDependencies": {
@@ -5021,12 +5021,12 @@
             }
         },
         "node_modules/codemirror-lang-rics": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/codemirror-lang-rics/-/codemirror-lang-rics-0.3.20.tgz",
-            "integrity": "sha512-vXyqiuTioXp2WdTWJgklGsyIBxzk8EcOB+IBVarOBSs5s+nhVQcCWPem41sZYcr8d604Z4OwNYKfHyXnYSbc7A==",
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/codemirror-lang-rics/-/codemirror-lang-rics-0.3.21.tgz",
+            "integrity": "sha512-oftS9y6mzWSSX01k70Ni0B5ykBvNzyK9d6oKaf88QdJp+bgYKth4fSULP99VoDvTu+mSmbiTeWLqAGMvDPW7IQ==",
             "license": "MIT",
             "dependencies": {
-                "rics": "0.3.20"
+                "rics": "0.3.21"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -9172,9 +9172,9 @@
             }
         },
         "node_modules/rics": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/rics/-/rics-0.3.20.tgz",
-            "integrity": "sha512-dr9u/Hb/M+gHfDk+CZ6lDU2XjJ63qNe3Px2DwZrMtBLJXg/xq7FxlX8cT/IbIai15H/Qbqh+fHgBlQawIrnA7A==",
+            "version": "0.3.21",
+            "resolved": "https://registry.npmjs.org/rics/-/rics-0.3.21.tgz",
+            "integrity": "sha512-u9mbIsUhzJ2Smhw3IqrjP6K6M3mv9izrT+a43w1+n5Q8Sdj8LI1M7u66/yuk4EeQlGj29L7KAVbcV8CgxbCa8w==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -45,13 +45,13 @@
         "@codemirror/view": "^6.41.1",
         "@formkit/auto-animate": "^0.9.0",
         "@fsegurai/codemirror-theme-material-dark": "^6.2.5",
-        "codemirror-lang-rics": "^0.3.20",
+        "codemirror-lang-rics": "^0.3.21",
         "dompurify": "^3.4.0",
         "extension": "2.1.3",
         "fast-xml-parser": "^5.7.3",
         "fflate": "^0.8.2",
         "marked": "^18.0.2",
-        "rics": "^0.3.20",
+        "rics": "^0.3.21",
         "sortablejs": "^1.15.7"
     },
     "devDependencies": {

--- a/src/modules/lyrics/providers/ttmlUtils.ts
+++ b/src/modules/lyrics/providers/ttmlUtils.ts
@@ -264,12 +264,12 @@ export async function fillTtml(
 
   const ttContainer = rawObj.find(e => "tt" in e)!;
   const tt = ttContainer.tt;
-  const ttHead = tt.find(e => e.head)!.head!;
+  const ttHead = tt.find(e => e.head)?.head;
   const ttBodyContainer = tt.find(e => e.body)!;
   const ttBody = ttBodyContainer.body!;
   const ttMeta = ttBodyContainer[":@"];
 
-  const metadataElements = ttHead.find(e => "metadata" in e)?.metadata ?? [];
+  const metadataElements = ttHead?.find(e => "metadata" in e)?.metadata ?? [];
 
   const agentMapping = extractAgentMapping(metadataElements);
 

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -265,6 +265,23 @@ const unisonControlsRegistry = {
 
 let unisonDockObserver: IntersectionObserver | null = null;
 
+type DockSuppressionReason = "cardVisible" | "ad" | "loading";
+const dockSuppressionReasons = new Set<DockSuppressionReason>();
+
+function applyDockSuppression(): void {
+  const dock = document.getElementsByClassName(UNISON_DOCK_CLASS)[0] as HTMLElement | undefined;
+  if (!dock) return;
+  dock.classList.toggle(`${UNISON_DOCK_CLASS}--hidden`, dockSuppressionReasons.size > 0);
+}
+
+function setUnisonDockSuppression(reason: DockSuppressionReason, suppressed: boolean): void {
+  const had = dockSuppressionReasons.has(reason);
+  if (suppressed === had) return;
+  if (suppressed) dockSuppressionReasons.add(reason);
+  else dockSuppressionReasons.delete(reason);
+  applyDockSuppression();
+}
+
 function refreshUnisonControls(unisonData: UnisonData): void {
   for (const btn of unisonControlsRegistry.upvotes) {
     btn.classList.toggle(VOTE_ACTIVE_CLASS, unisonData.vote === 1);
@@ -410,13 +427,14 @@ export function mountUnisonDock(unisonData: UnisonData, position: string): void 
 
   dock.appendChild(inner);
   sidePanel.appendChild(dock);
+  applyDockSuppression();
 
   const card = document.querySelector<HTMLElement>(`.${FOOTER_CLASS}__unison-card`);
   if (card) {
     unisonDockObserver = new IntersectionObserver(
       entries => {
         for (const entry of entries) {
-          dock.classList.toggle(`${UNISON_DOCK_CLASS}--hidden`, entry.isIntersecting);
+          setUnisonDockSuppression("cardVisible", entry.isIntersecting);
         }
       },
       { threshold: 0.4 }
@@ -430,6 +448,7 @@ export function unmountUnisonDock(): void {
     unisonDockObserver.disconnect();
     unisonDockObserver = null;
   }
+  dockSuppressionReasons.delete("cardVisible");
   const dock = document.getElementsByClassName(UNISON_DOCK_CLASS)[0];
   if (dock) dock.remove();
 }
@@ -605,6 +624,7 @@ function setLoaderState(state: LoaderState, text?: string): void {
   if (text !== undefined) {
     loader.style.setProperty("--blyrics-loader-text", `"${text}"`);
   }
+  setUnisonDockSuppression("loading", state !== "hidden");
 }
 
 /**
@@ -776,6 +796,7 @@ export function showAdOverlay(): void {
   }
 
   adOverlay.setAttribute("active", "");
+  setUnisonDockSuppression("ad", true);
 }
 
 /**
@@ -786,6 +807,7 @@ export function hideAdOverlay(): void {
   if (adOverlay) {
     adOverlay.removeAttribute("active");
   }
+  setUnisonDockSuppression("ad", false);
 }
 
 /**


### PR DESCRIPTION
## Overview

- Made `ttHead` lookup optional cuz `fillTtml` crashes when parsing stuff that omits `<>`
- Hide Unison Dock on ad breaks/loading screens/card visible states