### PR TITLE
fix: re-sign on PUBLIC_KEY_REQUIRED retry to avoid nonce replay

### DIFF
--- a/src/modules/unison/unisonApi.ts
+++ b/src/modules/unison/unisonApi.ts
@@ -25,7 +25,7 @@ async function signedRequest<T>(
   data: Record<string, unknown>
 ): Promise<ApiResult<T>> {
   try {
-    const signed = await signPayload(data);
+    let signed = await signPayload(data);
     let needsRegistration = !(await isKeyRegistered());
 
     const body: Record<string, unknown> = {
@@ -47,6 +47,9 @@ async function signedRequest<T>(
     if (response.status === 400 && !needsRegistration) {
       cachedErrorBody = await response.json().catch(() => null);
       if (cachedErrorBody?.error === "PUBLIC_KEY_REQUIRED") {
+        signed = await signPayload(data);
+        body.payload = signed.payload;
+        body.signature = signed.signature;
         body.publicKey = signed.publicKey;
         needsRegistration = true;
         response = await fetchWithTimeout(`${UNISON_API_BASE_URL}${endpoint}`, {

--- a/src/options/store/themeStoreApi.ts
+++ b/src/options/store/themeStoreApi.ts
@@ -49,7 +49,7 @@ export async function trackInstall(themeId: string): Promise<ApiResult<number | 
   }
 
   try {
-    const signed = await signInstall(themeId);
+    let signed = await signInstall(themeId);
     let needsRegistration = !(await isKeyRegistered());
 
     const body: Record<string, unknown> = {
@@ -70,6 +70,9 @@ export async function trackInstall(themeId: string): Promise<ApiResult<number | 
     if (response.status === 400 && !needsRegistration) {
       const errorData = await response.json().catch(() => null);
       if (errorData?.error === "PUBLIC_KEY_REQUIRED") {
+        signed = await signInstall(themeId);
+        body.payload = signed.payload;
+        body.signature = signed.signature;
         body.publicKey = signed.publicKey;
         needsRegistration = true;
         response = await fetchWithTimeout(`${THEME_STORE_API_URL}/api/install/${encodeURIComponent(themeId)}`, {
@@ -113,7 +116,7 @@ export async function submitRating(
   }
 
   try {
-    const signed = await signRating(themeId, rating);
+    let signed = await signRating(themeId, rating);
     const certificate = await getCertificate();
     let needsRegistration = !(await isKeyRegistered());
 
@@ -145,6 +148,9 @@ export async function submitRating(
     if (response.status === 400 && !needsRegistration) {
       const errorData = await response.json().catch(() => null);
       if (errorData?.error === "PUBLIC_KEY_REQUIRED") {
+        signed = await signRating(themeId, rating);
+        body.payload = signed.payload;
+        body.signature = signed.signature;
         body.publicKey = signed.publicKey;
         needsRegistration = true;
         response = await fetchWithTimeout(`${THEME_STORE_API_URL}/api/rate/${encodeURIComponent(themeId)}`, {
@@ -182,7 +188,7 @@ export async function submitRating(
 
 export async function fetchUserRatings(): Promise<ApiResult<Record<string, number>>> {
   try {
-    const signed = await signPayload({});
+    let signed = await signPayload({});
     let needsRegistration = !(await isKeyRegistered());
 
     const body: Record<string, unknown> = {
@@ -203,6 +209,9 @@ export async function fetchUserRatings(): Promise<ApiResult<Record<string, numbe
     if (response.status === 400 && !needsRegistration) {
       const errorData = await response.json().catch(() => null);
       if (errorData?.error === "PUBLIC_KEY_REQUIRED") {
+        signed = await signPayload({});
+        body.payload = signed.payload;
+        body.signature = signed.signature;
         body.publicKey = signed.publicKey;
         needsRegistration = true;
         response = await fetchWithTimeout(`${THEME_STORE_API_URL}/api/user/ratings`, {


### PR DESCRIPTION
# Description

- Retry path on `PUBLIC_KEY_REQUIRED` was reusing the original signed payload, so the server-burned nonce caused a 409 `NONCE_REPLAY` on the retry.