### PR TITLE
Move `langCodesMatch` to shared utils and use base language matching in `ytCaptions`

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -55,3 +55,13 @@ export function languageMatchesAny(lang: string, collection: string[] | Record<s
   const baseLang = lang.split("-")[0];
   return baseLang !== lang && check(baseLang);
 }
+
+/**
+ * Compare base language codes, e.g. "en" matches "en-US"
+ */
+export function langCodesMatch(lang1: string, lang2: string): boolean {
+  if (!lang1 || !lang2) return false;
+  const base1 = lang1.split("-")[0];
+  const base2 = lang2.split("-")[0];
+  return base1 === base2;
+}

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -45,7 +45,7 @@ import {
   renderLoader,
   setExtraHeight,
 } from "@modules/ui/dom";
-import { getRelativeBounds, languageMatchesAny, log } from "@utils";
+import { getRelativeBounds, langCodesMatch, languageMatchesAny, log } from "@utils";
 
 let disableRichsync = registerThemeSetting("blyrics-disable-richsync", false, true);
 let lineSyncedAnimationDelay = registerThemeSetting("blyrics-line-synced-animation-delay", 50, true);
@@ -891,14 +891,4 @@ function isSameText(str1: string, str2: string): boolean {
     .trim();
 
   return str1 === str2;
-}
-
-/**
- * Compare base language codes, e.g. "en" matches "en-US"
- */
-function langCodesMatch(lang1: string, lang2: string): boolean {
-  if (!lang1 || !lang2) return false;
-  const base1 = lang1.split("-")[0];
-  const base2 = lang2.split("-")[0];
-  return base1 === base2;
 }

--- a/src/modules/lyrics/providers/ytCaptions.ts
+++ b/src/modules/lyrics/providers/ytCaptions.ts
@@ -1,5 +1,5 @@
 import { MUSIC_NOTES } from "@constants";
-import { log } from "@utils";
+import { langCodesMatch, log } from "@utils";
 import type { LyricsArray, ProviderParameters } from "./shared";
 
 export async function ytCaptions(providerParameters: ProviderParameters): Promise<void> {
@@ -27,12 +27,13 @@ export async function ytCaptions(providerParameters: ProviderParameters): Promis
     log("Found Caption Tracks, but couldn't determine the default", audioTrackData);
     providerParameters.sourceMap["yt-captions"].filled = true;
     providerParameters.sourceMap["yt-captions"].lyricSourceResult = null;
+    return;
   }
 
   let captionsUrl: URL | null = null;
   for (let captionTracksKey in audioTrackData.captionTracks) {
     let data = audioTrackData.captionTracks[captionTracksKey];
-    if (!data.displayName.includes("auto-generated") && data.languageCode === langCode) {
+    if (!data.displayName.includes("auto-generated") && langCodesMatch(data.languageCode, langCode)) {
       captionsUrl = new URL(data.url);
       break;
     }


### PR DESCRIPTION
### TL;DR

Moved `langCodesMatch` from a local function in `injectLyrics.ts` to a shared utility, and improved language code matching in the YouTube Captions provider.

### What changed?

`langCodesMatch` has been extracted from `injectLyrics.ts` and moved into `src/core/utils.ts` so it can be reused across modules. The YouTube Captions provider now uses `langCodesMatch` instead of a strict equality check (`===`) when comparing language codes, and also guards against a falsy `langCode` before attempting the comparison.

### How to test?

Youtube Captions now load for: https://music.youtube.com/watch?v=CdZN8PI3MqM

### Why make this change?

The strict equality check (`===`) in the YouTube Captions provider would fail to match language codes that differ only by region (e.g. `en` vs `en-US`). By reusing the existing `langCodesMatch` logic — which compares only the base language code — and centralising it as a shared utility, the matching becomes more robust and the logic is no longer duplicated.