### PR TITLE
Fix black bars in video mode by syncing aspect ratio CSS variable to intrinsic video dimensions

### DIFF
--- a/public/css/ytmusic/fullscreen.css
+++ b/public/css/ytmusic/fullscreen.css
@@ -69,6 +69,42 @@ ytmusic-player-page:not([is-mweb-modernization-enabled])[player-fullscreened]:no
   margin: 0 auto;
 }
 
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #movie_player,
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #song-media-window,
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #player.ytmusic-player-page {
+  aspect-ratio: var(--blyrics-video-aspect-ratio);
+  height: auto;
+  min-height: 0;
+}
+
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #player.ytmusic-player-page {
+  background-color: transparent;
+}
+
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #av-id {
+  padding-bottom: 10px;
+}
+
+/* Cap #player width so width / aspect-ratio (its derived height) fits in the
+   available vertical space. Without this, tall videos like 4:3 overflow on
+   wide screens — the bottom is hidden by the player bar in non-fullscreen, or
+   pushes the song-info off-screen in fullscreen. */
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode]:not([player-fullscreened]) #player.ytmusic-player-page {
+  width: min(
+    100%,
+    calc((100vh - 80px - var(--ytmusic-player-page-vertical-padding) - var(--ytmusic-nav-bar-height) - var(--ytmusic-player-bar-height)) * (var(--blyrics-video-aspect-ratio)))
+  );
+  max-width: 100%;
+}
+
+ytmusic-player-page[player-fullscreened]:not([blyrics-dfs])[blyrics-video-mode] #player.ytmusic-player-page {
+  width: min(
+    100%,
+    calc((100vh - 18rem) * var(--blyrics-video-aspect-ratio))
+  );
+  max-width: 100%;
+}
+
 /* Center Player When No Lyrics */
 ytmusic-player-page[player-fullscreened]:not([blyrics-video-mode]):not([blyrics-dfs]):has(.blyrics-container[data-no-lyrics="true"]) #main-panel {
   position: relative;

--- a/public/css/ytmusic/general.css
+++ b/public/css/ytmusic/general.css
@@ -131,8 +131,8 @@ ytmusic-player-page:not([is-mweb-modernization-enabled]):not([player-ui-state=MI
 /* Keep album art small */
 ytmusic-player-page:not([is-mweb-modernization-enabled]):not([blyrics-video-mode]):not([player-ui-state=MINIPLAYER]) #player.ytmusic-player-page {
   width: 100%;
-  margin-left: auto;
-  margin-right: auto;
+  margin-left: auto !important;
+  margin-right: auto !important;
 }
 
 ytmusic-player-page:not([is-mweb-modernization-enabled]):not([blyrics-video-mode]):not([video-mode])

--- a/public/css/ytmusic/variables.css
+++ b/public/css/ytmusic/variables.css
@@ -5,4 +5,5 @@
   --blyrics-fullscreen-video-panel-size: 25%;
   --blyrics-no-lyrics-slide-delay: 1.8s;
   --blyrics-fullscreen-bottom-dock-shift: -24px;
+  --blyrics-video-aspect-ratio: 16 / 9;
 }

--- a/public/script.js
+++ b/public/script.js
@@ -27,6 +27,46 @@ let pausedTickCounter = 0;
 let cachedContentRect = null;
 let playerResizeObserver = null;
 let lastVideoId = null;
