### PR TITLE
Fix wraps happening at random points for Portato Lyrics

### DIFF
--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -196,8 +196,6 @@ const TRAILING_ATTACHED_PUNCT_REGEX = /^[\p{Pe}\p{Pf}\p{Po}]+$/u;
  * unbroken runs such as SEA-language lyrics. Duration is distributed linearly across sub-parts.
  */
 function splitLongPart(part: LyricPart, threshold: number): LyricPart[] {
-  if (threshold <= 0 || part.words.length <= threshold) return [part];
-
   let segments: string[];
   try {
     const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
@@ -216,28 +214,14 @@ function splitLongPart(part: LyricPart, threshold: number): LyricPart[] {
     return acc;
   }, [] as string[]);
 
-  const chunks: string[] = [];
-  let current = "";
-  for (const seg of segments) {
-    if (current.length > 0 && current.length + seg.length > threshold) {
-      chunks.push(current);
-      current = seg;
-    } else {
-      current += seg;
-    }
-  }
-  if (current.length > 0) chunks.push(current);
-
-  if (chunks.length <= 1) return [part];
-
   const totalChars = part.words.length;
   const subParts: LyricPart[] = [];
   let charsBefore = 0;
-  for (let i = 0; i < chunks.length; i++) {
-    const chunk = chunks[i];
+  for (let i = 0; i < segments.length; i++) {
+    const chunk = segments[i];
     const subStart = part.startTimeMs + Math.round((part.durationMs * charsBefore) / totalChars);
     const subEnd =
-      i === chunks.length - 1
+      i === segments.length - 1
         ? part.startTimeMs + part.durationMs
         : part.startTimeMs + Math.round((part.durationMs * (charsBefore + chunk.length)) / totalChars);
     subParts.push({
@@ -261,33 +245,55 @@ function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTML
   let lastEmittedSpan: HTMLSpanElement | null = null;
   const wrapThreshold = longWordWrapThreshold.getNumberValue();
 
+  parts = parts.flatMap(original => {
+    const parts = original.words.match(/^(\s*)([\s\S]*?)(\s*)$/u);
+    let returnArray: LyricPart[] = [];
+    if (parts && parts.length > 0) {
+      const beginWhitespace = parts[1];
+      const core = parts[2];
+      const endWhitespace = parts[3];
+      if (core.length === 0) {
+        return [original];
+      }
+
+      if (beginWhitespace.length > 0) {
+        returnArray.push({
+          startTimeMs: original.startTimeMs,
+          words: beginWhitespace,
+          durationMs: 0,
+          explicit: original.explicit,
+          isBackground: original.isBackground,
+        });
+      }
+      returnArray.push({
+        startTimeMs: original.startTimeMs,
+        words: core,
+        durationMs: original.durationMs,
+        explicit: original.explicit,
+        isBackground: original.isBackground,
+      });
+      if (endWhitespace.length > 0) {
+        returnArray.push({
+          startTimeMs: original.startTimeMs + original.durationMs,
+          words: endWhitespace,
+          durationMs: 0,
+          explicit: original.explicit,
+          isBackground: original.isBackground,
+        });
+      }
+    }
+    return returnArray;
+  });
+
   parts.forEach(originalPart => {
-    // Separate leading whitespace from the part's core text. Whitespace is not emitted
-    // as DOM content; it becomes a class on the preceding span so CSS can re-add spacing in a way
-    // that disappears cleanly at line / row ends.
-    // Trailing whitespace isn't removed at this stage and is used to insert the appropriate classes later
-    const match = originalPart.words.match(/^(\s*)([\s\S]*?)$/u);
-    const leadingWs = match?.[1] ?? "";
-    const core = match?.[2] ?? originalPart.words;
-    if (core.length === 0) {
+    if (originalPart.words.trim().length === 0) {
       if (lastEmittedSpan) {
         lastEmittedSpan.classList.add(HAS_TRAILING_SPACE_CLASS);
       }
       return;
     }
 
-    if (leadingWs.length > 0 && lastEmittedSpan) {
-      lastEmittedSpan.classList.add(HAS_TRAILING_SPACE_CLASS);
-    }
-
-    const cleanedPart: LyricPart = {
-      startTimeMs: originalPart.startTimeMs,
-      durationMs: originalPart.durationMs,
-      words: core,
-      isBackground: originalPart.isBackground,
-      explicit: originalPart.explicit,
-    };
-    const subParts = splitLongPart(cleanedPart, wrapThreshold);
+    const subParts = splitLongPart(originalPart, wrapThreshold);
 
     subParts.forEach((part, subIdx) => {
       const isLastSub = subIdx === subParts.length - 1;
@@ -362,9 +368,6 @@ function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTML
   }
 
   groupByWordAndInsert(lyricElement, lyricElementsBuffer);
-  if (lyricElement.children.length > 0) {
-    lyricElement.children[lyricElement.children.length - 1].classList.add(HAS_TRAILING_SPACE_CLASS);
-  }
 }
 
 function createBreakElem(lyricElement: HTMLElement, order: number) {


### PR DESCRIPTION
### TL;DR

Refactored lyric part splitting to separate whitespace handling from word segmentation, and simplified `splitLongPart` to operate directly on segmented words rather than chunking by character threshold.

### What changed?

- `splitLongPart` no longer short-circuits based on a threshold or chunks segments by character count — it now distributes timing linearly across each individual segment directly.
- Leading and trailing whitespace is now stripped from lyric parts *before* they reach `splitLongPart`, by splitting each `LyricPart` into up to three sub-parts (leading whitespace with zero duration, core text, trailing whitespace with zero duration) via a `flatMap` in `createLyricsLine`.
- The inline whitespace-stripping logic inside the `parts.forEach` loop has been removed, since whitespace parts are now pre-separated. A whitespace-only part simply adds `HAS_TRAILING_SPACE_CLASS` to the last emitted span as before.

### How to test?

1. Open a track with synced lyrics that contains parts with leading and/or trailing whitespace.
2. Verify that spacing between lyric spans renders correctly and disappears cleanly at line/row ends.
3. Open a track with long lyric lines (e.g. unbroken SEA-language lyrics) and confirm that timing is distributed correctly across the split segments.
4. Confirm no visual regressions in standard Latin-script lyrics with normal spacing.

### Why make this change?

The previous approach mixed whitespace handling and chunking logic together inside `splitLongPart` and the `forEach` loop, making the behavior harder to reason about. By pre-splitting parts on whitespace boundaries before segmentation, each concern is handled independently, resulting in cleaner and more predictable timing distribution and spacing behavior.