### PR TITLE
feat: adds a blank style class `blyrics-explicit` for marked explicit

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -10,6 +10,7 @@ export const RTL_CLASS = "blyrics-rtl" as const;
 export const WORD_CLASS = "blyrics--word" as const;
 export const HAS_TRAILING_SPACE_CLASS = "blyrics--has-trailing-space" as const;
 export const BACKGROUND_LYRIC_CLASS = "blyrics-background-lyric" as const;
+export const EXPLICIT_WORD_CLASS = "blyrics-explicit" as const;
 export const ANIMATING_CLASS = "blyrics--animating" as const;
 export const PAUSED_CLASS = "blyrics--paused" as const;
 export const PRE_ANIMATING_CLASS = "blyrics--pre-animating" as const;

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -1,5 +1,6 @@
 import {
   BACKGROUND_LYRIC_CLASS,
+  EXPLICIT_WORD_CLASS,
   HAS_TRAILING_SPACE_CLASS,
   LOG_PREFIX,
   LYRICS_CLASS,
@@ -323,6 +324,9 @@ function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTML
       }
       if (part.isBackground) {
         span.classList.add(BACKGROUND_LYRIC_CLASS);
+      }
+      if (part.explicit) {
+        span.classList.add(EXPLICIT_WORD_CLASS);
       }
 
       // Non-final sub-parts signal a group-flush (wrap opportunity) without a trailing-space

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -245,6 +245,7 @@ function splitLongPart(part: LyricPart, threshold: number): LyricPart[] {
       durationMs: subEnd - subStart,
       words: chunk,
       isBackground: part.isBackground,
+      explicit: part.explicit,
     });
     charsBefore += chunk.length;
   }
@@ -284,6 +285,7 @@ function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTML
       durationMs: originalPart.durationMs,
       words: core,
       isBackground: originalPart.isBackground,
+      explicit: originalPart.explicit,
     };
     const subParts = splitLongPart(cleanedPart, wrapThreshold);
 

--- a/src/modules/lyrics/providers/shared.ts
+++ b/src/modules/lyrics/providers/shared.ts
@@ -81,6 +81,7 @@ export interface LyricPart {
   words: string;
   durationMs: number;
   isBackground?: boolean;
+  explicit?: boolean;
 }
 
 export interface ProviderParameters {

--- a/src/modules/lyrics/providers/ttmlTypes.ts
+++ b/src/modules/lyrics/providers/ttmlTypes.ts
@@ -45,6 +45,8 @@ interface ParagraphAttributes {
   "@_key": string;
   "@_agent": string;
   "@_role": string;
+  "@_explicit"?: string;
+  "@_obscene"?: string; // AMLL explicit content flag
 }
 
 export interface SpanElement {
@@ -236,6 +238,7 @@ interface CleanWord {
   end: number;
   text: string;
   isBackground: boolean;
+  explicit?: boolean;
 }
 
 /** A single line of lyrics */

--- a/src/modules/lyrics/providers/ttmlUtils.ts
+++ b/src/modules/lyrics/providers/ttmlUtils.ts
@@ -108,22 +108,27 @@ function parseLyricPart(p: ParagraphElementOrBackground[], beginTime: number, ig
       if (subPart["#text"] && (!ignoreSpanSpace || localP.length <= 1)) {
         text += subPart["#text"];
         let lastPart = parts[parts.length - 1];
+        let explicit = (subPart[":@"]?.["@_explicit"] || subPart[":@"]?.["@_obscene"]) === "true";
+
         parts.push({
           startTimeMs: lastPart ? lastPart.startTimeMs + lastPart.durationMs : beginTime,
           durationMs: 0,
           words: subPart["#text"],
           isBackground,
+          explicit
         });
       } else if (subPart.span) {
         let spanText = subPart.span[0]["#text"]!;
         let startTimeMs = parseTime(subPart[":@"]?.["@_begin"]);
         let endTimeMs = parseTime(subPart[":@"]?.["@_end"]);
+        let explicit = (subPart[":@"]?.["@_explicit"] || subPart[":@"]?.["@_obscene"]) === "true";
 
         parts.push({
           startTimeMs,
           durationMs: endTimeMs - startTimeMs,
           isBackground,
           words: spanText,
+          explicit
         });
         text += spanText;
 

--- a/src/modules/lyrics/providers/ttmlUtils.ts
+++ b/src/modules/lyrics/providers/ttmlUtils.ts
@@ -119,7 +119,7 @@ function parseLyricPart(p: ParagraphElementOrBackground[], beginTime: number, ig
         let spanText = subPart.span[0]["#text"]!;
         let startTimeMs = parseTime(subPart[":@"]?.["@_begin"]);
         let endTimeMs = parseTime(subPart[":@"]?.["@_end"]);
-        let explicit = (subPart[":@"]?.["@_explicit"] || subPart[":@"]?.["@_obscene"]) === "true";
+        let explicit = subPart[":@"]?.["@_explicit"] === "true" || subPart[":@"]?.["@_obscene"] === "true";
 
         parts.push({
           startTimeMs,

--- a/src/modules/lyrics/providers/ttmlUtils.ts
+++ b/src/modules/lyrics/providers/ttmlUtils.ts
@@ -108,14 +108,12 @@ function parseLyricPart(p: ParagraphElementOrBackground[], beginTime: number, ig
       if (subPart["#text"] && (!ignoreSpanSpace || localP.length <= 1)) {
         text += subPart["#text"];
         let lastPart = parts[parts.length - 1];
-        let explicit = (subPart[":@"]?.["@_explicit"] || subPart[":@"]?.["@_obscene"]) === "true";
 
         parts.push({
           startTimeMs: lastPart ? lastPart.startTimeMs + lastPart.durationMs : beginTime,
           durationMs: 0,
           words: subPart["#text"],
           isBackground,
-          explicit
         });
       } else if (subPart.span) {
         let spanText = subPart.span[0]["#text"]!;
@@ -128,7 +126,7 @@ function parseLyricPart(p: ParagraphElementOrBackground[], beginTime: number, ig
           durationMs: endTimeMs - startTimeMs,
           isBackground,
           words: spanText,
-          explicit
+          explicit,
         });
         text += spanText;
 


### PR DESCRIPTION
# Description

Adds a blank style class `blyrics-explicit` up for theme creators to customize marked lyric lines word by checking if there are any `@_explicit` or `@_obscene` attribute on the `span`

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots (if applicable)

| Before             | After              |
| ------------------ | ------------------ |
| <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bc6e7f00-8145-4611-a97b-6cad3028c80f" /> | <img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c88cb896-0a21-44e7-b421-ddf8a34febd0" /> |

The before is without the class (mostly the same as without styling it), the after is with the class styled manually within the theme to blur the word out
> for some reason my code for adding the explicit class did not work so i manually added the class on the after image. lmk if it works for you though