+let observedVideoElement = null;
+
+/**
+ * Writes the video's intrinsic aspect ratio (from the <video> element's
+ * videoWidth/videoHeight) to a CSS variable so styles can resize the player
+ * to match it (eliminating black bars). Removes the variable when no real
+ * video frame is available so CSS falls back to its default.
+ * @param {HTMLVideoElement | null} video
+ */
+const updateVideoAspectRatioVar = video => {
+  if (video && video.videoWidth > 0 && video.videoHeight > 0) {
+    document.documentElement.style.setProperty(
+      "--blyrics-video-aspect-ratio",
+      `${video.videoWidth} / ${video.videoHeight}`
+    );
+  } else {
+    document.documentElement.style.removeProperty("--blyrics-video-aspect-ratio");
+  }
+};
+
+const handleVideoResize = () => updateVideoAspectRatioVar(observedVideoElement);
+
+/**
+ * Finds the <video> inside the player and (re)attaches a resize listener so
+ * we react to intrinsic-dimension changes (loadedmetadata, quality switches).
+ * @param {HTMLElement} player
+ */
+const attachVideoListener = player => {
+  const video = player && player.querySelector("video");
+  if (video !== observedVideoElement) {
+    if (observedVideoElement) {
+      observedVideoElement.removeEventListener("resize", handleVideoResize);
+    }
+    observedVideoElement = video || null;
+    if (observedVideoElement) {
+      observedVideoElement.addEventListener("resize", handleVideoResize);
+    }
+  }
+  updateVideoAspectRatioVar(observedVideoElement);
+};
 
 /**
  * Sets up a ResizeObserver on the player element to cache the content rect.
@@ -42,9 +82,11 @@ const setupResizeObserver = player => {
     if (player && typeof player.getVideoContentRect === "function") {
       cachedContentRect = player.getVideoContentRect();
     }
+    attachVideoListener(player);
   });
 
   playerResizeObserver.observe(player);
+  attachVideoListener(player);
 };
 // ------------------------------------------
 
@@ -79,6 +121,7 @@ const startLyricsTick = () => {
           if (typeof player.getVideoContentRect === "function") {
             cachedContentRect = player.getVideoContentRect();
           }
+          attachVideoListener(player);
         }
 
         const audioTrackData = player.getAudioTrack();
@@ -152,6 +195,11 @@ const stopLyricsTick = () => {
   if (playerResizeObserver) {
     playerResizeObserver.disconnect();
     playerResizeObserver = null;
+  }
+
+  if (observedVideoElement) {
+    observedVideoElement.removeEventListener("resize", handleVideoResize);
+    observedVideoElement = null;
   }
 };
 


### PR DESCRIPTION
### TL;DR

Fixes black bars in video mode by dynamically sizing the player to match the video's intrinsic aspect ratio.

### What changed?

- Introduced a `--blyrics-video-aspect-ratio` CSS variable (defaulting to `16 / 9`) that is dynamically updated at runtime to reflect the actual `videoWidth / videoHeight` of the playing video element.
- Added CSS rules that apply `aspect-ratio`, constrain `width` using `min()`, and cap the player height to prevent overflow in both fullscreen and non-fullscreen video mode. This ensures tall videos (e.g. 4:3) don't get clipped by the player bar or push song info off-screen.
- Added `attachVideoListener` and `updateVideoAspectRatioVar` functions in `script.js` to track the `<video>` element inside the player, listen for intrinsic dimension changes (e.g. quality switches), and keep the CSS variable in sync.
- The video resize listener is properly cleaned up when lyrics ticking stops or the observed element changes.
- Added `!important` to album art centering margins to prevent conflicts with the new video mode width constraints.

### How to test?

1. Open YouTube Music and enable video mode.
2. Play a video with a non-16:9 aspect ratio (e.g. 4:3 or vertical).
3. Verify the player resizes to match the video's aspect ratio without black bars, and that the video does not overflow or push UI elements off-screen.
4. Toggle fullscreen and confirm the player still fits correctly within the available space.
5. Switch video quality and confirm the player adjusts if the intrinsic dimensions change.

### Why make this change?

Previously, the player used a fixed size that did not account for the video's actual aspect ratio, resulting in black bars or overflow for non-standard aspect ratios. By reading the intrinsic dimensions directly from the `<video>` element and exposing them as a CSS variable, the player can now accurately size itself to eliminate black bars across all video formats and screen sizes.



![image.png](https://app.graphite.com/user-attachments/assets/cdd114c9-356e-49eb-8dec-f3fe4c0b6353.png)

![image.png](https://app.graphite.com/user-attachments/assets/be80919b-25e6-48ed-b29b-ab4e46ef1a2e.png)

![image.png](https://app.graphite.com/user-attachments/assets/bee05bf2-01d0-4c27-88b7-2a0685779da1.png)

![image.png](https://app.graphite.com/user-attachments/assets/67888b5f-3137-482b-9092-c9b2bed9452a.png)

<img width="2385" height="1033" alt="image" src="https://github.com/user-attachments/assets/ec1f8bc8-d2a7-48c9-835c-dbbe8dbf3ae1" />
