### PR TITLE
Rewrite animation engine and injectLyrics.ts

### DIFF
--- a/STYLING-SKILL.md
+++ b/STYLING-SKILL.md
@@ -34,17 +34,61 @@ Essential reference for creating custom themes. For deep dives, see [STYLING.md]
 
 ```css
 :root {
+  --blyrics-animate-line-scale: 1;
+  --blyrics-animate-word-wobble: 1;
+  --blyrics-animate-highlight-swipe: 1;
+  --blyrics-animate-highlight-glow: 1;
+  --blyrics-animate-highlight-fade: 1;
+  --blyrics-animate-scroll: 1;
+  --blyrics-animate-instrumental: 1;
   --blyrics-loader-transition-duration: 0.6s;
   --blyrics-loader-transition-easing: cubic-bezier(0.22, 1, 0.36, 1);
   --blyrics-scale-transition-duration: 0.166s;
+  --blyrics-line-enter-transform-from: scale(var(--blyrics-scale));
+  --blyrics-line-enter-transform-to: scale(var(--blyrics-active-scale));
+  --blyrics-line-exit-transform-from: scale(var(--blyrics-active-scale));
+  --blyrics-line-exit-transform-to: scale(var(--blyrics-scale));
+  --blyrics-line-enter-easing: ease;
+  --blyrics-line-exit-easing: ease;
   --blyrics-lyric-highlight-fade-in-duration: 0.33s;
   --blyrics-lyric-highlight-fade-out-duration: 0.5s;
+  --blyrics-lyric-highlight-fade-in-easing: ease;
+  --blyrics-lyric-highlight-fade-out-easing: ease;
+  --blyrics-highlight-swipe-easing: linear;
+  --blyrics-highlight-swipe-start-from: -0.2;
+  --blyrics-highlight-swipe-end-from: -0.1;
+  --blyrics-highlight-swipe-start-to: 1.4;
+  --blyrics-highlight-swipe-end-to: 1.5;
+  --blyrics-highlight-glow-filter-from: drop-shadow(0 0 0.8rem var(--blyrics-glow-color));
+  --blyrics-highlight-glow-filter-to: drop-shadow(0 0 0 var(--blyrics-glow-color));
+  --blyrics-highlight-glow-duration-ratio: 1.2;
+  --blyrics-highlight-glow-min-duration: 1.2s;
+  --blyrics-highlight-glow-easing: ease;
   --blyrics-wobble-duration: 1s;
+  --blyrics-word-wobble-transform-from: scaleX(1);
+  --blyrics-word-wobble-transform-peak: translateX(0.05em) scaleX(1.025);
+  --blyrics-word-wobble-transform-settle: translateX(0) scaleX(1);
+  --blyrics-word-wobble-transform-to: scaleX(1);
+  --blyrics-word-wobble-peak-offset: 0.125;
+  --blyrics-word-wobble-settle-offset: 0.75;
+  --blyrics-word-wobble-easing: ease;
+  --blyrics-word-wobble-peak-easing: ease-in-out;
+  --blyrics-word-wobble-end-easing: ease-out;
+  --blyrics-instrumental-fill-fade-duration: 150ms;
+  --blyrics-instrumental-fill-fade-easing: ease;
+  --blyrics-instrumental-fill-transform-from: translateY(78%);
+  --blyrics-instrumental-fill-transform-to: translateY(-4%);
+  --blyrics-instrumental-fill-easing: linear;
+  --blyrics-instrumental-wave-transform-from: scaleY(1.2);
+  --blyrics-instrumental-wave-transform-to: scaleY(0.0001);
+  --blyrics-instrumental-wave-easing: ease-in;
+  --blyrics-instrumental-wave-oscillation-duration: 1.25s;
+  --blyrics-instrumental-wave-oscillation-easing: ease-in-out;
   --blyrics-timing-offset: 0.115s;
   --blyrics-richsync-timing-offset: 0.150s;
   --blyrics-scroll-timing-offset: 0.5s;
-  --blyrics-lyric-scroll-duration: 750ms;
-  --blyrics-lyric-scroll-timing-function: cubic-bezier(0.86, 0, 0.07, 1);
+  --blyrics-lyric-scroll-duration: 650ms;
+  --blyrics-lyric-scroll-timing-function: cubic-bezier(0.86, 0, 0.2, 1);
 }
 ```
 
@@ -98,18 +142,26 @@ Comment-based parameters that control JS behavior. Place anywhere in your theme:
 blyrics-disable-richsync = true;
 blyrics-line-synced-animation-delay = 50;
 blyrics-target-scroll-pos-ratio = 0.37;
+blyrics-swipe-lead-ratio = 0.1;
+blyrics-swipe-duration-ratio = 1.6;
+blyrics-line-scroll-duration = 750ms;
+blyrics-line-scroll-below-duration = calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1, 2.71828) * 80ms + var(--blyrics-line-scroll-abs-relative-index) * 20ms);
+blyrics-line-scroll-above-duration = calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1) * 10ms);
 */
 ```
 
 | Knob | Default | Description |
 |------|---------|-------------|
-| `blyrics-disable-richsync` | `false` | Disable word-level animation |
+| `blyrics-disable-richsync` | `false` | Render richsynced lyrics through the line-synced path instead, including line-synced fade-in |
 | `blyrics-line-synced-animation-delay` | `50` | Per-word delay for synced lyrics (ms) |
 | `blyrics-lyric-ending-threshold-s` | `0.5` | Seconds before line ends to consider it complete |
-| `blyrics-early-scroll-consider-s` | `0.62` | Future lookahead for scroll grouping (s) |
-| `blyrics-queue-scroll-ms` | `150` | Max queued scroll delay (ms) |
+| `blyrics-early-scroll-consider-s` | auto (`~0.54` default) | Future lookahead for scroll grouping (s) |
+| `blyrics-queue-scroll-ms` | auto (`~131` default, capped at `200`) | Max queued scroll delay (ms) |
 | `blyrics-debug-renderer` | `false` | Enable debug overlay |
+| `blyrics-debug-animation-timing` | `false` | Log WAAPI lyric animation timing samples, learned offsets, and timing cleanup events |
 | `blyrics-target-scroll-pos-ratio` | `0.37` | Lyric position (0=top, 0.5=center, 1=bottom) |
+| `blyrics-swipe-lead-ratio` | `0.1` | Rich-sync swipe lead as a fraction of word duration |
+| `blyrics-swipe-duration-ratio` | `1.6` | Rich-sync swipe duration as a multiple of word duration |
 | `blyrics-long-word-threshold` | `1500` | Duration (ms) above which `data-long-word` is set |
 | `blyrics-hide-instrumental-only` | `false` | Treat "[Instrumental Only]" as no lyrics (enables fullscreen effect) |
 | `blyrics-passive-scroll-enabled` | `true` | Unsynced auto-scroll: enable/disable entirely (overrides user setting) |
@@ -117,8 +169,15 @@ blyrics-target-scroll-pos-ratio = 0.37;
 | `blyrics-passive-scroll-bottom-pause-s` | `1.5` | Unsynced auto-scroll: pause at bottom (s) |
 | `blyrics-passive-scroll-reset-duration-s` | `0.6` | Unsynced auto-scroll: scroll-back-to-top duration (s) |
 | `blyrics-passive-scroll-top-pause-s` | `0.8` | Unsynced auto-scroll: pause at top (s) |
+| `blyrics-line-scroll-duration` | `750ms` | Per-line scroll animation duration |
+| `blyrics-line-scroll-{above,active,below}-duration` | side-specific tail defaults | Side-specific scroll duration; `above`/`below` swap on upward scrolls. Defaults use uncapped relative-index formulas so farther trailing lines settle progressively later. |
+| `blyrics-line-scroll-timing-function` | `var(--blyrics-lyric-scroll-timing-function)` | Shared line-scroll easing |
+| `blyrics-line-scroll-{start,end}-easing` | timing / `linear` | Keyframe easing |
+| `blyrics-line-scroll-{above,active,below}-{start,end}-easing` | shared keyframe easing | Side-specific keyframe easing; `above`/`below` swap on upward scrolls |
+| `blyrics-line-scroll-translate-y-{start,end}` | delta / `0px` | Shared Y offsets |
+| `blyrics-line-scroll-{above,active,below}-translate-y-{start,end}` | shared offset | Side-specific Y offsets; `above`/`below` swap on upward scrolls |
 
-**Scroll equation**: `--blyrics-lyric-scroll-duration` + 0.02s = `blyrics-early-scroll-consider-s` + `blyrics-queue-scroll-ms`
+**Scroll timing**: if `blyrics-early-scroll-consider-s` and `blyrics-queue-scroll-ms` are not manually set, they are derived from `--blyrics-lyric-scroll-duration` using the default timing ratio. If one is manually set, the other is derived from the scroll equation; auto-derived queueing is capped at `200ms`. If both are manually set, keep this balanced: `--blyrics-lyric-scroll-duration` + 0.02s = `blyrics-early-scroll-consider-s` + `blyrics-queue-scroll-ms`.
 
 ## Dynamic Properties
 
@@ -127,28 +186,36 @@ Properties set by JS at runtime on individual elements:
 | Property | Set On | Description |
 |----------|--------|-------------|
 | `--blyrics-duration` | `.blyrics--word`, `.blyrics--instrumental` | Duration of current element (ms) |
-| `--blyrics-anim-delay` | `.blyrics--word`, `.blyrics--line` | Delay until animation starts |
-| `--blyrics-swipe-delay` | `.blyrics--word::after` | Swipe transition delay (anim-delay - 10% of duration) |
+| `--blyrics-line-scroll-relative-index` | visible animated lyric lines | Active line is `0`, below lines are positive, above lines are negative |
+| `--blyrics-line-scroll-abs-relative-index` | visible animated lyric lines | Absolute relative index |
+| `--blyrics-line-scroll-side` | visible animated lyric lines | Direction-aware side: `above`, `active`, or `below`; `above`/`below` swap on upward scrolls |
+| `--blyrics-line-scroll-delta-px` | visible animated lyric lines | Signed scroll delta |
+| `--blyrics-line-scroll-distance-px` | visible animated lyric lines | Absolute scroll distance |
+| `--blyrics-padding-top` | `:root` | Calculated top spacer for scroll positioning |
+| `--blyrics-padding-bottom` | `:root` | Calculated bottom spacer for scroll positioning |
+
+Lyric timing is driven by `element.animate()`.
 
 ## DOM Structure
 
 ```
 .blyrics-container [data-sync] [data-loader-visible] [data-no-lyrics]
 ├── .blyrics--line (div) [data-agent] [data-time] [data-duration] [data-line-number]
-│   ├── span
-│   │   └── .blyrics--word (span) [data-content] [data-time] [data-duration] [data-long-word]
-│   ├── .blyrics--break (span) - line break
-│   └── .blyrics-background-lyric (span) - background vocals
-├── .blyrics--line.blyrics--animating (active line)
-│   └── .blyrics--word.blyrics--animating (animating word)
-│       └── .blyrics--word.blyrics--paused (paused state)
+│   ├── .blyrics-line-main (div)
+│   │   └── .blyrics-bidi-run (span)
+│   │       └── .blyrics-word-group (span)
+│   │           └── .blyrics--word (span) [data-content] [data-time] [data-duration] [data-long-word]
+│   │               └── .blyrics-word-highlight (span, only for long wrapped words)
+│   ├── .blyrics-background-line (div, only when primary background vocals are present)
+│   │   └── .blyrics-bidi-run (span)
+│   │       └── .blyrics-word-group.blyrics-background-lyric
+│   ├── .blyrics--romanized.blyrics-content-line
+│   └── .blyrics--translated.blyrics-content-line
 ├── .blyrics--instrumental.blyrics--line [data-instrumental="true"]
 │   └── .blyrics--instrumental-icon (svg)
 │       ├── .blyrics--instrumental-bg (path)
 │       ├── .blyrics--instrumental-fill (path)
-│       └── .blyrics--wave-clip/.blyrics--wave-path
-├── .blyrics--translated (span)
-├── .blyrics--romanized (span)
+│       └── .blyrics--wave-clip/.blyrics--wave-rect/.blyrics--wave-path
 └── .blyrics-footer
 ```
 
@@ -164,7 +231,7 @@ Properties set by JS at runtime on individual elements:
 
 | Attribute | Description |
 |-----------|-------------|
-| `data-content` | Word text (used by `::after` for karaoke) |
+| `data-content` | Word text (used by generated highlight overlay when no real overlay is needed) |
 | `data-time` | Start time in seconds |
 | `data-duration` | Duration in seconds |
 | `data-long-word` | `"true"` or absent - present when duration exceeds threshold |
@@ -183,11 +250,15 @@ Properties set by JS at runtime on individual elements:
 |----------|---------|
 | `.blyrics-container` | Main lyrics wrapper |
 | `.blyrics--line` | Lyric line (div) |
+| `.blyrics-line-main` | Main lyric text row |
+| `.blyrics-background-line` | Primary background vocal row |
+| `.blyrics-bidi-run` | Inline text-flow wrapper for native browser bidi ordering |
+| `.blyrics-bidi-sensitive` | Applied to rows containing RTL script; makes word wrappers inline-flow for correct bidi wrapping |
+| `.blyrics-word-group` | Word/syllable group; `inline-block` for LTR-only rows and `display: contents` inside `.blyrics-bidi-sensitive` |
 | `.blyrics--word` | Word span |
-| `.blyrics--animating` | Currently active/animating (USE THIS for styling) |
-| `.blyrics--pre-animating` | About to animate |
-| `.blyrics--active` | Currently highlighted (use in `:has()` only) |
-| `.blyrics--paused` | Playback paused |
+| `.blyrics-word-highlight` | Real highlight overlay for long wrapped words |
+| `.blyrics-line-synced-word` | Zero-duration line-synced word; fades in without rich-sync swipe |
+| `.blyrics--active` | Currently selected for scrolling/current line state |
 | `.blyrics-user-scrolling` | User is scrolling manually |
 | `.blyrics-rtl` | RTL language support |
 | `.blyrics--translated` | Translation text |
@@ -201,10 +272,11 @@ Properties set by JS at runtime on individual elements:
 
 ## Animation System
 
-Karaoke effect uses `::after` with `background-clip: text`:
+Karaoke effect uses `::after` with `background-clip: text`; long wrapped words use `.blyrics-word-highlight` instead so the highlight can wrap at inserted `<wbr>` points:
 
 ```css
-.blyrics--word::after {
+.blyrics--word::after,
+.blyrics-word-highlight {
   content: attr(data-content);
   color: transparent;
   background-image: linear-gradient(90deg, var(--blyrics-lyric-active-color) ..., transparent ...);
@@ -212,15 +284,27 @@ Karaoke effect uses `::after` with `background-clip: text`:
 }
 ```
 
+Timing uses the Web Animations API:
+
+- Rich-sync swipe starts at `wordStart - blyrics-swipe-lead-ratio * wordDuration`
+- Rich-sync swipe duration is `blyrics-swipe-duration-ratio * wordDuration`
+- Rich-sync word-timed highlights become visible instantly at `wordStart`; they do not use the highlight fade-in duration
+- Line-synced `.blyrics-line-synced-word` skips swipe and fades in at word time
+- `--blyrics-animate-highlight-swipe: 0` keeps rich-sync timing but makes each word fully highlighted instantly instead of fading like line-synced lyrics
+- Glow lasts `max(wordDuration * --blyrics-highlight-glow-duration-ratio, --blyrics-highlight-glow-min-duration)`
+- Lyric line scale and scroll smoothing also use `element.animate()`
+- Scroll smoothing uses per-line `translate`, not container `transform`; JS automatically animates lines visible in the previous or current viewport and provides relative index, absolute relative index, signed scroll delta, and absolute scroll distance as CSS variables
+- Visible lyric lines receive inline `will-change: transform, translate` before scroll animations start
+- Per-line scroll effects can overlap with additive Web Animations (`composite: "add"`); custom line durations are visual only, and the next autoscroll is gated by `--blyrics-lyric-scroll-duration`
+- Visual keyframe values, effect enable flags, durations, and easing are CSS variables; JS still owns scheduling, pause/resume, seeking, and cancellation
+- `prefers-reduced-motion: reduce` keeps smooth scroll enabled but disables side-specific line-scroll differential effects
+
 ### Keyframes
 
 | Animation | Description |
 |-----------|-------------|
-| `blyrics-wobble` | Word bounce effect (scaleX 1 -> 1.025 -> 1) |
-| `blyrics-glow` | Drop-shadow fade (0.8rem -> 0) |
 | `blyrics-spin` | Loader rotation |
 | `blyrics-shimmer` | Loading text shimmer |
-| `blyrics-wave` | Instrumental wave oscillation |
 
 ## Unison Submitter Card and Floating Dock
 
@@ -331,11 +415,15 @@ Override `--blyrics-fullscreen-bottom-dock-shift` to tune the lift.
 ### 1. Disable Default Animations
 
 ```css
-@keyframes blyrics-wobble { 0%, to { transform: none; } }
-@keyframes blyrics-glow { 0%, to { filter: none; } }
-.blyrics--word::after {
-  animation: none !important;
-  content: none !important;
+:root {
+  --blyrics-animate-line-scale: 0;
+  --blyrics-animate-word-wobble: 0;
+  --blyrics-animate-highlight-swipe: 0;
+  --blyrics-animate-highlight-glow: 0;
+  --blyrics-animate-scroll: 0;
+  --blyrics-animate-instrumental: 0;
+  --blyrics-scale: 1;
+  --blyrics-active-scale: 1;
 }
 ```
 
@@ -360,11 +448,11 @@ Override `--blyrics-fullscreen-bottom-dock-shift` to tune the lift.
   filter: blur(6px);
   transition: opacity 0.7s, filter 0.7s, transform 1.66s;
 }
-.blyrics-container > div.blyrics--animating:not(:empty):not(.blyrics--translated):not(.blyrics--romanized) {
+.blyrics-container > div.blyrics--active:not(:empty) {
   opacity: 1;
   filter: blur(0px);
 }
-.blyrics-user-scrolling > div:not(.blyrics--animating) {
+.blyrics-user-scrolling > div {
   opacity: 1 !important;
   filter: blur(0px) !important;
 }
@@ -455,7 +543,7 @@ ytmusic-player-page::before {
 ### 11. User Scroll State
 
 ```css
-.blyrics-user-scrolling > div:not(.blyrics--animating) {
+.blyrics-user-scrolling > div {
   opacity: 1 !important;
   filter: blur(0px) !important;
 }
@@ -497,23 +585,15 @@ Target sustained notes for special effects:
 /* Set threshold in knobs */
 /* blyrics-long-word-threshold = 1500; */
 
-.blyrics--word[data-long-word]::after {
+.blyrics--word[data-long-word]::after,
+.blyrics--word[data-long-word] > .blyrics-word-highlight {
   --blyrics-glow-color: color(display-p3 1 0.8 0.3 / 1);
-  animation-duration: calc(var(--blyrics-duration) * 2) !important;
 }
 ```
 
-### 15. Paused State Handling
+### 15. Pause Behavior
 
-```css
-.blyrics--word.blyrics--paused {
-  animation-play-state: paused;
-}
-.blyrics--word.blyrics--paused::after {
-  transition-duration: 100000000s; /* Freeze transition */
-  opacity: 0.5;
-}
-```
+Playback pause is handled by pausing the active Web Animations API animations in JavaScript.
 
 ## Best Practices
 
@@ -525,13 +605,14 @@ Target sustained notes for special effects:
 6. **Handle `data-sync="none"`** - smooth transition when sync loads
 7. **Exclude translation/romanization** - `:not(.blyrics--translated):not(.blyrics--romanized)`
 8. **Handle user scroll** - `.blyrics-user-scrolling`
-9. **Use `.blyrics--animating`** for styling, `.blyrics--active` in `:has()` only
+9. **Prefer structural selectors** such as `.blyrics-line-main`, `.blyrics-word-group`, and data attributes; use `.blyrics--active` only for current-line affordances
+10. **Respect RTL inline flow** - do not force `.blyrics-bidi-sensitive .blyrics-word-group` or `.blyrics-bidi-sensitive .blyrics--word` back to `inline-block`; word wobble transforms should be treated as unavailable on RTL-sensitive rows
 
 ## Do NOT Modify
 
 - `--noto-sans-universal` - International font fallback chain
 - `--blyrics-gradient-stops` - Complex fullscreen gradient
-- `.blyrics--active` for styling - use `.blyrics--animating` instead (`.blyrics--active` only in `:has()` checks)
+- Core animation variables such as `--lyric-transition-amount-start` and `--lyric-transition-amount-end` unless you are replacing the karaoke highlight effect
 - Core DOM structure expectations
 - YouTube Music element selectors (unless intentional)
 
@@ -539,7 +620,7 @@ Target sustained notes for special effects:
 
 | File | Purpose |
 |------|---------|
-| [`blyrics.css`](https://github.com/better-lyrics/better-lyrics/blob/master/public/css/blyrics.css) | Core lyrics styling and animations |
+| [`lyrics.css`](https://github.com/better-lyrics/better-lyrics/blob/master/public/css/blyrics/lyrics.css) | Core lyrics styling and animations |
 | [`ytmusic.css`](https://github.com/better-lyrics/better-lyrics/blob/master/public/css/ytmusic.css) | YouTube Music layout modifications |
 | [`themesong.css`](https://github.com/better-lyrics/better-lyrics/blob/master/public/css/themesong.css) | ThemeSong extension compatibility |
 | [`disablestylizedanimations.css`](https://github.com/better-lyrics/better-lyrics/blob/master/public/css/disablestylizedanimations.css) | Disables animations when toggled |

--- a/STYLING.md
+++ b/STYLING.md
@@ -160,17 +160,113 @@ These custom properties allow for easy customization of colors, sizes, and other
 
 ### Animations
 
-| Variable                                      | Default Value                        | Description                                                                                     |
-| --------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| `--blyrics-loader-transition-duration`        | `0.6s`                               | Duration of loader enter/exit transitions                                                       |
-| `--blyrics-loader-transition-easing`          | `cubic-bezier(0.22, 1, 0.36, 1)`    | Easing curve for loader enter/exit transitions                                                  |
-| `--blyrics-scale-transition-duration`         | `0.166s`                             | Transition duration of scale effect                                                             |
-| `--blyrics-lyric-highlight-fade-in-duration`  | `0.33s`       | Controls duration of fade in transition                                                         |
-| `--blyrics-lyric-highlight-fade-out-duration` | `0.5s`        | Controls duration of fade out transition                                                        |
-| `--blyrics-wobble-duration`                   | `1s`          | Controls duration of wobble animation                                                           |
-| `--blyrics-timing-offset`                     | `0.115s`      | Offsets lyrics highlighting for synced lyrics (positive values = lyrics highlighted earlier)    |
-| `--blyrics-richsync-timing-offset`            | `0.02s`       | Offsets highlighting for richsynced lyrics (positive values = lyrics highlighted earlier)       |
-| `--blyrics-scroll-timing-offset`              | `0.5s`        | Offsets the scroll time (positive values = scroll earlier). Applied after other timing offsets. |
+JavaScript controls animation timing with the Web Animations API, but the visual values are CSS variables.
+
+| Variable                                      | Default Value                     | Description                                                                                  |
+| --------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------- |
+| `--blyrics-loader-transition-duration`        | `0.6s`                            | Duration of loader enter/exit transitions                                                    |
+| `--blyrics-loader-transition-easing`          | `cubic-bezier(0.22, 1, 0.36, 1)` | Easing curve for loader enter/exit transitions                                               |
+| `--blyrics-scale-transition-duration`         | `0.166s`                          | Duration of lyric line scale enter/exit                                                      |
+| `--blyrics-line-enter-transform-from`         | `scale(var(--blyrics-scale))`     | Line enter start transform                                                                   |
+| `--blyrics-line-enter-transform-to`           | `scale(var(--blyrics-active-scale))` | Line enter end transform                                                                  |
+| `--blyrics-line-exit-transform-from`          | `scale(var(--blyrics-active-scale))` | Line exit start transform                                                                 |
+| `--blyrics-line-exit-transform-to`            | `scale(var(--blyrics-scale))`     | Line exit end transform                                                                      |
+| `--blyrics-line-enter-easing`                 | `ease`                            | Line enter easing                                                                            |
+| `--blyrics-line-exit-easing`                  | `ease`                            | Line exit easing                                                                             |
+| `--blyrics-lyric-highlight-fade-in-duration`  | `0.33s`                           | Line-synced highlight fade-in duration; rich-sync word-timed highlights become visible instantly |
+| `--blyrics-lyric-highlight-fade-out-duration` | `0.5s`                            | Highlight fade-out duration                                                                  |
+| `--blyrics-lyric-highlight-fade-in-easing`    | `ease`                            | Line-synced highlight fade-in easing                                                         |
+| `--blyrics-lyric-highlight-fade-out-easing`   | `ease`                            | Highlight fade-out easing                                                                    |
+| `--blyrics-highlight-swipe-easing`            | `linear`                          | Rich-sync swipe easing                                                                       |
+| `--blyrics-highlight-swipe-start-from`        | `-0.2`                            | Swipe gradient start value before animation                                                  |
+| `--blyrics-highlight-swipe-end-from`          | `-0.1`                            | Swipe gradient end value before animation                                                    |
+| `--blyrics-highlight-swipe-start-to`          | `1.4`                             | Swipe gradient start value after animation                                                   |
+| `--blyrics-highlight-swipe-end-to`            | `1.5`                             | Swipe gradient end value after animation                                                     |
+| `--blyrics-highlight-glow-filter-from`     | `drop-shadow(0 0 0.8rem var(--blyrics-glow-color))` | Glow start filter                                                   |
+| `--blyrics-highlight-glow-filter-to`       | `drop-shadow(0 0 0 var(--blyrics-glow-color))` | Glow end filter                                                        |
+| `--blyrics-highlight-glow-duration-ratio`     | `1.2`                             | Glow duration multiplier relative to word duration                                           |
+| `--blyrics-highlight-glow-min-duration`       | `1.2s`                            | Minimum glow duration                                                                        |
+| `--blyrics-highlight-glow-easing`             | `ease`                            | Glow easing                                                                                  |
+| `--blyrics-wobble-duration`                   | `1s`                              | Word wobble duration                                                                         |
+| `--blyrics-word-wobble-transform-from`        | `scaleX(1)`                       | Word wobble start transform                                                                  |
+| `--blyrics-word-wobble-transform-peak`        | `translateX(0.05em) scaleX(1.025)` | Word wobble peak transform                                                                  |
+| `--blyrics-word-wobble-transform-settle`      | `translateX(0) scaleX(1)`         | Word wobble settle transform                                                                 |
+| `--blyrics-word-wobble-transform-to`          | `scaleX(1)`                       | Word wobble end transform                                                                    |
+| `--blyrics-word-wobble-peak-offset`           | `0.125`                           | Word wobble peak keyframe offset                                                             |
+| `--blyrics-word-wobble-settle-offset`         | `0.75`                            | Word wobble settle keyframe offset                                                           |
+| `--blyrics-word-wobble-easing`                | `ease`                            | Word wobble animation easing                                                                 |
+| `--blyrics-word-wobble-peak-easing`           | `ease-in-out`                     | Word wobble peak keyframe easing                                                             |
+| `--blyrics-word-wobble-end-easing`            | `ease-out`                        | Word wobble end keyframe easing                                                              |
+| `--blyrics-instrumental-fill-fade-duration`   | `150ms`                           | Instrumental note fill opacity duration                                                      |
+| `--blyrics-instrumental-fill-fade-easing`     | `ease`                            | Instrumental note fill opacity easing                                                        |
+| `--blyrics-instrumental-fill-transform-from`  | `translateY(78%)`                 | Instrumental fill travel start                                                               |
+| `--blyrics-instrumental-fill-transform-to`    | `translateY(-4%)`                 | Instrumental fill travel end                                                                 |
+| `--blyrics-instrumental-fill-easing`          | `linear`                          | Instrumental fill travel easing                                                              |
+| `--blyrics-instrumental-wave-transform-from`  | `scaleY(1.2)`                     | Instrumental wave start transform                                                            |
+| `--blyrics-instrumental-wave-transform-to`    | `scaleY(0.0001)`                  | Instrumental wave end transform                                                              |
+| `--blyrics-instrumental-wave-easing`          | `ease-in`                         | Instrumental wave easing                                                                     |
+| `--blyrics-instrumental-wave-oscillation-duration` | `1.25s`                    | Duration of each instrumental wave surface oscillation loop                                   |
+| `--blyrics-instrumental-wave-oscillation-easing` | `ease-in-out`                  | Easing for the instrumental wave surface oscillation                                          |
+| `--blyrics-line-scroll-duration`              | `750ms`                          | Per-line scroll-triggered translate animation duration                              |
+| `--blyrics-line-scroll-above-duration`        | `calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1) * 10ms)` | Duration for lines above the active line; can use line-scroll input variables       |
+| `--blyrics-line-scroll-below-duration`        | `calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1, 2.71828) * 80ms + var(--blyrics-line-scroll-abs-relative-index) * 20ms)` | Duration for lines below the active line; can use line-scroll input variables      |
+| `--blyrics-line-scroll-timing-function`       | Same as `--blyrics-lyric-scroll-timing-function` | Per-line scroll-triggered translate animation easing                              |
+| `--blyrics-line-scroll-start-easing`          | `--blyrics-line-scroll-timing-function` | Easing attached to the start keyframe                                               |
+| `--blyrics-line-scroll-end-easing`            | `linear`                          | Easing attached to the end keyframe                                                           |
+| `--blyrics-line-scroll-relative-index`        | Set by JS                         | Relative line index during line-scroll animation; active line is `0`, below lines are positive |
+| `--blyrics-line-scroll-abs-relative-index`    | Set by JS                         | Absolute value of `--blyrics-line-scroll-relative-index`                                      |
+| `--blyrics-line-scroll-side`                  | Set by JS                         | Direction-aware side used for side-specific knobs: `above`, `active`, or `below`              |
+| `--blyrics-line-scroll-delta-px`              | Set by JS                         | Signed scroll delta for the autoscroll that triggered the animation                           |
+| `--blyrics-line-scroll-distance-px`           | Set by JS                         | Absolute scroll distance for the autoscroll that triggered the animation                      |
+| `--blyrics-line-scroll-translate-y-start`     | `--blyrics-line-scroll-delta-px`  | Shared per-line scroll animation start Y offset                                              |
+| `--blyrics-line-scroll-translate-y-end`       | `0px`                             | Shared per-line scroll animation end Y offset                                                |
+| `--blyrics-line-scroll-above-translate-y-start` | Shared start value             | Start Y offset for lines above the active line                                               |
+| `--blyrics-line-scroll-below-translate-y-start` | Shared start value             | Start Y offset for lines below the active line                                               |
+| `--blyrics-line-scroll-above-start-easing`    | Shared start easing              | Start keyframe easing for lines above the active line                                        |
+| `--blyrics-line-scroll-below-start-easing`    | Shared start easing              | Start keyframe easing for lines below the active line                                        |
+| `--blyrics-timing-offset`                     | `0.115s`                          | Offsets lyrics highlighting for synced lyrics                                                |
+| `--blyrics-richsync-timing-offset`            | `0.150s`                          | Offsets highlighting for richsynced lyrics                                                   |
+| `--blyrics-scroll-timing-offset`              | `0.5s`                            | Offsets the scroll time after other timing offsets                                           |
+
+Animation effect flags use `1`/`0` values:
+
+| Variable | Default Value | Description |
+| -------- | ------------- | ----------- |
+| `--blyrics-animate-line-scale` | `1` | Enable line scale animation |
+| `--blyrics-animate-word-wobble` | `1` | Enable word wobble animation |
+| `--blyrics-animate-highlight-swipe` | `1` | Enable rich-sync gradient swipe |
+| `--blyrics-animate-highlight-glow` | `1` | Enable highlight glow |
+| `--blyrics-animate-highlight-fade` | `1` | Enable animated line-synced highlight fade and highlight fade-out; rich-sync word-timed fade-in is always instant |
+| `--blyrics-animate-scroll` | `1` | Enable smooth WAAPI scroll animation |
+| `--blyrics-animate-instrumental` | `1` | Enable instrumental fill travel, wave flattening, and wave oscillation |
+
+The default CSS includes a `prefers-reduced-motion: reduce` block that disables the vestibular triggers — zoom-on-active line scale, translateX word wobble, and instrumental fill / wave motion — and flattens the active/inactive scale delta to `1`. Smooth scroll remains enabled as the position indicator for synced lyrics, but the engine suppresses side-specific line-scroll differential effects so every visible line uses the shared scroll duration, easing, and offsets. The karaoke gradient swipe on richsync lyrics and the highlight glow stay on because they are gradient / drop-shadow fills rather than movement; and the line-synced highlight fade-in / highlight fade-out are opacity transitions, not motion.
+
+Scroll smoothing uses per-line `translate` animations. When the lyrics pane autoscrolls, JS finds the lyric lines visible in the previous or current viewport and sets input variables on those lines: `--blyrics-line-scroll-relative-index` (`0` active, positive below, negative above), `--blyrics-line-scroll-abs-relative-index`, `--blyrics-line-scroll-side`, `--blyrics-line-scroll-delta-px`, and `--blyrics-line-scroll-distance-px`. Visible lyric lines also receive inline `will-change: transform, translate` so text rasterization does not shift when a scroll animation starts.
+
+Side-specific knobs are relative to scroll direction. On a downward scroll, lines above the active line use `above` settings and lines below use `below` settings. On an upward scroll, those sides swap so the animation can mirror the movement direction. The numeric `--blyrics-line-scroll-relative-index` does not swap; it always describes real line position, with negative values above the active line and positive values below it.
+
+Configure line-scroll style values with comment-based knobs, not `:root` declarations. JS copies those values onto each animated line before resolving the Web Animation, so formulas that reference per-line variables resolve in the correct line scope. The resolved keyframes are snapshotted before the animation starts, which lets later scrolls update the same line variables without changing animations that are already running.
+
+The default two-keyframe animation starts each visible line at the signed scroll delta and animates it back to `0`. The base scroll gate is `--blyrics-lyric-scroll-duration`, while the default per-line visual tail uses `750ms` plus a side-specific relative-index delay. Lines above the active lyric get a subtle logarithmic tail. Lines below get a stronger logarithmic tail plus a small linear term, so farther trailing lines keep finishing progressively later during larger jumps instead of flattening at a fixed cap.
+
+```css
+/*
+blyrics-line-scroll-translate-y-start = var(--blyrics-line-scroll-delta-px);
+blyrics-line-scroll-translate-y-end = 0px;
+blyrics-line-scroll-duration = 750ms;
+blyrics-line-scroll-start-easing = var(--blyrics-line-scroll-timing-function);
+blyrics-line-scroll-below-duration = calc(
+    750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1, 2.71828) * 80ms +
+      var(--blyrics-line-scroll-abs-relative-index) * 20ms
+  );
+blyrics-line-scroll-above-duration = calc(
+    750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1) * 10ms
+  );
+*/
+```
+
+The engine animates the individual `translate` property instead of `transform`, so this effect can run alongside the existing line-scale transform animation. Per-line scroll effects can overlap: custom line durations may run longer than `--blyrics-lyric-scroll-duration`, but the next autoscroll is gated only by `--blyrics-lyric-scroll-duration`. Overlapping scroll effects are composed with additive Web Animations (`composite: "add"`), so this behavior expects modern browser support for additive `element.animate()` effects.
 
 ### Layout
 
@@ -201,11 +297,10 @@ These custom properties allow for easy customization of colors, sizes, and other
 
 | Variable                                 | Default Value                    | Description                                     |
 | ---------------------------------------- | -------------------------------- | ----------------------------------------------- |
-| `--blyrics-lyric-scroll-duration`³       | `750ms`                          | Duration for scrolling lyric transitions        |
-| `--blyrics-lyric-scroll-timing-function` | `cubic-bezier(0.86, 0, 0.07, 1)` | Timing function for scrolling lyric transitions |
+| `--blyrics-lyric-scroll-duration`³       | `650ms`                          | Duration for scrolling lyric transitions        |
+| `--blyrics-lyric-scroll-timing-function` | `cubic-bezier(0.86, 0, 0.2, 1)`  | Timing function for scrolling lyric transitions |
 
-³Modifying this variable alone may introduce glitches to lyric-scroll animation. To maintain smoothness, you should also adjust  `blyrics-early-scroll-consider-s` +
-`blyrics-queue-scroll-ms` knobs. See [Additional Configuration Options (Knobs)](#additional-configuration-options-knobs) for details.
+³If `blyrics-early-scroll-consider-s` and `blyrics-queue-scroll-ms` are not manually set, they are derived automatically from this duration. See [Additional Configuration Options (Knobs)](#additional-configuration-options-knobs) for details.
 
 ### Gradient Stops
 
@@ -239,7 +334,10 @@ An example may look something like this:
 blyrics-disable-richsync = false;
 blyrics-line-synced-animation-delay = 50; (in ms)
 blyrics-debug-renderer=false;
+blyrics-debug-animation-timing=false;
 blyrics-target-scroll-pos-ratio = 0.37;
+blyrics-swipe-lead-ratio = 0.1;
+blyrics-swipe-duration-ratio = 1.6;
 */
 ```
 
@@ -249,13 +347,16 @@ The following options are avalible:
 
 | Key                                   | Default Value | Description                                                                                                                                |
 | ------------------------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `blyrics-disable-richsync`            | `false`       | Set to `true` to disable richsynced lyrics from displaying.                                                                                |
+| `blyrics-disable-richsync`            | `false`       | Set to `true` to render richsynced lyrics through the line-synced path instead, including zero-duration `.blyrics-line-synced-word` spans and line-synced fade-in. |
 | `blyrics-line-synced-animation-delay` | `50`          | For non-richsynced lyrics, this value controls the delay each word gets when highlighting (in ms).                                         |
 | `blyrics-lyric-ending-threshold-s`    | `0.5`         | Controls the time (in seconds) before a lyric line is finished that we consider it completed for scrolling purposes.                       |
-| `blyrics-early-scroll-consider-s`⁴    | `0.62`        | Controls how far into the future (in seconds) we should look for lines to group together for scrolling purposes.                           |
-| `blyrics-queue-scroll-ms`⁴            | `150`         | If we're unable to scroll due to having scrolled recently, what is the maximum amount of time that a scroll can be "queued" for.           |
+| `blyrics-early-scroll-consider-s`⁴    | Auto (`~0.54` at the default scroll duration) | Controls how far into the future (in seconds) we should look for lines to group together for scrolling purposes.                           |
+| `blyrics-queue-scroll-ms`⁴            | Auto (`~131` at the default scroll duration)  | If we're unable to scroll due to having scrolled recently, what is the maximum amount of time that a scroll can be "queued" for.           |
 | `blyrics-debug-renderer`              | `false`       | Set to `true` to enable the debug renderer.                                                                                                |
+| `blyrics-debug-animation-timing`      | `false`       | Set to `true` to log WAAPI lyric animation timing samples, learned offsets, and timing cleanup events.                                    |
 | `blyrics-target-scroll-pos-ratio`     | `0.37`        | Position on the screen lyrics should be at. 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom. |
+| `blyrics-swipe-lead-ratio`            | `0.1`         | Rich-sync swipe starts this fraction of word duration before the word time.                                                                |
+| `blyrics-swipe-duration-ratio`        | `1.6`         | Rich-sync swipe lasts this multiple of word duration.                                                                                      |
 | `blyrics-long-word-threshold`         | `1500`        | Duration threshold (in ms) above which words get `data-long-word="true"`. Useful for glow effects on held notes.                           |
 | `blyrics-hide-instrumental-only`      | `false`       | Treat "[Instrumental Only]" as no lyrics (enables fullscreen effect).                                                                      |
 | `blyrics-passive-scroll-enabled`          | `true`    | Enable/disable unsynced lyrics auto-scroll entirely. Overrides the user setting when set to `false`.                                       |
@@ -263,13 +364,36 @@ The following options are avalible:
 | `blyrics-passive-scroll-bottom-pause-s`   | `1.5`     | For unsynced lyrics auto-scroll: seconds to pause at the bottom before scrolling back to top.                                              |
 | `blyrics-passive-scroll-reset-duration-s` | `0.6`     | For unsynced lyrics auto-scroll: seconds for the scroll-back-to-top animation.                                                             |
 | `blyrics-passive-scroll-top-pause-s`      | `0.8`     | For unsynced lyrics auto-scroll: seconds to pause at the top before scrolling down again.                                                  |
+| `blyrics-line-scroll-duration`            | `750ms` | Per-line scroll animation duration.                                                                                  |
+| `blyrics-line-scroll-above-duration`      | `calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1) * 10ms)` | Duration for visible lines above the active line.                                                                   |
+| `blyrics-line-scroll-active-duration`     | Inherits line-scroll duration | Duration for the active line.                                                                                        |
+| `blyrics-line-scroll-below-duration`      | `calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 1, 2.71828) * 80ms + var(--blyrics-line-scroll-abs-relative-index) * 20ms)` | Duration for visible lines below the active line.                                                                    |
+| `blyrics-line-scroll-timing-function`     | `var(--blyrics-lyric-scroll-timing-function)` | Shared line-scroll easing.                                                                            |
+| `blyrics-line-scroll-start-easing`        | `var(--blyrics-line-scroll-timing-function)` | Easing attached to the start keyframe.                                                                  |
+| `blyrics-line-scroll-end-easing`          | `linear` | Easing attached to the end keyframe.                                                                                         |
+| `blyrics-line-scroll-above-start-easing`  | Inherits shared start easing | Start keyframe easing for visible lines above the active line.                                                 |
+| `blyrics-line-scroll-active-start-easing` | Inherits shared start easing | Start keyframe easing for the active line.                                                              |
+| `blyrics-line-scroll-below-start-easing`  | Inherits shared start easing | Start keyframe easing for visible lines below the active line.                                                 |
+| `blyrics-line-scroll-above-end-easing`    | Inherits shared end easing | End keyframe easing for visible lines above the active line.                                                   |
+| `blyrics-line-scroll-active-end-easing`   | Inherits shared end easing | End keyframe easing for the active line.                                                                |
+| `blyrics-line-scroll-below-end-easing`    | Inherits shared end easing | End keyframe easing for visible lines below the active line.                                                   |
+| `blyrics-line-scroll-translate-y-start`   | `var(--blyrics-line-scroll-delta-px)` | Shared line-scroll start offset.                                                                       |
+| `blyrics-line-scroll-translate-y-end`     | `0px` | Shared line-scroll end offset.                                                                                         |
+| `blyrics-line-scroll-above-translate-y-start` | Inherits shared start offset | Start offset for visible lines above the active line.                                                        |
+| `blyrics-line-scroll-active-translate-y-start` | Inherits shared start offset | Start offset for the active line.                                                                      |
+| `blyrics-line-scroll-below-translate-y-start` | Inherits shared start offset | Start offset for visible lines below the active line.                                                        |
+| `blyrics-line-scroll-above-translate-y-end` | Inherits shared end offset | End offset for visible lines above the active line.                                                          |
+| `blyrics-line-scroll-active-translate-y-end` | Inherits shared end offset | End offset for the active line.                                                                        |
+| `blyrics-line-scroll-below-translate-y-end` | Inherits shared end offset | End offset for visible lines below the active line.                                                          |
 
-⁴Make sure that the following equation is met
+⁴If neither knob is manually set, both values are derived from `--blyrics-lyric-scroll-duration` using the default timing ratio. Auto-derived queue time is capped at `200ms`.
+
+If one of these knobs is manually set, the other is derived from the equation below. Auto-derived queue time is still capped at `200ms`.
 
 `var(--blyrics-lyric-scroll-duration)` + `0.02s` = `blyrics-early-scroll-consider-s` +
 `blyrics-queue-scroll-ms`
 
-An unbalanced equation may cause dropped frames or missed scrolls. The default values of all three variables are already balanced.
+If both are manually set, keep the equation balanced yourself. An unbalanced equation may cause dropped frames or missed scrolls.
 
 Tip: Pay attention to the units of the values; Some values are in *seconds* (s), while others are in *milliseconds* (ms).
 
@@ -351,7 +475,7 @@ Use `data-loader-visible` to adjust styles when the loader is active:
 
 ## 5. Styling Individual Lyric Lines
 
-Animating lyrics is a multi-step process involving various classes and properties that work together to ensure smooth, timed transitions even if the browser stutters. When a div or span has an active or animating class, it doesn't necessarily mean it's currently "active" or animating. These classes are applied early, and the code later inserts specific animation/transition delays to trigger effects at the correct time.
+Lyric lines are rendered as normal block and inline text so the browser can wrap at natural whitespace. Timed words are still represented by spans, and animation timing is driven by the Web Animations API.
 
 ### Base Structure
 
@@ -359,74 +483,113 @@ The lyrics use a hierarchical structure with specific class names:
 
 - `.blyrics-container` - The main container for all lyrics
 - `.blyrics--line` - Each lyric line (a `<div>`)
+- `.blyrics-line-main` - Main lyric text row inside a line
+- `.blyrics-background-line` - Background vocal row, shown below the main row when background vocals are present
+- `.blyrics-bidi-run` - Inline text-flow wrapper that lets the browser apply native bidi ordering across timed word spans
+- `.blyrics-bidi-sensitive` - Applied to lyric text rows that contain RTL script; changes word wrappers to inline text flow for correct browser bidi and wrapping
+- `.blyrics-word-group` - Word group; syllable-synced parts for one word stay together. It is `inline-block` for LTR-only rows and `display: contents` inside `.blyrics-bidi-sensitive`
 - `.blyrics--word` - Each word within a line (a `<span>`)
-- `.blyrics--break` - Line break elements within a line
-- `.blyrics-background-lyric` - Background vocal elements
+- `.blyrics-word-highlight` - Real highlight overlay used when a long word contains inserted `<wbr>` wrap points
+- `.blyrics-background-lyric` - Background vocal word group or timed word
+
+Example:
+
+```html
+<div class="blyrics--line" data-agent="v1" data-time="10.259" data-duration="10.291">
+  <div class="blyrics-line-main" dir="auto">
+    <span class="blyrics-bidi-run" dir="auto">
+      <span class="blyrics-word-group">
+        <span class="blyrics--word" data-time="10.259" data-duration="0.42" data-content="Hello">Hello</span>
+      </span>
+      text
+    </span>
+  </div>
+  <div class="blyrics-background-line">
+    <span class="blyrics-bidi-run" dir="auto">
+      <span class="blyrics-word-group blyrics-background-lyric">...</span>
+    </span>
+  </div>
+  <div class="blyrics--romanized blyrics-content-line">...</div>
+  <div class="blyrics--translated blyrics-content-line">...</div>
+</div>
+```
 
 ### Base Styling for Each Lyric
 
 ```css
 .blyrics-container > div {
   cursor: pointer;
-  padding-bottom: var(--blyrics-padding) !important;
+  padding: var(--blyrics-padding) 0.25em !important;
+  transform: scale(var(--blyrics-scale));
   transform-origin: left center;
-  word-break: break-word;
 }
 
 .blyrics--line {
-  transform: scale(var(--blyrics-scale));
-  transition-property: transform;
-  transition-duration: var(--blyrics-scale-transition-duration);
-  transition-timing-function: ease;
-  display: flex;
-  flex-flow: row wrap;
-  align-items: start;
-  align-content: flex-start;
-  padding-left: 0.25em;
-  padding-right: 0.25em;
+  color: var(--blyrics-lyric-inactive-color);
+  unicode-bidi: plaintext;
+  white-space: normal;
+}
+
+.blyrics-line-main,
+.blyrics-background-line {
+  display: block;
+  text-align: inherit;
+  unicode-bidi: plaintext;
+  white-space: normal;
+}
+
+.blyrics-word-group {
+  display: inline-block;
+  white-space: nowrap;
+}
+
+.blyrics-bidi-sensitive .blyrics-word-group {
+  display: contents;
+}
+
+.blyrics-bidi-sensitive .blyrics--word {
+  display: inline;
 }
 ```
 
 - **Inactive Scale**: The element is scaled by `--blyrics-scale` for inactive lyrics
-- **Flexbox Layout**: Uses `flex-flow: row wrap` for proper word wrapping
+- **Text Layout**: Uses normal inline text flow, not flexbox or CSS `order`
+- **Word Grouping**: Syllable-synced parts inside a word stay in one `.blyrics-word-group`. In LTR-only rows it is an unbreakable inline box; in RTL-sensitive rows it becomes `display: contents` so browser bidi can order and wrap the line correctly
+- **Background Vocals**: Primary lyric background vocals are moved to `.blyrics-background-line`; timed romanization does not split background parts onto a separate line
 - **Transform Origin**: Set to `left center` for proper scaling animation
 
 ### Activating a Lyric
 
-When a lyric becomes active, the line gets the `.blyrics--animating` class:
+When a lyric becomes active, the line gets `.blyrics--active` for current-line state and its scale is animated with `element.animate()`:
 
 ```css
-.blyrics--line.blyrics--animating {
-  transform: scale(var(--blyrics-active-scale));
-  transition-delay: var(--blyrics-anim-delay);
+.blyrics--active {
+  cursor: default;
 }
 ```
 
-This changes the scale to `--blyrics-active-scale`, triggering the transition defined above.
+The scale animation uses `--blyrics-scale`, `--blyrics-active-scale`, and `--blyrics-scale-transition-duration`. Lyric timing is managed by the Web Animations API.
 
-> **Important**: Use `.blyrics--animating` for styling active lines. Avoid using `.blyrics--active` directly for styling as it causes issues when multiple lyrics are selected.
+> **Important:** Prefer styling stable structure classes and data attributes. The extension may select multiple nearby lines for scrolling, so avoid assumptions that exactly one `.blyrics--active` line exists.
 
 ### Styling Each Word
 
 Every word uses the `.blyrics--word` class:
 
 ```css
-.blyrics--line > span {
-  color: var(--blyrics-lyric-inactive-color);
-  display: inline-block;
-  white-space: pre-wrap;
-}
-
 .blyrics--word {
-  white-space: pre;
-  display: inline-block;
-  transform: translateY(0px);
+  color: var(--blyrics-lyric-inactive-color);
+  position: relative;
+  unicode-bidi: normal;
+  white-space: inherit;
 }
 ```
 
 - **Color**: Set to inactive color initially
-- **Display**: `inline-block` preserves spacing and layout
-- **Transform**: `translateY(0px)` prevents layout issues
+- **Generated Highlight**: Most words use `.blyrics--word::after` for the active overlay
+- **Long Wrapped Words**: Words that need internal `<wbr>` breakpoints use `.blyrics-word-highlight` as a real child overlay so the highlight wraps exactly like the visible text
+- **Line-Synced Words**: Zero-duration line-synced words get `.blyrics-line-synced-word` and fade in without the rich-sync swipe
+- **RTL-Sensitive Words**: Rows containing RTL script use `.blyrics-bidi-sensitive`; their `.blyrics--word` spans compute to `display: inline` and their `.blyrics-word-group` wrappers compute to `display: contents`
 
 #### Word Data Attributes
 
@@ -436,7 +599,7 @@ Each word span has the following data attributes:
 | ---------------- | --------------------------------------------------------------------------- |
 | `data-time`      | Start time of the word in seconds                                           |
 | `data-duration`  | Duration of the word in seconds                                             |
-| `data-content`   | The word text (used by `::after` pseudo-element for karaoke effect)         |
+| `data-content`   | The word text (used by the generated highlight overlay when no real overlay is needed) |
 | `data-long-word` | Present (with value `"true"`) when word duration exceeds the threshold      |
 
 #### Targeting Long Words
@@ -453,20 +616,33 @@ Words with duration exceeding `blyrics-long-word-threshold` (default: 1500ms) ge
 }
 ```
 
+For very long unbroken text, the visible word may contain `<wbr>` and a `.blyrics-word-highlight` child:
+
+```css
+.blyrics-word-highlight {
+  /* real overlay for long wrapped words */
+}
+```
+
 Changing the threshold triggers a lyric reload automatically.
 
 ### Applying the Wobble Animation
 
-When a word is animating, it receives the `.blyrics--animating` class:
+The wobble effect is created by JavaScript with `element.animate()`, but the keyframe values come from CSS variables:
 
 ```css
-.blyrics--word.blyrics--animating {
-  animation: blyrics-wobble var(--blyrics-wobble-duration) forwards ease;
-  animation-delay: var(--blyrics-anim-delay);
+:root {
+  --blyrics-wobble-duration: 1s;
+  --blyrics-word-wobble-transform-from: scaleX(1);
+  --blyrics-word-wobble-transform-peak: translateX(0.05em) scaleX(1.025);
+  --blyrics-word-wobble-transform-settle: translateX(0) scaleX(1);
+  --blyrics-word-wobble-transform-to: scaleX(1);
 }
 ```
 
-Each word gets a unique `--blyrics-anim-delay` custom property to control timing.
+Use `--blyrics-animate-word-wobble: 0` to disable the wobble effect.
+
+> **RTL note:** Word wobble uses CSS transforms on `.blyrics--word`. Rows that contain RTL script are rendered as true inline text (`.blyrics-bidi-sensitive .blyrics--word { display: inline; }`) so the browser can apply the Unicode Bidirectional Algorithm correctly. Transforms do not reliably apply to normal inline text, so word wobble should be treated as unavailable for RTL-sensitive rows.
 
 ### Implementing the Swipe (Karaoke) Transition
 
@@ -493,12 +669,12 @@ Two custom properties control the swipe transition:
 The swipe effect uses each word's `::after` pseudo-element with `background-clip: text`:
 
 ```css
-.blyrics--word::after {
+.blyrics--word::after,
+.blyrics-word-highlight {
   position: absolute;
-  content: attr(data-content);
   top: -2rem;
   left: -2rem;
-  white-space: pre-wrap;
+  white-space: inherit;
   padding: 2rem;
   color: transparent;
   box-sizing: content-box;
@@ -512,60 +688,30 @@ The swipe effect uses each word's `::after` pseudo-element with `background-clip
   );
   background-clip: text;
   opacity: 0;
-  --lyric-transition-amount-start: -0.2;
-  --lyric-transition-amount-end: -0.1;
-  transition: --lyric-transition-amount-start 1s linear 1000s, --lyric-transition-amount-end 1s linear 1000s, opacity 0.5s ease;
+  --lyric-transition-amount-start: var(--blyrics-highlight-swipe-start-from, -0.2);
+  --lyric-transition-amount-end: var(--blyrics-highlight-swipe-end-from, -0.1);
 }
 ```
 
-This creates an overlay using `background-clip: text` with a gradient that reveals the active color progressively, creating the karaoke swipe effect.
+This creates an overlay using `background-clip: text` with a gradient that reveals the active color progressively. Rich-synced words animate the gradient and make the active overlay visible instantly at the word start time; they do not fade in. Line-synced words (`.blyrics-line-synced-word`) skip the gradient swipe and fade the fully highlighted overlay in word by word.
 
-#### Pre-animation States
+#### Timing Model
 
-Before the swipe effect, there's a reset state:
+The swipe and glow are driven by `element.animate()`:
 
-```css
-.blyrics--word.blyrics--pre-animating:not(.blyrics--animating)::after {
-  transition: none;
-  --lyric-transition-amount-start: -0.2;
-  --lyric-transition-amount-end: -0.1;
-  opacity: 0;
-}
-
-.blyrics--word.blyrics--pre-animating:not(.blyrics--animating):not(.blyrics-zero-dur-animate)::after {
-  opacity: 1;
-}
-```
-
-The `.blyrics-zero-dur-animate` class handles cases where there's no swipe animation duration.
-
-#### Final State: Lyric Selection
-
-When a lyric is selected:
-
-```css
-.blyrics--word.blyrics--animating::after {
-  opacity: 1;
-  animation: blyrics-glow max(calc(var(--blyrics-duration) * 1.2), 1.2s) forwards ease;
-  animation-delay: var(--blyrics-anim-delay);
-  --lyric-transition-amount-start: 1.4;
-  --lyric-transition-amount-end: 1.5;
-  transition-property: --lyric-transition-amount-start, --lyric-transition-amount-end, opacity;
-  transition-duration: calc(var(--blyrics-duration) * 1.6), calc(var(--blyrics-duration) * 1.6), var(--blyrics-lyric-highlight-fade-in-duration);
-  transition-timing-function: linear, linear, ease;
-  transition-delay: var(--blyrics-swipe-delay), var(--blyrics-swipe-delay), var(--blyrics-anim-delay);
-}
-```
-
-This creates the final swipe and glow effects synchronized with the music. Note the use of `--blyrics-swipe-delay` and `--blyrics-anim-delay` custom properties for precise timing control.
-
-`--blyrics-anim-delay` = the time until this lyric highlights
-`--blyrics-swipe-delay` = (the time until this lyric highlights) - 0.1 * (lyric duration)
+- Rich-sync swipe starts at `wordStart - blyrics-swipe-lead-ratio * wordDuration`
+- Rich-sync swipe duration is `blyrics-swipe-duration-ratio * wordDuration`
+- With the default ratios, the swipe reaches the end of the word at `wordStart + wordDuration`; the remaining `0.5 * wordDuration` is the tail moving past the word
+- Rich-sync word-timed opacity becomes visible instantly at `wordStart`; `--blyrics-lyric-highlight-fade-in-duration` is not used for rich-sync fade-in
+- Line-synced opacity fade-in starts at its generated word time and uses `--blyrics-lyric-highlight-fade-in-duration`
+- Glow starts at `wordStart` and lasts `max(wordDuration * --blyrics-highlight-glow-duration-ratio, --blyrics-highlight-glow-min-duration)`
+- Fade-out uses `--blyrics-lyric-highlight-fade-out-duration`
+- `--blyrics-animate-highlight-swipe: 0` keeps rich-sync timing in JS but makes each word fully highlighted instantly at `wordStart` instead of moving the gradient
 
 
 ## 6. Creating Animation Effects
 
-The CSS defines several keyframe animations:
+Most lyric timing uses the Web Animations API, but the same conceptual effects remain:
 
 ```css
 @keyframes blyrics-wobble {
@@ -618,6 +764,8 @@ These animations create:
 - **blyrics-glow**: Drop shadow glow effect that fades out (uses `filter: drop-shadow` for better compatibility with `background-clip: text`)
 - **blyrics-spin**: Rotating animation for the loading spinner
 - **blyrics-shimmer**: Shimmer animation for loading text
+
+Theme authors should prefer CSS variables and stable structural selectors. The default line scale, word swipe, word glow, instrumental fill, and lyric scroll smoothing are all run with `element.animate()`.
 
 ## 7. Modifying YouTube Music's Layout
 
@@ -882,9 +1030,21 @@ The `[blyrics-dfs]` attribute allows users to disable fullscreen styling if pref
 .blyrics-rtl {
   direction: rtl;
 }
+
+.blyrics-bidi-sensitive .blyrics-word-group {
+  display: contents;
+}
+
+.blyrics-bidi-sensitive .blyrics--word {
+  display: inline;
+}
 ```
 
-The `.blyrics-rtl` class is applied to lyrics containers when RTL language content is detected, ensuring proper text direction for languages like Arabic or Hebrew.
+The `.blyrics-rtl` class is applied when RTL language content is detected, ensuring proper text direction for languages like Arabic or Hebrew. Timed lyric text is also wrapped in `.blyrics-bidi-run`, an inline wrapper that preserves logical DOM order while allowing the browser's Unicode Bidirectional Algorithm to decide visual order and line wrapping.
+
+When a text row contains RTL script, the row also receives `.blyrics-bidi-sensitive`. In that mode, `.blyrics-word-group` becomes `display: contents` and `.blyrics--word` becomes normal inline text. This is intentional: `inline-block` word boxes make each RTL word correct internally but can make the word sequence render in the wrong order. Do not reverse DOM order for RTL lyrics; that breaks wrapping and timing. Use normal logical order and let browser bidi layout produce the visual order.
+
+Because RTL-sensitive word spans are inline, transform-based word wobble does not apply reliably on those rows. Highlight timing, glow, swipe, click seeking, and line selection still use the same timed `.blyrics--word` elements.
 
 ### Agent-Based Alignment
 
@@ -893,7 +1053,6 @@ For multi-voice lyrics (duets, conversations), the `data-agent` attribute contro
 ```css
 .blyrics--line[data-agent="v2"],
 .blyrics--line[data-agent="v3"] {
-  justify-content: flex-end;
   text-align: right;
   transform-origin: right center !important;
 }
@@ -906,7 +1065,7 @@ For multi-voice lyrics (duets, conversations), the `data-agent` attribute contro
 | `data-agent="v3"`    | Tertiary voice (right-aligned)                       |
 | `data-agent="v1000"` | Both speakers simultaneously (duet/chorus, centered) |
 
-This right-aligns secondary voices (v2, v3) while the primary voice (v1) remains left-aligned, creating a visual conversation layout. When both speakers sing simultaneously (v1000), the lyrics are centered.
+This right-aligns secondary voices (v2, v3) while the primary voice (v1) remains left-aligned, creating a visual conversation layout. When both speakers sing simultaneously (v1000), the lyrics are centered. The lyric layout does not use flexbox; use `text-align` and `transform-origin` for agent-specific alignment.
 
 ## 12. Adding a Watermark
 
@@ -1040,7 +1199,7 @@ This CSS feature query detects when ThemeSong is active and adjusts the layout a
 }
 ```
 
-Provides distinct styling for translated lyrics and romanized text, with romanized text getting a subtle background container.
+Provides distinct styling for translated lyrics and romanized text, with romanized text getting a subtle background container. If romanization is timed, it can contain the same `.blyrics-line-main`, `.blyrics-word-group`, and `.blyrics--word` structure as the primary lyric line, but background parts are not split into a separate `.blyrics-background-line` inside romanization.
 
 ## 17. Instrumental Breaks
 
@@ -1054,6 +1213,7 @@ Better Lyrics detects instrumental breaks (intros, outros, and mid-song gaps) an
     <defs>
       <filter id="blyrics-glow-...">...</filter>
       <clipPath id="blyrics-wave-clip-..." class="blyrics--wave-clip">
+        <path class="blyrics--wave-rect" d="..." />
         <path class="blyrics--wave-path" d="..." />
       </clipPath>
     </defs>
@@ -1080,29 +1240,14 @@ Better Lyrics detects instrumental breaks (intros, outros, and mid-song gaps) an
 | `.blyrics--instrumental-bg`   | Background path of the music note (uses inactive color)            |
 | `.blyrics--instrumental-fill` | Fill path of the music note (uses active color)                    |
 | `.blyrics--wave-clip`         | ClipPath for the fill animation                                    |
-| `.blyrics--wave-path`         | Animated wave path inside the clip                                 |
+| `.blyrics--wave-rect`         | Static lower block of the fill clip                                |
+| `.blyrics--wave-path`         | Animated wavy top edge inside the clip                             |
 
 ### Instrumental Animation
 
-The instrumental break uses two keyframe animations:
+When the note becomes active, the engine fades in `.blyrics--instrumental-fill`, moves `.blyrics--wave-clip` upward to fill the note, flattens `.blyrics--wave-path` over the break duration, and runs a looping wave-surface `d` path animation on `.blyrics--wave-path`.
 
-```css
-/* Wave animation - continuous oscillation */
-@keyframes blyrics-wave {
-  0%, 100% {
-    d: path("M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 30 L -4 30 Z");
-  }
-  50% {
-    d: path("M -4 3 Q 1 4 5 3 Q 10 2 14 3 Q 18 4 22 3 Q 26 2 30 3 L 30 30 L -4 30 Z");
-  }
-}
-
-/* Rise animation - fills the icon from bottom to top */
-@keyframes blyrics-rise {
-  0% { transform: translateY(80%); }
-  100% { transform: translateY(-10%); }
-}
-```
+Use `--blyrics-instrumental-fill-transform-*` for the fill travel, `--blyrics-instrumental-wave-transform-*` for the wave flattening, and `--blyrics-instrumental-wave-oscillation-duration` / `--blyrics-instrumental-wave-oscillation-easing` for the visible wave loop.
 
 ### Styling Instrumental Breaks
 

--- a/biome.json
+++ b/biome.json
@@ -35,6 +35,13 @@
       "correctness": { "noUnusedVariables": "error" }
     }
   },
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "off"
+      }
+    }
+  },
   "javascript": {
     "formatter": {
       "jsxQuoteStyle": "double",

--- a/knip.json
+++ b/knip.json
@@ -13,11 +13,8 @@
     "src/core/generated/locales.ts"
   ],
   "project": ["src/**/*.ts", "public/**/*.js"],
-  "ignore": ["src/types/**"],
   "ignoreDependencies": [
     "@codemirror/language",
-    "@plasmohq/edge-addons-api",
-    "@types/chrome",
     "@typescript/lib-dom"
   ],
   "ignoreIssues": {

--- a/public/css/blyrics/instrumental.css
+++ b/public/css/blyrics/instrumental.css
@@ -62,25 +62,17 @@
 	transform: translateY(100%) !important;
 }
 
-
-/* Setup the Wavy Path Transition */
 .blyrics--wave-path {
-	/* Set the transform origin to the bottom of the wave shape (y=4) */
+	/* Set the transform origin to the bottom of the wave shape (y=4). */
 	transform-box: fill-box;
 	transform-origin: bottom;
 
-	/* Wiggle animation (indefinite) */
-	animation: blyrics-wave 1.25s ease-in-out infinite;
-	animation-play-state: paused;
-
-	/* Prepare the flatten transition */
+	/* Prepare the WAAPI flatten transition. */
 	transform: scaleY(1.2);
 }
 
 /* Trigger the Flattening */
 .blyrics--instrumental.blyrics--animating:not(.blyrics--paused) .blyrics--wave-path {
-	animation-play-state: running;
-
 	/* Flatten the wave to 0 height */
 	transform: scaleY(0);
 

--- a/public/css/blyrics/lyrics.css
+++ b/public/css/blyrics/lyrics.css
@@ -5,127 +5,120 @@
 	font-weight: var(--blyrics-font-weight);
 	isolation: isolate;
 	line-height: var(--blyrics-line-height);
-	position: relative !important;
-	z-index: 1;
-  will-change: transform;
-  transition: transform var(--blyrics-lyric-scroll-duration)
-		var(--blyrics-lyric-scroll-timing-function) 0s;
-	padding-top: 2rem;
 	padding-bottom: calc(var(--blyrics-padding-bottom));
+	padding-top: 2rem;
+	position: relative !important;
+	transition: transform var(--blyrics-lyric-scroll-duration)
+		var(--blyrics-lyric-scroll-timing-function) 0s;
+	will-change: transform;
+	z-index: 1;
 }
 
 .blyrics-container > div {
+	box-sizing: border-box;
 	cursor: pointer;
-	padding-bottom: var(--blyrics-padding) !important;
+	padding: var(--blyrics-padding) 0.25em !important;
+	transform: scale(var(--blyrics-scale));
 	transform-origin: left center;
-	word-break: break-word;
-}
-
-.blyrics-container > div,
-.blyrics-container > div:first-child {
-	padding-top: var(--blyrics-padding) !important;
 }
 
 .blyrics--active {
 	cursor: default;
 }
 
-:not(.blyrics-background-lyric) {
-	order: 0;
-}
-
-.blyrics-background-lyric {
-	order: 2;
-}
-
-.blyrics--line > span > span.blyrics-background-lyric {
-	font-size: 0.75em;
-	font-weight: 500;
-}
-
 .blyrics--line {
-	transform: scale(var(--blyrics-scale));
-	transition-property: transform;
-	transition-duration: var(--blyrics-scale-transition-duration);
-	transition-timing-function: ease;
-	display: flex;
-	flex-flow: row wrap;
-	align-items: start;
-	align-content: flex-start;
-	padding-left: 0.25em;
-	padding-right: 0.25em;
-	margin-right: -0.25em;
-	box-sizing: border-box;
-  will-change: transform;
-}
-
-.blyrics--line.blyrics--animating {
-	transform: scale(var(--blyrics-active-scale));
-	transition-delay: var(--blyrics-anim-delay);
-}
-
-.blyrics--line > span {
 	color: var(--blyrics-lyric-inactive-color);
-	display: inline-block;
-	white-space: pre-wrap;
+	max-width: 100%;
+	unicode-bidi: plaintext;
+	white-space: normal;
+	word-break: normal;
 }
 
-.blyrics--has-trailing-space{
-	margin-right: 0.25em;
+.blyrics-line-main {
+	display: block;
+	max-width: 100%;
+	overflow-wrap: normal;
+	text-align: inherit;
+	unicode-bidi: plaintext;
+	white-space: normal;
+}
+
+.blyrics-background-line {
+	display: block;
+	margin-top: 0.1em;
+	max-width: 100%;
+	text-align: inherit;
+	unicode-bidi: plaintext;
+	white-space: normal;
+}
+
+.blyrics-bidi-run {
+	display: inline;
+	max-width: 100%;
+	unicode-bidi: normal;
+	white-space: inherit;
+}
+
+.blyrics-word-group {
+	display: inline-block;
+	max-width: 100%;
+	unicode-bidi: normal;
+	vertical-align: baseline;
+	white-space: nowrap;
+}
+
+.blyrics-word-group-long {
+	display: inline;
+	overflow-wrap: anywhere;
+	white-space: normal;
+	word-break: break-word;
 }
 
 .blyrics--word {
-	white-space: pre;
+	color: var(--blyrics-lyric-inactive-color);
+	display: inline;
+	position: relative;
+	transform: translateY(0);
+	unicode-bidi: normal;
+	white-space: inherit;
+}
+
+.blyrics-word-group:not(.blyrics-word-group-long) .blyrics--word {
 	display: inline-block;
-	transform: translateY(0px);
 }
 
-
-[blyrics-alt-hover] .blyrics--word:hover {
-	text-decoration: underline;
-	text-underline-offset: 0.15em;
+.blyrics-bidi-sensitive .blyrics-word-group,
+.blyrics-bidi-sensitive .blyrics-word-group-long {
+	display: contents;
+	max-width: none;
+	overflow-wrap: normal;
+	unicode-bidi: normal;
+	white-space: normal;
+	word-break: normal;
 }
 
-.blyrics--break {
-	flex-basis: 100%;
-	height: 0;
-}
-
-.blyrics--word.blyrics--animating {
-	animation: blyrics-wobble var(--blyrics-wobble-duration) forwards ease;
-  will-change: transform;
-	animation-delay: var(--blyrics-anim-delay);
-	animation-play-state: running;
-}
-
-.blyrics--word.blyrics--animating.blyrics--paused {
-	animation-play-state: paused;
+.blyrics-bidi-sensitive .blyrics--word,
+.blyrics-bidi-sensitive .blyrics-word-group:not(.blyrics-word-group-long) .blyrics--word {
+	display: inline;
+	unicode-bidi: normal;
+	white-space: inherit;
 }
 
 @property --lyric-transition-amount-start {
 	syntax: "<number>";
 	inherits: false;
-	initial-value: 0;
+	initial-value: -0.2;
 }
 
 @property --lyric-transition-amount-end {
 	syntax: "<number>";
 	inherits: false;
-	initial-value: 0;
+	initial-value: -0.1;
 }
 
-.blyrics--word::after {
-	position: absolute;
-	content: attr(data-content);
-	top: -2rem;
-	left: -2rem;
-	white-space: pre-wrap;
-	padding: 2rem;
-	pointer-events: none;
-	/*color: var(--blyrics-lyric-active-color);*/
+.blyrics--word::after,
+.blyrics-word-highlight {
 	color: transparent;
-	box-sizing: content-box;
-	width: 100%;
 	background-image: linear-gradient(
 		90deg,
 		var(--blyrics-lyric-active-color)
@@ -139,97 +132,40 @@
 					var(--lyric-transition-amount-end) + 2rem + 1px
 			)
 	);
-	opacity: 0;
-	--lyric-transition-amount-start: -0.2;
-	--lyric-transition-amount-end: -0.1;
-  will-change: background-image;
-	transition:
-		--lyric-transition-amount-start 1s linear 1000s,
-		--lyric-transition-amount-end 1s linear 1000s,
-		opacity 0.5s ease;
 	background-clip: text;
-}
-
-.blyrics--word.blyrics--pre-animating:not(.blyrics--animating)::after {
-	/*The transition is purposely very long for the background position when we deselect a lyric, so here we need to reset the background position
-    to zero so that the lyric is in a valid state for the karaoke transition to play*/
-	transition: none;
-	--lyric-transition-amount-start: -0.2;
-	--lyric-transition-amount-end: -0.1;
+	box-sizing: content-box;
+	filter: drop-shadow(0 0 0 var(--blyrics-glow-color));
+	left: -2rem;
 	opacity: 0;
+	padding: 2rem;
+	pointer-events: none;
+	position: absolute;
+	top: -2rem;
+	white-space: inherit;
+	width: 100%;
+	--lyric-transition-amount-start: var(
+		--blyrics-highlight-swipe-start-from,
+		-0.2
+	);
+	--lyric-transition-amount-end: var(--blyrics-highlight-swipe-end-from, -0.1);
 }
 
-.blyrics--word.blyrics--pre-animating:not(.blyrics--animating):not(
-		.blyrics-zero-dur-animate
-	)::after {
-	opacity: 1;
+.blyrics--word::after {
+	content: attr(data-content);
 }
 
-.blyrics--word.blyrics--animating::after {
-	opacity: 1;
-	animation: blyrics-glow max(calc(var(--blyrics-duration) * 1.2), 1.2s)
-		forwards ease;
-  will-change: filter;
-	animation-delay: var(--blyrics-anim-delay);
-	animation-play-state: running;
-
-	--lyric-transition-amount-start: 1.4;
-	--lyric-transition-amount-end: 1.5;
-	transition-property:
-		--lyric-transition-amount-start, --lyric-transition-amount-end, opacity;
-	transition-duration:
-		calc(var(--blyrics-duration) * 1.6), calc(var(--blyrics-duration) * 1.6),
-		var(--blyrics-lyric-highlight-fade-in-duration);
-	transition-timing-function: linear, linear, ease;
-	transition-delay:
-		var(--blyrics-swipe-delay), var(--blyrics-swipe-delay),
-		var(--blyrics-anim-delay);
+.blyrics-word-highlight {
+	user-select: none;
 }
 
-.blyrics--word.blyrics--animating.blyrics--paused::after {
-	transition-duration: 100000000s, 100000000s, 100000000s;
-	/* Set new values to update the transition */
-	--lyric-transition-amount-start: 10;
-	--lyric-transition-amount-end: 10;
-	opacity: 0.5;
-	animation-play-state: paused;
+.blyrics--word:has(.blyrics-word-highlight)::after {
+	content: none;
 }
 
-.blyrics--translated,
-.blyrics--romanized {
-	display: block;
-	font-size: var(--blyrics-translated-font-size);
-	font-weight: var(--blyrics-translated-font-weight);
-	font-family: var(--blyrics-translated-font-family);
-	color: var(--blyrics-translated-color);
-	white-space: normal;
-	line-height: 1.1;
-	margin-top: 8px;
-}
-
-.blyrics--romanized > span {
-	color: var(--blyrics-lyric-inactive-color);
-	display: inline-block;
-	white-space: pre-wrap;
-}
-
-/* Romanization */
-.blyrics--romanized {
-	/* font-style: italic; */
-	width: fit-content;
-	padding-block: 1rem;
-	font-size: calc(var(--blyrics-translated-font-size) / 1.25);
-	background: rgba(255, 255, 255, 0.05);
-	padding: 0.375rem 0.75rem;
-	border: 1px solid rgba(255, 255, 255, 0.1);
-	border-radius: 1rem;
-}
-
-.blyrics-rtl {
-	direction: rtl;
-}
-
-.blyrics-rtl.blyrics--word::after {
+.blyrics-rtl.blyrics--word::after,
+.blyrics--word.blyrics-rtl::after,
+.blyrics-rtl .blyrics-word-highlight,
+.blyrics--word.blyrics-rtl .blyrics-word-highlight {
 	background-image: linear-gradient(
 		270deg,
 		var(--blyrics-lyric-active-color)
@@ -245,48 +181,94 @@
 	);
 }
 
+[blyrics-alt-hover] .blyrics--word:hover {
+	text-decoration: underline;
+	text-underline-offset: 0.15em;
+}
+
+.blyrics--line > .blyrics-line-main > .blyrics-background-lyric,
+.blyrics--line > .blyrics-background-line > .blyrics-background-lyric,
+.blyrics--line > .blyrics-line-main > .blyrics-bidi-run > .blyrics-background-lyric,
+.blyrics--line > .blyrics-background-line > .blyrics-bidi-run > .blyrics-background-lyric {
+	font-size: 0.75em;
+	font-weight: 500;
+}
+
+.blyrics--line > .blyrics-line-main > .blyrics-word-group.blyrics-background-lyric,
+.blyrics--line > .blyrics-background-line > .blyrics-word-group.blyrics-background-lyric,
+.blyrics--line > .blyrics-line-main > .blyrics-bidi-run > .blyrics-word-group.blyrics-background-lyric,
+.blyrics--line > .blyrics-background-line > .blyrics-bidi-run > .blyrics-word-group.blyrics-background-lyric {
+	color: color-mix(in srgb, var(--blyrics-lyric-inactive-color) 78%, transparent);
+}
+
+.blyrics-explicit {
+	text-decoration: line-through;
+	text-decoration-thickness: 0.08em;
+}
+
+.blyrics--translated,
+.blyrics--romanized {
+	color: var(--blyrics-translated-color);
+	display: block;
+	font-family: var(--blyrics-translated-font-family);
+	font-size: var(--blyrics-translated-font-size);
+	font-weight: var(--blyrics-translated-font-weight);
+	line-height: 1.1;
+	margin-top: 8px;
+	max-width: 100%;
+	text-align: inherit;
+	unicode-bidi: plaintext;
+	white-space: normal;
+}
+
+.blyrics--romanized {
+	background: rgba(255, 255, 255, 0.05);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 1rem;
+	box-sizing: border-box;
+	display: block;
+	font-size: calc(var(--blyrics-translated-font-size) / 1.25);
+	padding: 0.375rem 0.75rem;
+	width: fit-content;
+}
+
+.blyrics--romanized .blyrics-line-main {
+	display: inline;
+}
+
+.blyrics-rtl {
+	direction: rtl;
+}
+
+.blyrics--line[data-direction="rtl"] {
+	text-align: right;
+	transform-origin: right center;
+}
+
 /* Secondary and tertiary vocals */
 .blyrics--line[data-agent="v2"],
 .blyrics--line[data-agent="v3"] {
-  justify-content: flex-end;
-  text-align: right;
-  transform-origin: right center !important;
+	text-align: right;
+	transform-origin: right center !important;
 }
 
 /* All vocals together */
 .blyrics--line[data-agent="v1000"] {
-	justify-content: center;
 	text-align: center;
 	transform-origin: center center !important;
 }
 
+.blyrics--line[data-agent="v2"] .blyrics--romanized,
+.blyrics--line[data-agent="v3"] .blyrics--romanized,
+.blyrics--line[data-direction="rtl"] .blyrics--romanized {
+	margin-left: auto;
+}
+
+.blyrics--line[data-agent="v1000"] .blyrics--romanized {
+	margin-left: auto;
+	margin-right: auto;
+}
+
 #blyrics-wrapper {
 	margin-top: 0;
-}
-
-/* Animations */
-@keyframes blyrics-wobble {
-	0% {
-		transform: scaleX(1);
-	}
-	12.5% {
-		transform: translateX(0.05em) scaleX(1.025);
-		animation-timing-function: ease-in-out;
-	}
-	75% {
-		transform: translateX(0) scaleX(1);
-	}
-	100% {
-		transform: scaleX(1);
-		animation-timing-function: ease-out;
-	}
-}
-
-@keyframes blyrics-glow {
-	0% {
-		filter: drop-shadow(0 0 0.8rem var(--blyrics-glow-color));
-	}
-	to {
-		filter: drop-shadow(0 0 0rem var(--blyrics-glow-color));
-	}
 }

--- a/public/css/blyrics/variables.css
+++ b/public/css/blyrics/variables.css
@@ -63,12 +63,27 @@
 	--blyrics-footer-font-weight: 400;
 
 	/* Animations */
+	--blyrics-animate-line-scale: 1;
+	--blyrics-animate-word-wobble: 1;
+	--blyrics-animate-highlight-swipe: 1;
+	--blyrics-animate-highlight-glow: 1;
+	--blyrics-animate-highlight-fade: 1;
+	--blyrics-animate-scroll: 1;
+	--blyrics-animate-instrumental: 1;
+
 	--blyrics-loader-transition-duration: 0.6s;
 	--blyrics-loader-transition-easing: cubic-bezier(0.22, 1, 0.36, 1);
 	--blyrics-scale-transition-duration: var(
 		--blyrics-transition-duration,
 		0.166s
 	);
+	--blyrics-line-enter-transform-from: scale(var(--blyrics-scale));
+	--blyrics-line-enter-transform-to: scale(var(--blyrics-active-scale));
+	--blyrics-line-exit-transform-from: scale(var(--blyrics-active-scale));
+	--blyrics-line-exit-transform-to: scale(var(--blyrics-scale));
+	--blyrics-line-enter-easing: ease;
+	--blyrics-line-exit-easing: ease;
+
 	--blyrics-lyric-highlight-fade-in-duration: var(
 		--blyrics-opacity-transition,
 		0.33s
@@ -77,7 +92,44 @@
 		--blyrics-opacity-transition,
 		0.5s
 	);
+	--blyrics-lyric-highlight-fade-in-easing: ease;
+	--blyrics-lyric-highlight-fade-out-easing: ease;
+	--blyrics-highlight-swipe-easing: linear;
+	--blyrics-highlight-swipe-start-from: -0.2;
+	--blyrics-highlight-swipe-end-from: -0.1;
+	--blyrics-highlight-swipe-start-to: 1.4;
+	--blyrics-highlight-swipe-end-to: 1.5;
+	--blyrics-highlight-glow-filter-from: drop-shadow(
+		0 0 0.8rem var(--blyrics-glow-color)
+	);
+	--blyrics-highlight-glow-filter-to: drop-shadow(
+		0 0 0 var(--blyrics-glow-color)
+	);
+	--blyrics-highlight-glow-duration-ratio: 1.2;
+	--blyrics-highlight-glow-min-duration: 1.2s;
+	--blyrics-highlight-glow-easing: ease;
+
 	--blyrics-wobble-duration: 1s;
+	--blyrics-word-wobble-transform-from: scaleX(1);
+	--blyrics-word-wobble-transform-peak: translateX(0.05em) scaleX(1.025);
+	--blyrics-word-wobble-transform-settle: translateX(0) scaleX(1);
+	--blyrics-word-wobble-transform-to: scaleX(1);
+	--blyrics-word-wobble-peak-offset: 0.125;
+	--blyrics-word-wobble-settle-offset: 0.75;
+	--blyrics-word-wobble-easing: ease;
+	--blyrics-word-wobble-peak-easing: ease-in-out;
+	--blyrics-word-wobble-end-easing: ease-out;
+
+	--blyrics-instrumental-fill-fade-duration: 150ms;
+	--blyrics-instrumental-fill-fade-easing: ease;
+	--blyrics-instrumental-fill-transform-from: translateY(78%);
+	--blyrics-instrumental-fill-transform-to: translateY(-4%);
+	--blyrics-instrumental-fill-easing: linear;
+	--blyrics-instrumental-wave-transform-from: scaleY(1.2);
+	--blyrics-instrumental-wave-transform-to: scaleY(0.0001);
+	--blyrics-instrumental-wave-easing: ease-in;
+	--blyrics-instrumental-wave-oscillation-duration: 1.25s;
+	--blyrics-instrumental-wave-oscillation-easing: ease-in-out;
 
 	/* Layout */
 	--blyrics-padding: 2rem;
@@ -96,11 +148,11 @@
 	/* Lyric Transition Properties */
 	--blyrics-lyric-scroll-duration: var(
 		--blyrics-lyric-transition-duration,
-		750ms
+		650ms
 	);
 	--blyrics-lyric-scroll-timing-function: var(
 		--blyrics-lyric-transition-timing-function,
-		cubic-bezier(0.86, 0, 0.07, 1)
+		cubic-bezier(0.86, 0, 0.2, 1)
 	);
 
 	/* Gradient stops */
@@ -119,4 +171,22 @@
     	var(--blyrics-ui-text-color) 50%,
     	color-mix(in srgb, var(--blyrics-ui-text-color) 50%, transparent) 70%
   	);
+}
+
+/* Reduced-motion disables the vestibular triggers (zoom-on-active line scale,
+   translateX word wobble, and instrumental fill/wave motion) and flattens the
+   active/inactive scale delta. Smooth scroll remains enabled, but the animation
+   engine suppresses side-specific line-scroll differential effects.
+   Everything else is left on by design:
+     - karaoke swipe + highlight glow: gradient mask / drop-shadow fills, not movement.
+     - highlight fade-in / fade-out: opacity transitions are not motion. */
+@media (prefers-reduced-motion: reduce) {
+	:root {
+		--blyrics-animate-line-scale: 0;
+		--blyrics-animate-word-wobble: 0;
+		--blyrics-animate-instrumental: 0;
+
+		--blyrics-scale: 1;
+		--blyrics-active-scale: 1;
+	}
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -8,12 +8,8 @@ export const CURRENT_LYRICS_CLASS = "blyrics--active" as const;
 export const ZERO_DURATION_ANIMATION_CLASS = "blyrics-zero-dur-animate" as const;
 export const RTL_CLASS = "blyrics-rtl" as const;
 export const WORD_CLASS = "blyrics--word" as const;
-export const HAS_TRAILING_SPACE_CLASS = "blyrics--has-trailing-space" as const;
 export const BACKGROUND_LYRIC_CLASS = "blyrics-background-lyric" as const;
 export const EXPLICIT_WORD_CLASS = "blyrics-explicit" as const;
-export const ANIMATING_CLASS = "blyrics--animating" as const;
-export const PAUSED_CLASS = "blyrics--paused" as const;
-export const PRE_ANIMATING_CLASS = "blyrics--pre-animating" as const;
 export const USER_SCROLLING_CLASS = "blyrics-user-scrolling" as const;
 export const TRANSLATED_LYRICS_CLASS = "blyrics--translated" as const;
 export const ROMANIZED_LYRICS_CLASS = "blyrics--romanized" as const;
@@ -170,8 +166,6 @@ export const PROVIDER_SWITCHED_LOG = "[BetterLyrics] Switching to provider = " a
 export const LYRICS_TAB_HIDDEN_LOG =
   "[BetterLyrics] (Safe to ignore) Lyrics tab is hidden, skipping lyrics fetch" as const;
 export const LYRICS_TAB_CLICKED_LOG = "[BetterLyrics] Lyrics tab clicked, fetching lyrics" as const;
-export const LYRICS_WRAPPER_NOT_VISIBLE_LOG =
-  "[BetterLyrics] (Safe to ignore) Lyrics wrapper is not visible, unable to inject lyrics" as const;
 export const LYRICS_WRAPPER_CREATED_LOG = "[BetterLyrics] Lyrics wrapper created" as const;
 export const FOOTER_NOT_VISIBLE_LOG =
   "[BetterLyrics] (Safe to ignore) Footer is not visible, unable to inject source link" as const;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -31,6 +31,18 @@ export function truncateSource(source: string): string {
   return source.slice(0, LOG_SOURCE_MAX_LENGTH) + `... (${source.length} chars total)`;
 }
 
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function positiveModulo(value: number, divisor: number): number {
+  return ((value % divisor) + divisor) % divisor;
+}
+
+export function roundedMs(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
 /**
  * Returns the position and dimensions of a child element relative to its parent.
  *
@@ -38,10 +50,38 @@ export function truncateSource(source: string): string {
  * @param child - The child element
  * @returns Rectangle with relative position and dimensions
  */
-export function getRelativeBounds(parent: Element, child: Element): DOMRect {
+function getRelativeBounds(parent: Element, child: Element): DOMRect {
   const parentBound = parent.getBoundingClientRect();
   const childBound = child.getBoundingClientRect();
   return new DOMRect(childBound.x - parentBound.x, childBound.y - parentBound.y, childBound.width, childBound.height);
+}
+
+/**
+ * Returns layout position/dimensions without including transient CSS transforms.
+ * This is important for lyric scroll math because line-scale and per-line scroll
+ * animations are transform based.
+ */
+export function getRelativeLayoutBounds(parent: HTMLElement, child: HTMLElement): DOMRect {
+  let x = 0;
+  let y = 0;
+  let element: HTMLElement | null = child;
+
+  while (element && element !== parent) {
+    x += element.offsetLeft;
+    y += element.offsetTop;
+    element = element.offsetParent as HTMLElement | null;
+  }
+
+  if (element !== parent) {
+    return getRelativeBounds(parent, child);
+  }
+
+  return new DOMRect(
+    x,
+    y,
+    Math.max(child.offsetWidth, child.scrollWidth),
+    Math.max(child.offsetHeight, child.scrollHeight)
+  );
 }
 
 /**

--- a/src/modules/lyrics/createInstrumentalElement.ts
+++ b/src/modules/lyrics/createInstrumentalElement.ts
@@ -1,12 +1,16 @@
 /**
  * Creates an HTML element representing an instrumental break in the lyrics.
  *
+ * @param container - Element to place instrumental parts into
  * @param durationMs - Duration of the instrumental break in milliseconds
  * @param lineIndex - Line index for unique SVG element IDs
  * @returns HTMLDivElement representing the instrumental break
  */
-export function createInstrumentalElement(durationMs: number, lineIndex: number): HTMLDivElement {
-  const container = document.createElement("div");
+export function createInstrumentalElement(
+  container: HTMLDivElement,
+  durationMs: number,
+  lineIndex: number
+): HTMLDivElement {
   container.classList.add("blyrics--instrumental");
   container.style.setProperty("--blyrics-duration", `${durationMs}ms`);
 

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -1,13 +1,11 @@
 import {
   BACKGROUND_LYRIC_CLASS,
   EXPLICIT_WORD_CLASS,
-  HAS_TRAILING_SPACE_CLASS,
   LOG_PREFIX,
   LYRICS_CLASS,
   LYRICS_FOUND_LOG,
   LYRICS_TAB_NOT_DISABLED_LOG,
   LYRICS_WRAPPER_ID,
-  LYRICS_WRAPPER_NOT_VISIBLE_LOG,
   NO_LYRICS_FOUND_LOG,
   NO_LYRICS_TEXT_SELECTOR,
   ROMANIZATION_LANGUAGES,
@@ -26,7 +24,6 @@ import { createInstrumentalElement } from "@modules/lyrics/createInstrumentalEle
 import { containsNonLatin, detectNonLatinLanguage, testRtl } from "@modules/lyrics/lyricParseUtils";
 import { applySegmentMapToLyrics, type LyricSourceResultWithMeta } from "@modules/lyrics/lyrics";
 import type { Lyric, LyricPart } from "@modules/lyrics/providers/shared";
-import type { UnisonData } from "@modules/lyrics/providers/unison";
 import {
   getRomanizationFromCache,
   getTranslationFromCache,
@@ -45,12 +42,26 @@ import {
   renderLoader,
   setExtraHeight,
 } from "@modules/ui/dom";
-import { getRelativeBounds, langCodesMatch, languageMatchesAny, log } from "@utils";
+import { getRelativeLayoutBounds, langCodesMatch, languageMatchesAny, log } from "@utils";
 
 let disableRichsync = registerThemeSetting("blyrics-disable-richsync", false, true);
 let lineSyncedAnimationDelay = registerThemeSetting("blyrics-line-synced-animation-delay", 50, true);
 let longWordThreshold = registerThemeSetting("blyrics-long-word-threshold", 1500, true);
-let longWordWrapThreshold = registerThemeSetting("blyrics-long-word-wrap-threshold", 5, true);
+let longWordWrapThreshold = registerThemeSetting("blyrics-long-word-wrap-threshold", 10, true);
+
+const LINE_MAIN_CLASS = "blyrics-line-main";
+const BACKGROUND_LINE_CLASS = "blyrics-background-line";
+const LINE_SYNCED_WORD_CLASS = "blyrics-line-synced-word";
+export const WORD_HIGHLIGHT_CLASS = "blyrics-word-highlight";
+const WORD_GROUP_CLASS = "blyrics-word-group";
+const LONG_WORD_GROUP_CLASS = "blyrics-word-group-long";
+const BIDI_RUN_CLASS = "blyrics-bidi-run";
+const BIDI_SENSITIVE_CLASS = "blyrics-bidi-sensitive";
+const CONTENT_LINE_CLASS = "blyrics-content-line";
+const RTL_SCRIPT_REGEX = /[\p{Script=Arabic}\p{Script=Hebrew}\p{Script=Syriac}\p{Script=Thaana}]/u;
+const LTR_SCRIPT_REGEX =
+  /[\p{Script=Latin}\p{Script=Greek}\p{Script=Cyrillic}\p{Script=Han}\p{Script=Hangul}\p{Script=Hiragana}\p{Script=Katakana}]/u;
+const SPACE_REGEX = /^\s+$/u;
 
 function isRomanizationDisabledForLang(lang: string): boolean {
   return languageMatchesAny(lang, AppState.romanizationDisabledLanguages);
@@ -61,12 +72,13 @@ function isTranslationDisabledForLang(lang: string): boolean {
 }
 
 function findNearestAgent(lyrics: Lyric[], fromIndex: number): string | undefined {
-  for (let i = fromIndex - 1; i >= 0; i--) {
+  // Look in the downwards direction first
+  for (let i = fromIndex + 1; i < lyrics.length; i++) {
     if (!lyrics[i].isInstrumental && lyrics[i].agent) {
       return lyrics[i].agent;
     }
   }
-  for (let i = fromIndex + 1; i < lyrics.length; i++) {
+  for (let i = fromIndex - 1; i >= 0; i--) {
     if (!lyrics[i].isInstrumental && lyrics[i].agent) {
       return lyrics[i].agent;
     }
@@ -75,12 +87,13 @@ function findNearestAgent(lyrics: Lyric[], fromIndex: number): string | undefine
 }
 
 function isNearestLyricRtl(lyrics: Lyric[], fromIndex: number): boolean {
-  for (let i = fromIndex - 1; i >= 0; i--) {
+  // Look in the downwards direction first
+  for (let i = fromIndex + 1; i < lyrics.length; i++) {
     if (!lyrics[i].isInstrumental && lyrics[i].words?.trim()) {
       return testRtl(lyrics[i].words);
     }
   }
-  for (let i = fromIndex + 1; i < lyrics.length; i++) {
+  for (let i = fromIndex - 1; i >= 0; i--) {
     if (!lyrics[i].isInstrumental && lyrics[i].words?.trim()) {
       return testRtl(lyrics[i].words);
     }
@@ -128,7 +141,7 @@ export interface PartData {
    */
   duration: number;
   lyricElement: HTMLElement;
-  animationStartTimeMs: number;
+  animations: Animation[];
 }
 
 export type LineData = {
@@ -154,6 +167,34 @@ export interface LyricsData {
   tabSelector: HTMLElement;
   lyricsContainer: HTMLElement;
   hasNonLatin: boolean;
+}
+
+type SpaceToken = {
+  kind: "space";
+};
+
+type PartToken = {
+  kind: "part";
+  part: LyricPart;
+};
+
+type RenderToken = {
+  text: string;
+} & (SpaceToken | PartToken);
+
+type PartialPartToken = {
+  kind: "part";
+  part: Omit<LyricPart, "durationMs" | "startTimeMs">;
+};
+
+type PartialRenderToken = {
+  text: string;
+} & (SpaceToken | PartialPartToken);
+
+interface WordGroup {
+  text: string;
+  isBackground: boolean;
+  tokens: RenderToken[];
 }
 
 /**
@@ -189,193 +230,366 @@ export function processLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible
   injectLyrics(data, keepLoaderVisible, signal);
 }
 
-const TRAILING_ATTACHED_PUNCT_REGEX = /^[\p{Pe}\p{Pf}\p{Po}]+$/u;
-
-/**
- * Fallback for issue #307: split a part whose core text exceeds the wrap threshold into smaller
- * sub-parts at natural word boundaries (via Intl.Segmenter). This creates wrap opportunities for
- * unbroken runs such as SEA-language lyrics. Duration is distributed linearly across sub-parts.
- */
-function splitLongPart(part: LyricPart, threshold: number): LyricPart[] {
-  let segments: string[];
-  try {
-    const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
-    segments = Array.from(segmenter.segment(part.words), s => s.segment);
-  } catch {
-    segments = Array.from(part.words);
-  }
-
-  // Combine punctuation with previous words
-  segments = segments.reduce((acc, curr) => {
-    if (acc.length > 0 && TRAILING_ATTACHED_PUNCT_REGEX.test(curr)) {
-      acc[acc.length - 1] += curr;
-    } else {
-      acc.push(curr);
-    }
-    return acc;
-  }, [] as string[]);
-
-  const totalChars = part.words.length;
-  const subParts: LyricPart[] = [];
-  let charsBefore = 0;
-  for (let i = 0; i < segments.length; i++) {
-    const chunk = segments[i];
-    const subStart = part.startTimeMs + Math.round((part.durationMs * charsBefore) / totalChars);
-    const subEnd =
-      i === segments.length - 1
-        ? part.startTimeMs + part.durationMs
-        : part.startTimeMs + Math.round((part.durationMs * (charsBefore + chunk.length)) / totalChars);
-    subParts.push({
-      startTimeMs: subStart,
-      durationMs: subEnd - subStart,
-      words: chunk,
-      isBackground: part.isBackground,
-      explicit: part.explicit,
-    });
-    charsBefore += chunk.length;
-  }
-  return subParts;
+function newPartData(part: LyricPart, span: HTMLElement): PartData {
+  return {
+    time: part.startTimeMs / 1000,
+    duration: part.durationMs / 1000,
+    lyricElement: span,
+    animations: [],
+  };
 }
 
-function createLyricsLine(parts: LyricPart[], line: LineData, lyricElement: HTMLDivElement) {
-  // To add rtl elements in reverse to the dom
-  let rtlBuffer: HTMLSpanElement[] = [];
-  let isAllRtl = true;
+function newLineData(lyricElement: HTMLElement, startTimeMs: number, durationMs: number): LineData {
+  return {
+    lyricElement,
+    time: startTimeMs / 1000,
+    duration: durationMs / 1000,
+    parts: [],
+    isScrolled: false,
+    isAnimationPlayStatePlaying: false,
+    accumulatedOffsetMs: 0,
+    isAnimating: false,
+    lastAnimSetupAt: 0,
+    isSelected: false,
+    height: -1,
+    position: -1,
+    animations: [],
+  };
+}
 
-  let lyricElementsBuffer = [] as HTMLSpanElement[];
-  let lastEmittedSpan: HTMLSpanElement | null = null;
-  const wrapThreshold = longWordWrapThreshold.getNumberValue();
+function detectDirection(text: string): "rtl" | "ltr" | "auto" {
+  for (const char of text) {
+    if (RTL_SCRIPT_REGEX.test(char)) return "rtl";
+    if (LTR_SCRIPT_REGEX.test(char)) return "ltr";
+  }
+  return "auto";
+}
 
-  parts = parts.flatMap(original => {
-    const parts = original.words.match(/^(\s*)([\s\S]*?)(\s*)$/u);
-    let returnArray: LyricPart[] = [];
-    if (parts && parts.length > 0) {
-      const beginWhitespace = parts[1];
-      const core = parts[2];
-      const endWhitespace = parts[3];
-      if (core.length === 0) {
-        return [original];
-      }
+function applyDirection(element: HTMLElement, text: string): void {
+  const direction = detectDirection(text);
+  element.dir = "auto";
+  if (direction === "rtl") {
+    element.classList.add(RTL_CLASS);
+    element.dataset.direction = "rtl";
+  } else if (direction === "ltr") {
+    element.dataset.direction = "ltr";
+  }
+}
 
-      if (beginWhitespace.length > 0) {
-        returnArray.push({
-          startTimeMs: original.startTimeMs,
-          words: beginWhitespace,
-          durationMs: 0,
-          explicit: original.explicit,
-          isBackground: original.isBackground,
-        });
-      }
-      returnArray.push({
-        startTimeMs: original.startTimeMs,
-        words: core,
-        durationMs: original.durationMs,
-        explicit: original.explicit,
-        isBackground: original.isBackground,
-      });
-      if (endWhitespace.length > 0) {
-        returnArray.push({
-          startTimeMs: original.startTimeMs + original.durationMs,
-          words: endWhitespace,
-          durationMs: 0,
-          explicit: original.explicit,
-          isBackground: original.isBackground,
-        });
-      }
+function applyBidiSensitivity(element: HTMLElement, text: string): void {
+  if (testRtl(text)) {
+    element.classList.add(BIDI_SENSITIVE_CLASS);
+  }
+}
+
+function splitPartIntoTokens(part: LyricPart): RenderToken[] {
+  const chunks = part.words.match(/\s+|\S+/gu) ?? [];
+
+  if (chunks.length === 0) return [];
+
+  const tokens: PartialRenderToken[] = [];
+
+  let spaceChars = 0;
+  for (const chunk of chunks) {
+    if (SPACE_REGEX.test(chunk)) {
+      tokens.push({ kind: "space", text: chunk });
+      spaceChars += chunk.length;
+      continue;
     }
-    return returnArray;
-  });
 
-  parts.forEach(originalPart => {
-    if (originalPart.words.trim().length === 0) {
-      if (lastEmittedSpan) {
-        lastEmittedSpan.classList.add(HAS_TRAILING_SPACE_CLASS);
-      }
-      return;
-    }
+    tokens.push({
+      kind: "part",
+      text: chunk,
+      part: {
+        words: chunk,
+        isBackground: part.isBackground,
+        explicit: part.explicit,
+      },
+    });
+  }
 
-    const subParts = splitLongPart(originalPart, wrapThreshold);
-
-    subParts.forEach((part, subIdx) => {
-      const isLastSub = subIdx === subParts.length - 1;
-      let isRtl = testRtl(part.words);
-      if (!isRtl && part.words.trim().length > 0) {
-        isAllRtl = false;
-        rtlBuffer.reverse().forEach(p => {
-          lyricElementsBuffer.push(p);
-        });
-        rtlBuffer = [];
-      }
-
-      let span = document.createElement("span");
-      span.classList.add(WORD_CLASS);
-      if (part.durationMs === 0) {
-        span.classList.add(ZERO_DURATION_ANIMATION_CLASS);
-      }
-      if (isRtl) {
-        span.classList.add(RTL_CLASS);
-      }
-
-      let partData: PartData = {
-        time: part.startTimeMs / 1000,
-        duration: part.durationMs / 1000,
-        lyricElement: span,
-        animationStartTimeMs: Infinity,
+  const nonWhiteSpaceChars = part.words.length - spaceChars;
+  let cursor = 0;
+  return tokens.map(t => {
+    if (t.kind === "part") {
+      const startTimeMs = part.startTimeMs + Math.round((part.durationMs * cursor) / nonWhiteSpaceChars);
+      const endTimeMs =
+        part.startTimeMs + Math.round((part.durationMs * (cursor + t.text.length)) / nonWhiteSpaceChars);
+      cursor += t.text.length;
+      return {
+        ...t,
+        part: {
+          ...t.part,
+          startTimeMs,
+          durationMs: endTimeMs - startTimeMs,
+        },
       };
-
-      span.textContent = part.words;
-      span.dataset.time = String(partData.time);
-      span.dataset.duration = String(partData.duration);
-      span.dataset.content = part.words;
-      span.style.setProperty("--blyrics-duration", part.durationMs + "ms");
-      if (part.durationMs > longWordThreshold.getNumberValue()) {
-        span.dataset.longWord = "true";
-      }
-      if (part.isBackground) {
-        span.classList.add(BACKGROUND_LYRIC_CLASS);
-      }
-      if (part.explicit) {
-        span.classList.add(EXPLICIT_WORD_CLASS);
-      }
-
-      // Non-final sub-parts signal a group-flush (wrap opportunity) without a trailing-space
-      // visual gap — the original text was contiguous.
-      if (!isLastSub) {
-        span.dataset.wrapAfter = "true";
-      }
-
-      line.parts.push(partData);
-
-      if (isRtl) {
-        rtlBuffer.push(span);
-      } else {
-        lyricElementsBuffer.push(span);
-      }
-
-      lastEmittedSpan = span;
-    });
+    }
+    return t;
   });
+}
 
-  //Add remaining rtl elements
-  if (isAllRtl && rtlBuffer.length > 0) {
-    lyricElement.classList.add(RTL_CLASS);
-    rtlBuffer.forEach(part => {
-      lyricElementsBuffer.push(part);
+function normalizeParts(parts: LyricPart[]): RenderToken[] {
+  return parts.flatMap(splitPartIntoTokens);
+}
+
+function groupTokensByWord(tokens: RenderToken[]): (WordGroup | RenderToken)[] {
+  const groups: (WordGroup | RenderToken)[] = [];
+  let current: WordGroup | null = null;
+
+  const flush = () => {
+    if (current && current.tokens.length > 0) {
+      groups.push(current);
+    }
+    current = null;
+  };
+
+  for (const token of tokens) {
+    if (token.kind === "space") {
+      flush();
+      groups.push(token);
+      continue;
+    }
+
+    const isBackground = token.part?.isBackground === true;
+    if (!current || current.isBackground !== isBackground) {
+      flush();
+      current = { text: "", isBackground, tokens: [] };
+    }
+
+    current.text += token.text;
+    current.tokens.push(token);
+  }
+
+  flush();
+  return groups;
+}
+
+function appendLongWordBreaks(span: HTMLElement, text: string, threshold: number): boolean {
+  if (text.length <= threshold) {
+    span.textContent = text;
+    return false;
+  }
+
+  for (let i = 0; i < text.length; i += threshold) {
+    span.appendChild(document.createTextNode(text.slice(i, i + threshold)));
+    if (i + threshold < text.length) {
+      span.appendChild(document.createElement("wbr"));
+    }
+  }
+  return true;
+}
+
+function cloneTextWithBreaks(source: HTMLElement): DocumentFragment {
+  const fragment = document.createDocumentFragment();
+  for (const node of source.childNodes) {
+    fragment.appendChild(node.cloneNode(true));
+  }
+  return fragment;
+}
+
+function createTimedWordSpan(part: LyricPart, wrapThreshold: number): HTMLSpanElement {
+  const span = document.createElement("span");
+  span.classList.add(WORD_CLASS);
+  span.dir = "auto";
+
+  if (part.durationMs === 0) {
+    span.classList.add(ZERO_DURATION_ANIMATION_CLASS);
+    span.classList.add(LINE_SYNCED_WORD_CLASS);
+  }
+  if (testRtl(part.words)) {
+    span.classList.add(RTL_CLASS);
+  }
+  if (part.durationMs > longWordThreshold.getNumberValue()) {
+    span.dataset.longWord = "true";
+  }
+  if (part.isBackground) {
+    span.classList.add(BACKGROUND_LYRIC_CLASS);
+  }
+  if (part.explicit) {
+    span.classList.add(EXPLICIT_WORD_CLASS);
+  }
+
+  const hasBreaks = appendLongWordBreaks(span, part.words, wrapThreshold);
+  if (hasBreaks) {
+    const highlight = document.createElement("span");
+    highlight.classList.add(WORD_HIGHLIGHT_CLASS);
+    highlight.setAttribute("aria-hidden", "true");
+    highlight.appendChild(cloneTextWithBreaks(span));
+    span.appendChild(highlight);
+  }
+  span.dataset.time = String(part.startTimeMs / 1000);
+  span.dataset.duration = String(part.durationMs / 1000);
+  span.dataset.content = part.words;
+  span.style.setProperty("--blyrics-duration", part.durationMs + "ms");
+  return span;
+}
+
+function createWordGroup(group: WordGroup, lineData: LineData): HTMLElement {
+  const wrapThreshold = Math.max(1, longWordWrapThreshold.getNumberValue());
+  const groupElement = document.createElement("span");
+  groupElement.classList.add(WORD_GROUP_CLASS);
+  groupElement.dir = "auto";
+  groupElement.dataset.content = group.text;
+
+  if (group.text.length > wrapThreshold * 2) {
+    groupElement.classList.add(LONG_WORD_GROUP_CLASS);
+  }
+
+  if (group.isBackground) {
+    groupElement.classList.add(BACKGROUND_LYRIC_CLASS);
+  }
+
+  for (const token of group.tokens) {
+    if (token.kind === "space") continue;
+
+    const span = createTimedWordSpan(token.part, wrapThreshold);
+    lineData.parts.push(newPartData(token.part, span));
+    groupElement.appendChild(span);
+  }
+
+  return groupElement;
+}
+
+function createContentLine(className: string, text: string): HTMLDivElement {
+  const line = document.createElement("div");
+  line.classList.add(className);
+  applyDirection(line, text);
+  applyBidiSensitivity(line, text);
+  return line;
+}
+
+function createBidiRun(text: string): HTMLSpanElement {
+  const run = document.createElement("span");
+  run.classList.add(BIDI_RUN_CLASS);
+  applyDirection(run, text);
+  return run;
+}
+
+function createLyricsLine(
+  parts: LyricPart[],
+  line: LineData,
+  lyricElement: HTMLElement,
+  options: { splitBackgroundLine: boolean } = { splitBackgroundLine: true }
+): HTMLElement {
+  const lineText = parts.map(part => part.words).join("");
+  const mainText = options.splitBackgroundLine
+    ? parts
+        .filter(part => part.isBackground !== true)
+        .map(part => part.words)
+        .join("")
+    : lineText;
+  const backgroundText = parts
+    .filter(part => part.isBackground === true)
+    .map(part => part.words)
+    .join("");
+  const main = createContentLine(LINE_MAIN_CLASS, mainText);
+  const mainRun = createBidiRun(mainText);
+  const groupedTokens = groupTokensByWord(normalizeParts(parts));
+  const backgroundLine = createContentLine(BACKGROUND_LINE_CLASS, backgroundText);
+  const backgroundRun = createBidiRun(backgroundText);
+  let hasBackground = false;
+  let pendingForegroundSpace = "";
+  let pendingBackgroundSpace = "";
+
+  main.appendChild(mainRun);
+  backgroundLine.appendChild(backgroundRun);
+
+  for (const item of groupedTokens) {
+    if ("kind" in item) {
+      // Is a RenderToken, not a WordGroup, only whitespace should enter this path
+      pendingForegroundSpace += item.text;
+      pendingBackgroundSpace += item.text;
+    } else {
+      const shouldUseBackgroundLine = options.splitBackgroundLine && item.isBackground;
+      const target = shouldUseBackgroundLine ? backgroundRun : mainRun;
+      const pendingSpace = shouldUseBackgroundLine ? pendingBackgroundSpace : pendingForegroundSpace;
+      if (target.childNodes.length > 0 && pendingSpace.length > 0) {
+        target.appendChild(document.createTextNode(pendingSpace));
+      }
+      target.appendChild(createWordGroup(item, line));
+      if (shouldUseBackgroundLine) {
+        hasBackground = true;
+        pendingBackgroundSpace = "";
+      } else {
+        pendingForegroundSpace = "";
+      }
+    }
+  }
+
+  lyricElement.appendChild(main);
+  if (hasBackground) {
+    lyricElement.appendChild(backgroundLine);
+  }
+  return main;
+}
+
+function buildLineSyncedParts(item: Lyric): LyricPart[] {
+  const parts: LyricPart[] = [];
+  const tokens = item.words.match(/\s+|\S+/gu) ?? [];
+  let wordIndex = 0;
+
+  for (const token of tokens) {
+    const isSpace = SPACE_REGEX.test(token);
+    const startTimeMs = item.startTimeMs + wordIndex * lineSyncedAnimationDelay.getNumberValue();
+    parts.push({
+      startTimeMs,
+      words: token,
+      durationMs: 0,
     });
-  } else if (rtlBuffer.length > 0) {
-    rtlBuffer.reverse().forEach(part => {
-      lyricElementsBuffer.push(part);
+
+    if (!isSpace) {
+      wordIndex += 1;
+    }
+  }
+
+  return parts;
+}
+
+function getSeekTimeFromClick(event: MouseEvent, lyricElement: HTMLElement): number | null {
+  const target = event.target as HTMLElement;
+  const container = lyricElement.closest(`.${LYRICS_CLASS}`) as HTMLElement | null;
+  const isRichsync = container?.dataset.sync === "richsync";
+
+  if (!isRichsync || !event.altKey) {
+    return parseFloat(lyricElement.dataset.time || "0");
+  }
+
+  let wordElement = target.closest(`.${WORD_CLASS}`) as HTMLElement | null;
+
+  if (!wordElement) {
+    const words = lyricElement.querySelectorAll(`.${WORD_CLASS}`);
+    let closestDist = Infinity;
+    words.forEach(word => {
+      const rect = word.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const dist = Math.hypot(event.clientX - centerX, event.clientY - centerY);
+      if (dist < closestDist) {
+        closestDist = dist;
+        wordElement = word as HTMLElement;
+      }
     });
   }
 
-  groupByWordAndInsert(lyricElement, lyricElementsBuffer);
+  if (!wordElement) return null;
+  return parseFloat(wordElement.dataset.time || "0");
 }
 
-function createBreakElem(lyricElement: HTMLElement, order: number) {
-  let breakElm: HTMLSpanElement = document.createElement("span");
-  breakElm.classList.add("blyrics--break");
-  breakElm.style.order = String(order);
-  lyricElement.appendChild(breakElm);
+function addSeekHandler(lyricElement: HTMLElement, allZero: boolean): void {
+  if (allZero) {
+    lyricElement.style.cursor = "unset";
+    return;
+  }
+
+  lyricElement.addEventListener("click", event => {
+    const seekTime = getSeekTimeFromClick(event, lyricElement);
+    if (seekTime === null) return;
+
+    log(LOG_PREFIX, `Seeking to ${seekTime.toFixed(2)}s`);
+    document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: seekTime }));
+    animEngineState.scrollResumeTime = 0;
+  });
 }
 
 /**
@@ -420,163 +634,54 @@ function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible = false
   let lines: LineData[] = [];
   let syncType: SyncType = allZero ? "none" : "synced";
 
-  // Pre-process all lines and add to DOM
-  lyrics.forEach((lyricItem, lineIndex) => {
-    if (lyricItem.isInstrumental) {
-      const instrumentalElement = createInstrumentalElement(lyricItem.durationMs, lineIndex);
-      instrumentalElement.classList.add("blyrics--line");
-      instrumentalElement.dataset.time = String(lyricItem.startTimeMs / 1000);
-      instrumentalElement.dataset.duration = String(lyricItem.durationMs / 1000);
-      instrumentalElement.dataset.lineNumber = String(lineIndex);
-      instrumentalElement.dataset.instrumental = "true";
-
-      const agent = findNearestAgent(lyrics, lineIndex);
-      if (agent) {
-        instrumentalElement.dataset.agent = agent;
-      }
-
-      if (isNearestLyricRtl(lyrics, lineIndex)) {
-        instrumentalElement.classList.add(RTL_CLASS);
-      }
-
-      if (!allZero) {
-        const seekTime = lyricItem.startTimeMs / 1000;
-        instrumentalElement.addEventListener("click", () => {
-          log(LOG_PREFIX, `Seeking to ${seekTime.toFixed(2)}s`);
-          document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: seekTime }));
-          animEngineState.scrollResumeTime = 0;
-        });
-      }
-
-      const line: LineData = {
-        lyricElement: instrumentalElement,
-        time: lyricItem.startTimeMs / 1000,
-        duration: lyricItem.durationMs / 1000,
-        parts: [],
-        isScrolled: false,
-        animationStartTimeMs: Infinity,
-        isAnimationPlayStatePlaying: false,
-        accumulatedOffsetMs: 0,
-        isAnimating: false,
-        lastAnimSetupAt: 0,
-        isSelected: false,
-        height: -1,
-        position: -1,
-      };
-
-      lines.push(line);
-      lyricsContainer.appendChild(instrumentalElement);
-      return;
-    }
-
-    if (!lyricItem.parts) {
-      lyricItem.parts = [];
-    }
-
-    let item = lyricItem as Required<Pick<Lyric, "parts">> & Lyric;
-
-    if (item.parts.length === 0 || disableRichsync.getBooleanValue()) {
-      lyricItem.parts = [];
-      const words = item.words.split(" ");
-
-      words.forEach((word, index) => {
-        word = word.trim().length < 1 ? word : word;
-        item.parts.push({
-          startTimeMs: item.startTimeMs + index * lineSyncedAnimationDelay.getNumberValue(),
-          words: word,
-          durationMs: 0,
-        });
-        item.parts.push({
-          startTimeMs: item.startTimeMs + index * lineSyncedAnimationDelay.getNumberValue(),
-          words: " ",
-          durationMs: 0,
-        });
-      });
-    }
-
-    if (!item.parts.every(part => part.durationMs === 0)) {
-      syncType = "richsync";
-    }
-
+  for (const [lineIndex, lyricItem] of lyrics.entries()) {
     let lyricElement = document.createElement("div");
-    lyricElement.classList.add("blyrics--line");
-
-    let line: LineData = {
-      lyricElement: lyricElement,
-      time: item.startTimeMs / 1000,
-      duration: item.durationMs / 1000,
-      parts: [],
-      isScrolled: false,
-      animationStartTimeMs: Infinity,
-      isAnimationPlayStatePlaying: false,
-      accumulatedOffsetMs: 0,
-      isAnimating: false,
-      lastAnimSetupAt: 0,
-      isSelected: false,
-      height: -1,
-      position: -1,
-    };
-
-    createLyricsLine(item.parts, line, lyricElement);
-    createBreakElem(lyricElement, 1);
+    const line = newLineData(lyricElement, lyricItem.startTimeMs, lyricItem.durationMs);
 
     lyricElement.dataset.time = String(line.time);
     lyricElement.dataset.duration = String(line.duration);
     lyricElement.dataset.lineNumber = String(lineIndex);
-    lyricElement.style.setProperty("--blyrics-duration", item.durationMs + "ms");
-    if (item.agent) {
-      lyricElement.dataset.agent = item.agent;
-    }
-
-    if (!allZero) {
-      lyricElement.addEventListener("click", e => {
-        const target = e.target as HTMLElement;
-        const container = lyricElement.closest(`.${LYRICS_CLASS}`) as HTMLElement | null;
-        const isRichsync = container?.dataset.sync === "richsync";
-
-        let seekTime: number;
-        if (isRichsync) {
-          if (e.altKey) {
-            let wordElement = target.closest(`.${WORD_CLASS}`) as HTMLElement | null;
-
-            if (!wordElement) {
-              const words = lyricElement.querySelectorAll(`.${WORD_CLASS}`);
-              let closestDist = Infinity;
-              words.forEach(word => {
-                const rect = word.getBoundingClientRect();
-                const centerX = rect.left + rect.width / 2;
-                const centerY = rect.top + rect.height / 2;
-                const dist = Math.hypot(e.clientX - centerX, e.clientY - centerY);
-                if (dist < closestDist) {
-                  closestDist = dist;
-                  wordElement = word as HTMLElement;
-                }
-              });
-            }
-
-            if (!wordElement) return;
-            seekTime = parseFloat(wordElement.dataset.time || "0");
-          } else {
-            seekTime = parseFloat(lyricElement.dataset.time || "0");
-          }
-        } else {
-          seekTime = parseFloat(lyricElement.dataset.time || "0");
-        }
-
-        log(LOG_PREFIX, `Seeking to ${seekTime.toFixed(2)}s`);
-        document.dispatchEvent(new CustomEvent("blyrics-seek-to", { detail: seekTime }));
-        animEngineState.scrollResumeTime = 0;
-      });
-    } else {
-      lyricElement.style.cursor = "unset";
-    }
-
+    lyricElement.classList.add("blyrics--line");
+    lyricElement.dir = "auto";
+    addSeekHandler(lyricElement, allZero);
     lines.push(line);
-    lyricsContainer.appendChild(lyricElement);
-  });
 
-  // Handle Translations and Romanizations in Batch
-  processBatchTranslationsAndRomanizations(data, lines, isStale, signal);
+    if (lyricItem.isInstrumental) {
+      createInstrumentalElement(lyricElement, lyricItem.durationMs, lineIndex);
+      lyricElement.dataset.instrumental = "true";
+
+      const agent = findNearestAgent(lyrics, lineIndex);
+      if (agent) {
+        lyricElement.dataset.agent = agent;
+      }
+
+      if (isNearestLyricRtl(lyrics, lineIndex)) {
+        lyricElement.classList.add(RTL_CLASS);
+        lyricElement.dataset.direction = "rtl";
+      }
+
+      lyricsContainer.appendChild(lyricElement);
+      continue;
+    }
+
+    if (!lyricItem.parts || lyricItem.parts.length === 0 || disableRichsync.getBooleanValue()) {
+      lyricItem.parts = buildLineSyncedParts(lyricItem);
+    }
+
+    if (!lyricItem.parts.every(part => part.durationMs === 0)) {
+      syncType = "richsync";
+    }
+
+    applyDirection(lyricElement, lyricItem.words);
+    createLyricsLine(lyricItem.parts, line, lyricElement);
+
+    lyricElement.style.setProperty("--blyrics-duration", lyricItem.durationMs + "ms");
+    if (lyricItem.agent) {
+      lyricElement.dataset.agent = lyricItem.agent;
+    }
+
+    lyricsContainer.appendChild(lyricElement);
+  }
 
   animEngineState.skipScrolls = 2;
   animEngineState.skipScrollsDecayTimes = [];
@@ -585,9 +690,15 @@ function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible = false
   }
   animEngineState.scrollResumeTime = 0;
 
+  lyricsContainer.dataset.sync = syncType;
+  lyricsContainer.dataset.loaderVisible = String(keepLoaderVisible);
+  if (lyrics[0].words === t("lyrics_notFound")) {
+    lyricsContainer.dataset.noLyrics = "true";
+  }
+
   const tabSelector = document.getElementsByClassName(TAB_HEADER_CLASS)[1] as HTMLElement;
 
-  let lyricsData = {
+  let lyricsData: LyricsData = {
     lines: lines,
     syncType: syncType,
     lyricWidth: lyricsContainer.clientWidth,
@@ -598,15 +709,11 @@ function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible = false
     hasNonLatin: lyrics.some(item => !!item.words && containsNonLatin(item.words)),
   };
 
-  if (data.segmentMap) {
-    applySegmentMapToLyrics(lyricsData, data.segmentMap);
-  }
+  // Set before addFooter so the dock controls read the current song's lyric data.
+  AppState.lyricData = lyricsData;
 
   if (lyrics[0].words !== t("lyrics_notFound")) {
-    // Set before addFooter so the dock controls read the current song's lyric data.
-    AppState.lyricData = lyricsData;
-    const unisonData =
-      data.source === "Unison" && "unisonData" in data ? (data as { unisonData: UnisonData }).unisonData : undefined;
+    const unisonData = data.source === "Unison" && "unisonData" in data ? data.unisonData : undefined;
     addFooter(
       data.source,
       data.sourceHref,
@@ -620,14 +727,13 @@ function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible = false
       syncType === "none"
     );
   } else {
-    AppState.lyricData = null;
     addNoLyricsButton(data.song, data.artist, data.album, data.duration, data.videoId);
   }
 
-  lyricsContainer.dataset.sync = syncType;
-  lyricsContainer.dataset.loaderVisible = String(keepLoaderVisible);
-  if (lyrics[0].words === t("lyrics_notFound")) {
-    lyricsContainer.dataset.noLyrics = "true";
+  void processBatchTranslationsAndRomanizations(data, lines, isStale, signal);
+
+  if (data.segmentMap) {
+    applySegmentMapToLyrics(lyricsData, data.segmentMap);
   }
 
   AppState.areLyricsTicking = true;
@@ -658,6 +764,7 @@ async function processBatchTranslationsAndRomanizations(
   const translationBatch: { index: number; text: string }[] = [];
 
   let sourceLanguage = data.language;
+  let didInjectCachedContent = false;
 
   // 1. Identify what needs to be translated/romanized
   lyrics.forEach((item, index) => {
@@ -667,7 +774,7 @@ async function processBatchTranslationsAndRomanizations(
     const lyricElement = lineData.lyricElement;
 
     // --- Romanization ---
-    const isLanguageDisabledForRomanization = sourceLanguage && isRomanizationDisabledForLang(sourceLanguage);
+    const isLanguageDisabledForRomanization = !!sourceLanguage && isRomanizationDisabledForLang(sourceLanguage);
     if (isRomanizationEnabled && !isLanguageDisabledForRomanization) {
       let romanizedResult: string | null = null;
       let timedRomanization: LyricPart[] | null = null;
@@ -679,8 +786,11 @@ async function processBatchTranslationsAndRomanizations(
         romanizedResult = getRomanizationFromCache(item.words);
       }
 
-      if (romanizedResult && !isSameText(romanizedResult, item.words)) {
-        injectRomanization(lyricElement, lineData, romanizedResult, timedRomanization);
+      if (romanizedResult) {
+        if (!isSameText(romanizedResult, item.words)) {
+          injectRomanization(lyricElement, lineData, romanizedResult, timedRomanization);
+          didInjectCachedContent = true;
+        }
       } else {
         const shouldRomanize =
           (sourceLanguage && languageMatchesAny(sourceLanguage, ROMANIZATION_LANGUAGES)) ||
@@ -713,11 +823,16 @@ async function processBatchTranslationsAndRomanizations(
 
       if (translationResult && !isSameText(translationResult, item.words)) {
         injectTranslation(lyricElement, translationResult);
+        didInjectCachedContent = true;
       } else if (sourceLanguage !== targetTranslationLang || containsNonLatin(item.words) || !sourceLanguage) {
         translationBatch.push({ index, text: item.words });
       }
     }
   });
+
+  if (didInjectCachedContent) {
+    lyricsElementAdded();
+  }
 
   if (isStale()) return;
 
@@ -791,13 +906,13 @@ function injectRomanization(
 ) {
   if (lyricElement.querySelector(`.${ROMANIZED_LYRICS_CLASS}`)) return;
 
-  createBreakElem(lyricElement, 4);
   const romanizedLine = document.createElement("div");
-  romanizedLine.classList.add(ROMANIZED_LYRICS_CLASS);
-  romanizedLine.style.order = "5";
+  romanizedLine.classList.add(ROMANIZED_LYRICS_CLASS, CONTENT_LINE_CLASS);
+  romanizedLine.dir = "auto";
+  applyDirection(romanizedLine, text);
 
   if (timedRomanization && timedRomanization.length > 0 && !disableRichsync.getBooleanValue()) {
-    createLyricsLine(timedRomanization, lineData, romanizedLine);
+    createLyricsLine(timedRomanization, lineData, romanizedLine, { splitBackgroundLine: false });
   } else {
     romanizedLine.textContent = text;
   }
@@ -807,10 +922,10 @@ function injectRomanization(
 function injectTranslation(lyricElement: HTMLElement, text: string) {
   if (lyricElement.querySelector(`.${TRANSLATED_LYRICS_CLASS}`)) return;
 
-  createBreakElem(lyricElement, 6);
   const translatedLine = document.createElement("div");
-  translatedLine.classList.add(TRANSLATED_LYRICS_CLASS);
-  translatedLine.style.order = "7";
+  translatedLine.classList.add(TRANSLATED_LYRICS_CLASS, CONTENT_LINE_CLASS);
+  translatedLine.dir = "auto";
+  applyDirection(translatedLine, text);
   translatedLine.textContent = text;
   lyricElement.appendChild(translatedLine);
 }
@@ -824,58 +939,13 @@ export function calculateLyricPositions() {
     data.lyricWidth = lyricsElement.clientWidth;
 
     data.lines.forEach(line => {
-      let bounds = getRelativeBounds(lyricsElement, line.lyricElement);
+      let bounds = getRelativeLayoutBounds(lyricsElement, line.lyricElement);
       line.position = bounds.y;
       line.height = bounds.height;
     });
     animEngineState.wasUserScrolling = true; // trigger rescrolls
     resizeCanvas();
   }
-}
-
-/**
- * Take elements from the buffer and group them together to control where wrapping happens
- * @param lyricElement element to push to
- * @param lyricElementsBuffer elements to add
- */
-function groupByWordAndInsert(lyricElement: HTMLDivElement, lyricElementsBuffer: HTMLSpanElement[]) {
-  let wordGroupBuffer = [] as HTMLSpanElement[];
-  let isCurrentBufferBg = false;
-
-  const pushWordGroupBuffer = () => {
-    if (wordGroupBuffer.length > 0) {
-      let span = document.createElement("span");
-      wordGroupBuffer.forEach(word => {
-        span.appendChild(word);
-      });
-
-      if (isCurrentBufferBg) {
-        span.classList.add(BACKGROUND_LYRIC_CLASS);
-      }
-
-      lyricElement.appendChild(span);
-      wordGroupBuffer = [];
-    }
-  };
-
-  lyricElementsBuffer.forEach(part => {
-    const partIsBg = part.classList.contains(BACKGROUND_LYRIC_CLASS);
-    const isNonMatchingType = isCurrentBufferBg !== partIsBg;
-    const hasTrailingSpace = part.classList.contains(HAS_TRAILING_SPACE_CLASS);
-    const wrapAfter = part.dataset.wrapAfter === "true";
-
-    if (isNonMatchingType) {
-      pushWordGroupBuffer();
-      isCurrentBufferBg = partIsBg;
-    }
-    wordGroupBuffer.push(part);
-
-    if (hasTrailingSpace || wrapAfter) {
-      pushWordGroupBuffer();
-    }
-  });
-
-  pushWordGroupBuffer();
 }
 
 /**

--- a/src/modules/lyrics/providers/shared.ts
+++ b/src/modules/lyrics/providers/shared.ts
@@ -4,7 +4,7 @@ import { log } from "@utils";
 import unified from "./unified";
 import ytLyrics, { type YTLyricSourceResult } from "./yt";
 import { ytCaptions } from "./ytCaptions";
-import unison, { type UnisonLyricSourceResult } from "@modules/lyrics/providers/unison";
+import unison, { type UnisonData } from "@modules/lyrics/providers/unison";
 /** Current version of the lyrics cache format */
 const LYRIC_CACHE_VERSION = "2.1.0";
 
@@ -42,7 +42,7 @@ interface AudioTrackData {
 interface LyricSource {
   filled: boolean;
   resultCached: boolean;
-  lyricSourceResult: LyricSourceResult | UnisonLyricSourceResult | YTLyricSourceResult | null;
+  lyricSourceResult: LyricSourceResult | YTLyricSourceResult | null;
   lyricSourceFiller: (providerParameters: ProviderParameters) => Promise<void>;
 }
 
@@ -57,7 +57,7 @@ export interface LyricSourceResult {
   artist?: string;
   song?: string;
   duration?: number;
-  unisonId?: number;
+  unisonData?: UnisonData;
 }
 
 export type LyricsArray = Lyric[];

--- a/src/modules/lyrics/providers/ttmlUtils.ts
+++ b/src/modules/lyrics/providers/ttmlUtils.ts
@@ -16,6 +16,7 @@ import type {
   TransliterationItem,
   TtmlRoot,
 } from "@/modules/lyrics/providers/ttmlTypes";
+import type { UnisonData } from "@modules/lyrics/providers/unison";
 
 /**
  * Parse time in hh:mm:ss.xx or offset-time with unit indicators "h", "m", "s", "ms" (e.g 432.25s)
@@ -229,6 +230,7 @@ interface FillTtmlOptions {
   source: string;
   sourceHref: string;
   cacheAllowed?: boolean;
+  unisonData?: UnisonData;
 }
 
 export async function fillTtml(
@@ -240,10 +242,10 @@ export async function fillTtml(
     source: HOMEPAGE_DOMAIN,
     sourceHref: HOMEPAGE_URL,
     cacheAllowed: true,
-  },
-  ...args: unknown[]
+    unisonData: undefined,
+  }
 ) {
-  const { richsyncKey, syncedKey, source, sourceHref, cacheAllowed } = options;
+  const { richsyncKey, syncedKey, source, sourceHref, cacheAllowed, unisonData } = options;
   const parserOptions: X2jOptions = {
     ignoreAttributes: false,
     attributeNamePrefix: "@_",
@@ -411,7 +413,7 @@ export async function fillTtml(
     musicVideoSynced: false,
     source,
     sourceHref,
-    ...(args[0] || {}),
+    unisonData,
   };
 
   if (isWordSynced) {

--- a/src/modules/lyrics/providers/unison.ts
+++ b/src/modules/lyrics/providers/unison.ts
@@ -34,10 +34,6 @@ export enum UnisonReportReason {
   OTHER = "other",
 }
 
-export type UnisonLyricSourceResult = LyricSourceResult & {
-  unisonData: UnisonData;
-};
-
 export interface UnisonData {
   vote: 1 | -1 | null;
   votes: number;
@@ -144,12 +140,6 @@ export default async function unison(providerParameters: ProviderParameters): Pr
     return;
   }
 
-  const result = {
-    cacheAllowed: false,
-    source: "Unison",
-    sourceHref: chrome.runtime.getURL("pages/unison.html"),
-  };
-
   const unisonData: UnisonData = {
     vote: responseData.userVote,
     votes: responseData.voteCount,
@@ -158,25 +148,26 @@ export default async function unison(providerParameters: ProviderParameters): Pr
     submitter: responseData.submitter,
   };
 
+  const result = {
+    cacheAllowed: false,
+    source: "Unison",
+    sourceHref: chrome.runtime.getURL("pages/unison.html"),
+    unisonData,
+  };
+
   switch (responseData.format) {
     case "ttml":
-      await fillTtml(
-        responseData.lyrics,
-        providerParameters,
-        {
-          richsyncKey: "unison-richsynced",
-          syncedKey: "unison-synced",
-          ...result,
-        },
-        { unisonData }
-      );
+      await fillTtml(responseData.lyrics, providerParameters, {
+        richsyncKey: "unison-richsynced",
+        syncedKey: "unison-synced",
+        ...result,
+      });
       providerParameters.sourceMap["unison-plain"].lyricSourceResult = null;
       break;
     case "lrc":
       const lrc = parseLRC(responseData.lyrics, responseData.duration);
       const res = {
         ...result,
-        unisonData,
         lyrics: lrc,
       };
 
@@ -191,7 +182,6 @@ export default async function unison(providerParameters: ProviderParameters): Pr
       providerParameters.sourceMap["unison-plain"].lyricSourceResult = plain
         ? {
             ...result,
-            unisonData,
             lyrics: plain,
           }
         : null;

--- a/src/modules/settings/themeOptions.ts
+++ b/src/modules/settings/themeOptions.ts
@@ -7,6 +7,7 @@ class Setting {
   value: number | boolean | string;
   readonly defaultValue: number | boolean | string;
   readonly requiresLyricReload: boolean;
+  private manuallySet = false;
 
   constructor(
     type: "number" | "boolean" | "string",
@@ -30,6 +31,14 @@ class Setting {
 
   public getStringValue(): string {
     return this.value as string;
+  }
+
+  public isManuallySet(): boolean {
+    return this.manuallySet;
+  }
+
+  public setManuallySet(manuallySet: boolean): void {
+    this.manuallySet = manuallySet;
   }
 }
 
@@ -58,13 +67,17 @@ export function setThemeSettings(map: Map<string, string>) {
         const parsed = parseFloat(value);
         if (isNaN(parsed)) {
           setting.value = setting.defaultValue;
+          setting.setManuallySet(false);
         } else {
           setting.value = parsed;
+          setting.setManuallySet(true);
         }
       } else if (setting.type === "boolean") {
         setting.value = value.toLowerCase() === "true";
+        setting.setManuallySet(true);
       } else {
         setting.value = value;
+        setting.setManuallySet(true);
       }
 
       if (setting.requiresLyricReload && lastValue !== setting.value) {
@@ -77,9 +90,12 @@ export function setThemeSettings(map: Map<string, string>) {
   for (const [key, setting] of keyToSettingMap.entries()) {
     if (!map.has(key) && setting.value !== setting.defaultValue) {
       setting.value = setting.defaultValue;
+      setting.setManuallySet(false);
       if (setting.requiresLyricReload) {
         needsLyricReload = true;
       }
+    } else if (!map.has(key)) {
+      setting.setManuallySet(false);
     }
   }
 

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -1,33 +1,96 @@
 import {
-  ANIMATING_CLASS,
   CURRENT_LYRICS_CLASS,
+  FOOTER_CLASS,
+  LOG_PREFIX,
   LYRICS_CHECK_INTERVAL_ERROR,
   LYRICS_CLASS,
   NO_LYRICS_ELEMENT_LOG,
-  PAUSED_CLASS,
-  PRE_ANIMATING_CLASS,
   TAB_HEADER_CLASS,
   TAB_RENDERER_SELECTOR,
   USER_SCROLLING_CLASS,
 } from "@constants";
 import { AppState } from "@core/appState";
 import { t } from "@core/i18n";
-import { calculateLyricPositions, type LineData } from "@modules/lyrics/injectLyrics";
+import { calculateLyricPositions, type LineData, type PartData } from "@modules/lyrics/injectLyrics";
 import { registerThemeSetting } from "@modules/settings/themeOptions";
 import { hideAdOverlay, isAdPlaying, isLoaderActive, showAdOverlay } from "@modules/ui/dom";
-import { log } from "@utils";
+import { clamp, getRelativeLayoutBounds, log, positiveModulo, roundedMs } from "@utils";
 import { ctx, resetDebugRender } from "./animationEngineDebug";
 
 const LYRIC_ENDING_THRESHOLD_S = registerThemeSetting("blyrics-lyric-ending-threshold-s", 0.5);
 const EARLY_SCROLL_CONSIDER = registerThemeSetting("blyrics-early-scroll-consider-s", 0.62);
 const QUEUE_SCROLL_THRESHOLD = registerThemeSetting("blyrics-queue-scroll-ms", 150);
 const TIME_JUMP_THRESHOLD = 0.5;
+const SCROLL_TIMING_RATIO_BASE_DURATION_MS = 750;
+const SCROLL_TIMING_RATIO_BASE_EARLY_SCROLL_CONSIDER_S = 0.62;
+const SCROLL_TIMING_RATIO_BASE_QUEUE_SCROLL_THRESHOLD_MS = 150;
+const MAX_AUTO_QUEUE_SCROLL_THRESHOLD_MS = 200;
+const SCROLL_TIMING_RATIO_BASE_TOTAL_MS =
+  SCROLL_TIMING_RATIO_BASE_EARLY_SCROLL_CONSIDER_S * 1000 + SCROLL_TIMING_RATIO_BASE_QUEUE_SCROLL_THRESHOLD_MS;
+const SCROLL_TIMING_BUFFER_MS = SCROLL_TIMING_RATIO_BASE_TOTAL_MS - SCROLL_TIMING_RATIO_BASE_DURATION_MS;
+const AUTO_QUEUE_SCROLL_RATIO = SCROLL_TIMING_RATIO_BASE_QUEUE_SCROLL_THRESHOLD_MS / SCROLL_TIMING_RATIO_BASE_TOTAL_MS;
+const SWIPE_LEAD_RATIO = registerThemeSetting("blyrics-swipe-lead-ratio", 0.1);
+const SWIPE_DURATION_RATIO = registerThemeSetting("blyrics-swipe-duration-ratio", 1.6);
 
 const ENABLE_DEBUG_RENDER = registerThemeSetting("blyrics-debug-renderer", false);
+const ENABLE_ANIMATION_TIMING_LOGS = registerThemeSetting("blyrics-debug-animation-timing", false);
+const ANIMATION_TIMING_LOG_WINDOW_MS = 3000;
+const ANIMATION_TIMING_LOG_INTERVAL_MS = 750;
+const ANIMATION_TIMING_LOG_THRESHOLD_MS = 30;
+const ANIMATION_TIMING_RESET_THRESHOLD_MS = 100;
+const ANIMATION_TIMING_ACCUMULATION_DECAY = 1.08;
+const ANIMATION_TIMING_ACCUMULATION_WEIGHT = 0.4;
+const ANIMATION_TIMING_LEARN_RATE = 0.08;
+const ANIMATION_TIMING_LEARN_SAMPLE_LIMIT_MS = 80;
+const ANIMATION_TIMING_MAX_LEARNED_OFFSET_MS = 80;
+
+function registerLineScrollStyleSetting(property: string, defaultValue: string) {
+  return [property, registerThemeSetting(property.slice(2), defaultValue)] as const;
+}
+
+const LINE_SCROLL_AFTER_FUNCTION =
+  "calc(750ms + log(var(--blyrics-line-scroll-abs-relative-index) + 2, 2.71828) * 80ms + (var(--blyrics-line-scroll-abs-relative-index) + 1) * 20ms)";
+
+const LINE_SCROLL_STYLE_SETTINGS = [
+  registerLineScrollStyleSetting("--blyrics-line-scroll-duration", LINE_SCROLL_AFTER_FUNCTION),
+  registerLineScrollStyleSetting(
+    "--blyrics-line-scroll-above-duration",
+    "calc(750ms + min(var(--blyrics-line-scroll-abs-relative-index), 6) * 20ms)"
+  ),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-active-duration", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-below-duration", LINE_SCROLL_AFTER_FUNCTION),
+  registerLineScrollStyleSetting(
+    "--blyrics-line-scroll-timing-function",
+    "var(--blyrics-lyric-scroll-timing-function)"
+  ),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-start-easing", "var(--blyrics-line-scroll-timing-function)"),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-end-easing", "linear"),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-above-start-easing", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-active-start-easing", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-below-start-easing", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-above-end-easing", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-active-end-easing", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-below-end-easing", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-translate-y-start", "var(--blyrics-line-scroll-delta-px)"),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-translate-y-end", "0px"),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-above-translate-y-start", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-active-translate-y-start", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-below-translate-y-start", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-above-translate-y-end", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-active-translate-y-end", ""),
+  registerLineScrollStyleSetting("--blyrics-line-scroll-below-translate-y-end", ""),
+] as const;
 
 let cachedTabRendererHeight: number | null = null;
 let tabRendererResizeObserver: ResizeObserver | null = null;
 let observedTabRenderer: HTMLElement | null = null;
+let lineScrollAnimations: LineScrollAnimationRecord[] = [];
+let lineScrollAnimationToken = 0;
+const lineScrollElementTokens = new WeakMap<HTMLElement, number>();
+let visibleWillChangeElements = new Set<HTMLElement>();
+let animationTimingVisibilityLogUntil = 0;
+let learnedAnimationTimingOffsetMs = 0;
+const animationTimingLastLogTimes = new WeakMap<LineData, number>();
 
 // 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom
 export const SCROLL_POS_OFFSET_RATIO = registerThemeSetting("blyrics-target-scroll-pos-ratio", 0.37);
@@ -90,20 +153,19 @@ export let animEngineState: AnimEngineState = {
   passiveLastWallTime: 0,
 };
 
-export function resetActiveAnimations(): void {
-  if (!AppState.lyricData || !animEngineState.lastPlayState) return;
-  for (const line of AppState.lyricData.lines) {
-    if (line.isSelected) {
-      line.isAnimating = false;
-    }
-  }
-}
-
 /**
  * Resets anim engine states
  * Called when song is switched or cleaned up
  */
 export function resetAnimEngineState(): void {
+  clearLineScrollAnimations();
+  clearVisibleLyricWillChange();
+  if (AppState.lyricData) {
+    for (const line of AppState.lyricData.lines) {
+      resetLineAnimationState(line);
+      line.isSelected = false;
+    }
+  }
   animEngineState.skipScrollsDecayTimes = [];
   animEngineState.lastActiveElements = [];
   animEngineState.lastScrollDebugContext.activeElms = [];
@@ -113,10 +175,963 @@ export function resetAnimEngineState(): void {
   animEngineState.passiveScrollAccumulatedTime = 0;
   animEngineState.passiveLastWallTime = 0;
   stopPassiveScrollLoop();
-  cachedDurations.clear();
+  clearAnimationStyleCache();
 }
 
-export let cachedDurations: Map<string, number> = new Map();
+function resetPartAnimations(part: PartData): void {
+  for (const animation of part.animations) {
+    animation.cancel();
+  }
+  part.animations = [];
+}
+
+function resetLineAnimations(lineData: LineData): void {
+  const children = [lineData, ...lineData.parts];
+  children.forEach(resetPartAnimations);
+}
+
+function hasLineAnimations(lineData: LineData): boolean {
+  return [lineData, ...lineData.parts].some(part => part.animations.length > 0);
+}
+
+function markLineAnimationsStopped(lineData: LineData): void {
+  lineData.isAnimating = false;
+  lineData.isAnimationPlayStatePlaying = false;
+  lineData.accumulatedOffsetMs = 0;
+}
+
+function resetLineAnimationState(lineData: LineData): void {
+  resetLineAnimations(lineData);
+  markLineAnimationsStopped(lineData);
+}
+
+function setAnimationsPlayState(lineData: LineData, isPlaying: boolean): void {
+  const children = [lineData, ...lineData.parts];
+  for (const part of children) {
+    for (const animation of part.animations) {
+      if (isPlaying) {
+        animation.play();
+      } else {
+        animation.pause();
+      }
+    }
+  }
+}
+
+const LINE_SYNCED_WORD_CLASS = "blyrics-line-synced-word";
+const WORD_HIGHLIGHT_SELECTOR = ".blyrics-word-highlight";
+const INSTRUMENTAL_FILL_SELECTOR = ".blyrics--instrumental-fill";
+const INSTRUMENTAL_WAVE_CLIP_SELECTOR = ".blyrics--wave-clip";
+const INSTRUMENTAL_WAVE_PATH_SELECTOR = ".blyrics--wave-path";
+const INSTRUMENTAL_WAVE_PATH_HIGH = 'path("M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 4 L -4 4 Z")';
+const INSTRUMENTAL_WAVE_PATH_LOW = 'path("M -4 3 Q 1 4 5 3 Q 10 2 14 3 Q 18 4 22 3 Q 26 2 30 3 L 30 4 L -4 4 Z")';
+type LineScrollSide = "above" | "active" | "below";
+type LineScrollKeyframe = "start" | "end";
+interface LineScrollItem {
+  lyricElement: HTMLElement;
+  height: number;
+  position: number;
+}
+interface LineScrollAnimationRecord {
+  animation: Animation;
+  lineElement: HTMLElement;
+  token: number;
+}
+const LINE_SCROLL_INDEX_PROPERTY = "--blyrics-line-scroll-index";
+const LINE_SCROLL_ACTIVE_INDEX_PROPERTY = "--blyrics-line-scroll-active-index";
+const LINE_SCROLL_RELATIVE_INDEX_PROPERTY = "--blyrics-line-scroll-relative-index";
+const LINE_SCROLL_ABS_RELATIVE_INDEX_PROPERTY = "--blyrics-line-scroll-abs-relative-index";
+const LINE_SCROLL_SIDE_PROPERTY = "--blyrics-line-scroll-side";
+const LINE_SCROLL_DELTA_PROPERTY = "--blyrics-line-scroll-delta-px";
+const LINE_SCROLL_DISTANCE_PROPERTY = "--blyrics-line-scroll-distance-px";
+const LINE_SCROLL_WILL_CHANGE_VALUE = "transform, translate";
+const LINE_SCROLL_INLINE_PROPERTIES = [
+  LINE_SCROLL_INDEX_PROPERTY,
+  LINE_SCROLL_ACTIVE_INDEX_PROPERTY,
+  LINE_SCROLL_RELATIVE_INDEX_PROPERTY,
+  LINE_SCROLL_ABS_RELATIVE_INDEX_PROPERTY,
+  LINE_SCROLL_SIDE_PROPERTY,
+  LINE_SCROLL_DELTA_PROPERTY,
+  LINE_SCROLL_DISTANCE_PROPERTY,
+  ...LINE_SCROLL_STYLE_SETTINGS.map(([property]) => property),
+];
+
+interface AnimationConfig {
+  enabled: {
+    lineScale: boolean;
+    wordWobble: boolean;
+    highlightSwipe: boolean;
+    highlightGlow: boolean;
+    highlightFade: boolean;
+    scroll: boolean;
+    instrumental: boolean;
+  };
+  line: {
+    durationMs: number;
+    enterEasing: string;
+    exitEasing: string;
+    enterFrom: string;
+    enterTo: string;
+    exitFrom: string;
+    exitTo: string;
+  };
+  highlight: {
+    fadeInDurationMs: number;
+    fadeOutDurationMs: number;
+    fadeInEasing: string;
+    fadeOutEasing: string;
+    swipeEasing: string;
+    swipeStartFrom: string;
+    swipeEndFrom: string;
+    swipeStartTo: string;
+    swipeEndTo: string;
+    glowFrom: string;
+    glowTo: string;
+    glowDurationRatio: number;
+    glowMinDurationMs: number;
+    glowEasing: string;
+  };
+  word: {
+    wobbleDurationMs: number;
+    wobbleEasing: string;
+    wobblePeakEasing: string;
+    wobbleEndEasing: string;
+    wobbleFrom: string;
+    wobblePeak: string;
+    wobbleSettle: string;
+    wobbleTo: string;
+    wobblePeakOffset: number;
+    wobbleSettleOffset: number;
+  };
+  instrumental: {
+    fillFadeDurationMs: number;
+    fillFadeEasing: string;
+    fillFrom: string;
+    fillTo: string;
+    fillEasing: string;
+    waveFrom: string;
+    waveTo: string;
+    waveEasing: string;
+    waveOscillationDurationMs: number;
+    waveOscillationEasing: string;
+  };
+  scroll: {
+    durationMs: number;
+    easing: string;
+  };
+  lineScroll: {
+    durationMs: number;
+    easing: string;
+    differentialEffects: boolean;
+  };
+}
+
+interface HighlightAnimations {
+  animations: Animation[];
+  swipe?: Animation;
+  fade?: Animation;
+  glow?: Animation;
+}
+
+interface AnimationTimingTrack {
+  offsetMs: number;
+  appliedTimingOffsetMs: number;
+  wrapDurationMs?: number;
+}
+
+interface NativeAnimationTimingSample {
+  actualTimeMs: number;
+  appliedTimingOffsetMs: number;
+  biasOffsetMs: number;
+  expectedTimeMs: number;
+  offsetMs: number;
+  playState: AnimationPlayState;
+}
+
+const animationTimingTracks = new WeakMap<Animation, AnimationTimingTrack>();
+
+function trackLyricAnimationTiming(
+  animation: Animation,
+  timing: Omit<AnimationTimingTrack, "appliedTimingOffsetMs"> & { appliedTimingOffsetMs?: number }
+): Animation {
+  animationTimingTracks.set(animation, {
+    ...timing,
+    appliedTimingOffsetMs: timing.appliedTimingOffsetMs ?? learnedAnimationTimingOffsetMs,
+  });
+  return animation;
+}
+
+function correctedAnimationTimeMs(targetTimeMs: number, appliedTimingOffsetMs: number, maxTimeMs?: number): number {
+  const scheduledTimeMs = targetTimeMs - appliedTimingOffsetMs;
+  return maxTimeMs === undefined ? scheduledTimeMs : Math.min(scheduledTimeMs, maxTimeMs);
+}
+
+function correctedWrappedAnimationTimeMs(
+  targetTimeMs: number,
+  appliedTimingOffsetMs: number,
+  wrapDurationMs: number
+): number {
+  return positiveModulo(targetTimeMs - appliedTimingOffsetMs, wrapDurationMs);
+}
+
+function correctedScrollTimeS(currentTime: number): number {
+  return currentTime - learnedAnimationTimingOffsetMs / 1000;
+}
+
+function timingValueToMs(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) || value === Number.POSITIVE_INFINITY ? value : null;
+  }
+
+  if (typeof value === "string") {
+    const durationMs = toMs(value);
+    return durationMs > 0 ? durationMs : null;
+  }
+
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const numericValue = value as { to?: (unit: string) => { value?: unknown } };
+  if (typeof numericValue.to !== "function") {
+    return null;
+  }
+
+  try {
+    const msValue = numericValue.to("ms").value;
+    return typeof msValue === "number" && Number.isFinite(msValue) ? msValue : null;
+  } catch (_err) {
+    return null;
+  }
+}
+
+function animationCurrentTimeMs(animation: Animation): number | null {
+  return timingValueToMs(animation.currentTime);
+}
+
+function animationActiveDurationMs(animation: Animation): number | null {
+  return timingValueToMs(animation.effect?.getComputedTiming().activeDuration);
+}
+
+function wrappedTimingOffsetMs(actualTimeMs: number, expectedTimeMs: number, wrapDurationMs: number): number {
+  return positiveModulo(actualTimeMs - expectedTimeMs + wrapDurationMs / 2, wrapDurationMs) - wrapDurationMs / 2;
+}
+
+function normalizeAnimationTimeMs(animation: Animation, timeMs: number, timing: AnimationTimingTrack): number | null {
+  if (!Number.isFinite(timeMs) || timeMs < 0) {
+    return null;
+  }
+
+  if (timing.wrapDurationMs && timing.wrapDurationMs > 0) {
+    return positiveModulo(timeMs, timing.wrapDurationMs);
+  }
+
+  const activeDurationMs = animationActiveDurationMs(animation);
+  if (activeDurationMs !== null && Number.isFinite(activeDurationMs)) {
+    return Math.min(timeMs, activeDurationMs);
+  }
+
+  return timeMs;
+}
+
+function animationTimingSample(
+  part: PartData,
+  animation: Animation,
+  currentTime: number
+): NativeAnimationTimingSample | null {
+  if (animation.playState === "idle") {
+    return null;
+  }
+
+  const timing = animationTimingTracks.get(animation);
+  if (!timing) {
+    return null;
+  }
+
+  const actualTimeMs = animationCurrentTimeMs(animation);
+  if (actualTimeMs === null) {
+    return null;
+  }
+
+  const rawExpectedTimeMs = (currentTime - part.time) * 1000 + timing.offsetMs;
+  const expectedTimeMs = normalizeAnimationTimeMs(animation, rawExpectedTimeMs, timing);
+  const normalizedActualTimeMs = normalizeAnimationTimeMs(animation, actualTimeMs, timing);
+  if (expectedTimeMs === null || normalizedActualTimeMs === null) {
+    return null;
+  }
+
+  const offsetMs =
+    timing.wrapDurationMs && timing.wrapDurationMs > 0
+      ? wrappedTimingOffsetMs(normalizedActualTimeMs, expectedTimeMs, timing.wrapDurationMs)
+      : normalizedActualTimeMs - expectedTimeMs;
+  const biasOffsetMs = offsetMs + timing.appliedTimingOffsetMs;
+
+  return {
+    actualTimeMs: normalizedActualTimeMs,
+    appliedTimingOffsetMs: timing.appliedTimingOffsetMs,
+    biasOffsetMs,
+    expectedTimeMs,
+    offsetMs,
+    playState: animation.playState,
+  };
+}
+
+function largestNativeTimingSample(part: PartData, currentTime: number): NativeAnimationTimingSample | null {
+  let largestSample: NativeAnimationTimingSample | null = null;
+
+  for (const animation of part.animations) {
+    const sample = animationTimingSample(part, animation, currentTime);
+    if (sample === null) {
+      continue;
+    }
+    if (largestSample === null || Math.abs(sample.offsetMs) > Math.abs(largestSample.offsetMs)) {
+      largestSample = sample;
+    }
+  }
+
+  return largestSample;
+}
+
+function lineNativeTimingSample(lineData: LineData, currentTime: number): NativeAnimationTimingSample | null {
+  let largestSample: NativeAnimationTimingSample | null = null;
+
+  for (const part of [lineData, ...lineData.parts]) {
+    const sample = largestNativeTimingSample(part, currentTime);
+    if (sample === null) {
+      continue;
+    }
+    if (largestSample === null || Math.abs(sample.offsetMs) > Math.abs(largestSample.offsetMs)) {
+      largestSample = sample;
+    }
+  }
+
+  return largestSample;
+}
+
+function linePreview(lineData: LineData): string {
+  return lineData.lyricElement.textContent?.trim().replace(/\s+/g, " ").slice(0, 80) ?? "";
+}
+
+function canUseTimingSampleForDrift(sample: NativeAnimationTimingSample, isPlaying: boolean): boolean {
+  if (!isPlaying) {
+    return false;
+  }
+
+  return sample.playState === "running" || sample.playState === "finished";
+}
+
+function learnAnimationTimingOffset(sample: NativeAnimationTimingSample): number {
+  if (Math.abs(sample.biasOffsetMs) > ANIMATION_TIMING_LEARN_SAMPLE_LIMIT_MS) {
+    return learnedAnimationTimingOffsetMs;
+  }
+
+  learnedAnimationTimingOffsetMs = clamp(
+    learnedAnimationTimingOffsetMs +
+      (sample.biasOffsetMs - learnedAnimationTimingOffsetMs) * ANIMATION_TIMING_LEARN_RATE,
+    -ANIMATION_TIMING_MAX_LEARNED_OFFSET_MS,
+    ANIMATION_TIMING_MAX_LEARNED_OFFSET_MS
+  );
+
+  return learnedAnimationTimingOffsetMs;
+}
+
+function shouldLogAnimationTiming(lineData: LineData, sample: NativeAnimationTimingSample, now: number): boolean {
+  if (!ENABLE_ANIMATION_TIMING_LOGS.getBooleanValue()) {
+    return false;
+  }
+
+  const isVisibilityLogWindow = now < animationTimingVisibilityLogUntil;
+  if (!isVisibilityLogWindow && Math.abs(sample.offsetMs) < ANIMATION_TIMING_LOG_THRESHOLD_MS) {
+    return false;
+  }
+
+  const lastLogTime = animationTimingLastLogTimes.get(lineData) ?? 0;
+  if (now - lastLogTime < ANIMATION_TIMING_LOG_INTERVAL_MS) {
+    return false;
+  }
+
+  animationTimingLastLogTimes.set(lineData, now);
+  return true;
+}
+
+function logAnimationTiming(
+  reason: string,
+  lineData: LineData,
+  lineIndex: number,
+  sample: NativeAnimationTimingSample,
+  currentTime: number,
+  accumulatedOffsetMs: number,
+  learnedOffsetMs = learnedAnimationTimingOffsetMs,
+  residualOffsetMs = sample.offsetMs
+): void {
+  if (!ENABLE_ANIMATION_TIMING_LOGS.getBooleanValue()) {
+    return;
+  }
+
+  log(LOG_PREFIX, "WAAPI timing", {
+    reason,
+    lineIndex,
+    lineTimeS: roundedMs(lineData.time * 1000) / 1000,
+    mediaTimeS: roundedMs(currentTime * 1000) / 1000,
+    actualTimeMs: roundedMs(sample.actualTimeMs),
+    expectedTimeMs: roundedMs(sample.expectedTimeMs),
+    offsetMs: roundedMs(sample.offsetMs),
+    learnedOffsetMs: roundedMs(learnedOffsetMs),
+    appliedTimingOffsetMs: roundedMs(sample.appliedTimingOffsetMs),
+    biasOffsetMs: roundedMs(sample.biasOffsetMs),
+    residualOffsetMs: roundedMs(residualOffsetMs),
+    accumulatedOffsetMs: roundedMs(accumulatedOffsetMs),
+    playState: sample.playState,
+    text: linePreview(lineData),
+  });
+}
+
+function logAnimationCleanup(
+  reason: string,
+  lineData: LineData,
+  lineIndex: number,
+  currentTime: number,
+  staleAnimationEndTime: number
+): void {
+  if (!ENABLE_ANIMATION_TIMING_LOGS.getBooleanValue()) {
+    return;
+  }
+
+  log(LOG_PREFIX, "Animation cleanup", {
+    reason,
+    lineIndex,
+    lineTimeS: roundedMs(lineData.time * 1000) / 1000,
+    mediaTimeS: roundedMs(currentTime * 1000) / 1000,
+    staleAnimationEndTimeS: roundedMs(staleAnimationEndTime * 1000) / 1000,
+    runningAnimationCount: [lineData, ...lineData.parts].reduce((count, part) => count + part.animations.length, 0),
+    text: linePreview(lineData),
+  });
+}
+
+export function noteAnimationVisibilityChange(): void {
+  if (!ENABLE_ANIMATION_TIMING_LOGS.getBooleanValue()) {
+    return;
+  }
+
+  if (!AppState.lyricData) return;
+
+  const runningAnimationCount = AppState.lyricData.lines.reduce(
+    (count, line) => count + [line, ...line.parts].reduce((lineCount, part) => lineCount + part.animations.length, 0),
+    0
+  );
+
+  if (document.visibilityState === "visible") {
+    animationTimingVisibilityLogUntil = Date.now() + ANIMATION_TIMING_LOG_WINDOW_MS;
+    log(LOG_PREFIX, "Visibility changed; keeping WAAPI animations for timing verification", {
+      visibilityState: document.visibilityState,
+      runningAnimationCount,
+      resetSkipped: true,
+      timingLogWindowMs: ANIMATION_TIMING_LOG_WINDOW_MS,
+    });
+    return;
+  }
+
+  log(LOG_PREFIX, "Visibility changed; WAAPI animations left intact", {
+    visibilityState: document.visibilityState,
+    runningAnimationCount,
+    resetSkipped: true,
+  });
+}
+
+function activeTextGradientKeyframes(config: AnimationConfig): Keyframe[] {
+  return [
+    {
+      "--lyric-transition-amount-start": config.highlight.swipeStartFrom,
+      "--lyric-transition-amount-end": config.highlight.swipeEndFrom,
+    },
+    {
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+  ] as Keyframe[];
+}
+
+function activeTextGlowKeyframes(config: AnimationConfig): Keyframe[] {
+  return [{ filter: config.highlight.glowFrom }, { filter: config.highlight.glowTo }];
+}
+
+function activeTextVisibleKeyframes(): Keyframe[] {
+  return [{ opacity: 1 }, { opacity: 1 }];
+}
+
+function activeTextInstantKeyframes(config: AnimationConfig): Keyframe[] {
+  return [
+    {
+      opacity: 1,
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+    {
+      opacity: 1,
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+  ] as Keyframe[];
+}
+
+function highlightTarget(part: PartData): { element: Element; options: KeyframeAnimationOptions } {
+  const highlight = part.lyricElement.querySelector(WORD_HIGHLIGHT_SELECTOR);
+  if (highlight) {
+    return { element: highlight, options: {} };
+  }
+  return { element: part.lyricElement, options: { pseudoElement: "::after" } };
+}
+
+function lineSyncedTextKeyframes(config: AnimationConfig): Keyframe[] {
+  return [
+    {
+      opacity: 0,
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+    {
+      opacity: 1,
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+  ] as Keyframe[];
+}
+
+function fadeOutTextKeyframes(config: AnimationConfig): Keyframe[] {
+  return [
+    {
+      opacity: 1,
+      filter: config.highlight.glowTo,
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+    {
+      opacity: 0,
+      filter: config.highlight.glowTo,
+      "--lyric-transition-amount-start": config.highlight.swipeStartTo,
+      "--lyric-transition-amount-end": config.highlight.swipeEndTo,
+    },
+  ] as Keyframe[];
+}
+
+function startRichSyncedHighlightAnimations(
+  part: PartData,
+  config: AnimationConfig,
+  swipeTimeMs: number,
+  wordTimeMs: number,
+  swipeDurationMs: number,
+  glowDurationMs: number,
+  appliedTimingOffsetMs: number
+): HighlightAnimations {
+  const animations: Animation[] = [];
+  const target = highlightTarget(part);
+
+  let swipeAnimation: Animation | undefined;
+  if (config.enabled.highlightSwipe) {
+    swipeAnimation = trackLyricAnimationTiming(
+      target.element.animate(activeTextGradientKeyframes(config), {
+        duration: swipeDurationMs,
+        easing: config.highlight.swipeEasing,
+        fill: "forwards",
+        ...target.options,
+      }),
+      { appliedTimingOffsetMs, offsetMs: swipeTimeMs - wordTimeMs }
+    );
+    swipeAnimation.currentTime = correctedAnimationTimeMs(swipeTimeMs, appliedTimingOffsetMs, swipeDurationMs);
+    animations.push(swipeAnimation);
+  }
+
+  const opacityAnimation = trackLyricAnimationTiming(
+    target.element.animate(
+      config.enabled.highlightSwipe ? activeTextVisibleKeyframes() : activeTextInstantKeyframes(config),
+      {
+        duration: 1,
+        easing: "linear",
+        fill: "forwards",
+        ...target.options,
+      }
+    ),
+    { appliedTimingOffsetMs, offsetMs: 0 }
+  );
+  opacityAnimation.currentTime = correctedAnimationTimeMs(wordTimeMs, appliedTimingOffsetMs, 1);
+  animations.push(opacityAnimation);
+
+  let glowAnimation: Animation | undefined;
+  if (config.enabled.highlightGlow) {
+    glowAnimation = trackLyricAnimationTiming(
+      target.element.animate(activeTextGlowKeyframes(config), {
+        duration: glowDurationMs,
+        easing: config.highlight.glowEasing,
+        fill: "forwards",
+        ...target.options,
+      }),
+      { appliedTimingOffsetMs, offsetMs: 0 }
+    );
+    glowAnimation.currentTime = correctedAnimationTimeMs(wordTimeMs, appliedTimingOffsetMs, glowDurationMs);
+    animations.push(glowAnimation);
+  }
+
+  return { animations, swipe: swipeAnimation, fade: opacityAnimation, glow: glowAnimation };
+}
+
+function startLineSyncedHighlightAnimations(
+  part: PartData,
+  config: AnimationConfig,
+  wordTimeMs: number,
+  glowDurationMs: number,
+  appliedTimingOffsetMs: number
+): HighlightAnimations {
+  const animations: Animation[] = [];
+  const fadeInDuration = config.enabled.highlightFade ? config.highlight.fadeInDurationMs : 1;
+  const target = highlightTarget(part);
+
+  const opacityAnimation = trackLyricAnimationTiming(
+    target.element.animate(lineSyncedTextKeyframes(config), {
+      duration: fadeInDuration,
+      easing: config.enabled.highlightFade ? config.highlight.fadeInEasing : "linear",
+      fill: "forwards",
+      ...target.options,
+    }),
+    { appliedTimingOffsetMs, offsetMs: 0 }
+  );
+  opacityAnimation.currentTime = correctedAnimationTimeMs(wordTimeMs, appliedTimingOffsetMs, fadeInDuration);
+  animations.push(opacityAnimation);
+
+  let glowAnimation: Animation | undefined;
+  if (config.enabled.highlightGlow) {
+    glowAnimation = trackLyricAnimationTiming(
+      target.element.animate(activeTextGlowKeyframes(config), {
+        duration: glowDurationMs,
+        easing: config.highlight.glowEasing,
+        fill: "forwards",
+        ...target.options,
+      }),
+      { appliedTimingOffsetMs, offsetMs: 0 }
+    );
+    glowAnimation.currentTime = correctedAnimationTimeMs(wordTimeMs, appliedTimingOffsetMs, glowDurationMs);
+    animations.push(glowAnimation);
+  }
+
+  return { animations, fade: opacityAnimation, glow: glowAnimation };
+}
+
+function startLineAnimation(
+  lineData: LineData,
+  config: AnimationConfig,
+  currentTime: number,
+  appliedTimingOffsetMs: number
+): void {
+  resetPartAnimations(lineData);
+
+  const rawElapsedMs = (currentTime - lineData.time) * 1000;
+
+  if (!config.enabled.lineScale) {
+    lineData.animations = [];
+    return;
+  }
+
+  const animation = trackLyricAnimationTiming(
+    lineData.lyricElement.animate([{ transform: config.line.enterFrom }, { transform: config.line.enterTo }], {
+      duration: config.line.durationMs,
+      easing: config.line.enterEasing,
+      fill: "forwards",
+    }),
+    { appliedTimingOffsetMs, offsetMs: 0 }
+  );
+
+  animation.currentTime = correctedAnimationTimeMs(rawElapsedMs, appliedTimingOffsetMs, config.line.durationMs);
+  lineData.animations = [animation];
+}
+
+function startLineExitAnimation(lineData: LineData, config: AnimationConfig): void {
+  resetPartAnimations(lineData);
+
+  if (!config.enabled.lineScale) {
+    return;
+  }
+
+  const animation = lineData.lyricElement.animate(
+    [{ transform: config.line.exitFrom }, { transform: config.line.exitTo }],
+    {
+      duration: config.line.durationMs,
+      easing: config.line.exitEasing,
+      fill: "none",
+    }
+  );
+
+  lineData.animations = [animation];
+  animation.addEventListener(
+    "finish",
+    () => {
+      resetPartAnimations(lineData);
+    },
+    { once: true }
+  );
+}
+
+function startWordAnimations(
+  part: PartData,
+  config: AnimationConfig,
+  currentTime: number,
+  appliedTimingOffsetMs: number
+): void {
+  resetPartAnimations(part);
+
+  const rawElapsedMs = (currentTime - part.time) * 1000;
+  const timedDurationMs = part.duration * 1000;
+  const isLineSyncedWord = part.lyricElement.classList.contains(LINE_SYNCED_WORD_CLASS);
+  const swipeLeadMs = timedDurationMs * SWIPE_LEAD_RATIO.getNumberValue();
+  const swipeTimeMs = rawElapsedMs + swipeLeadMs;
+  const wordTimeMs = rawElapsedMs;
+  const swipeDurationMs = timedDurationMs * SWIPE_DURATION_RATIO.getNumberValue();
+  const glowDurationMs = Math.max(
+    timedDurationMs * config.highlight.glowDurationRatio,
+    config.highlight.glowMinDurationMs
+  );
+
+  const highlightAnimations = isLineSyncedWord
+    ? startLineSyncedHighlightAnimations(
+        part,
+        config,
+        wordTimeMs,
+        config.highlight.glowMinDurationMs,
+        appliedTimingOffsetMs
+      )
+    : startRichSyncedHighlightAnimations(
+        part,
+        config,
+        swipeTimeMs,
+        wordTimeMs,
+        swipeDurationMs,
+        glowDurationMs,
+        appliedTimingOffsetMs
+      );
+
+  const wobbleAnimation = config.enabled.wordWobble
+    ? trackLyricAnimationTiming(
+        part.lyricElement.animate(
+          [
+            { transform: config.word.wobbleFrom },
+            {
+              transform: config.word.wobblePeak,
+              offset: config.word.wobblePeakOffset,
+              easing: config.word.wobblePeakEasing,
+            },
+            { transform: config.word.wobbleSettle, offset: config.word.wobbleSettleOffset },
+            { transform: config.word.wobbleTo, easing: config.word.wobbleEndEasing },
+          ],
+          {
+            duration: config.word.wobbleDurationMs,
+            easing: config.word.wobbleEasing,
+            fill: "forwards",
+          }
+        ),
+        { appliedTimingOffsetMs, offsetMs: 0 }
+      )
+    : null;
+
+  if (wobbleAnimation) {
+    wobbleAnimation.currentTime = correctedAnimationTimeMs(
+      wordTimeMs,
+      appliedTimingOffsetMs,
+      config.word.wobbleDurationMs
+    );
+  }
+  part.animations = wobbleAnimation
+    ? [...highlightAnimations.animations, wobbleAnimation]
+    : highlightAnimations.animations;
+}
+
+function startLineAnimations(lineData: LineData, config: AnimationConfig, currentTime: number): void {
+  const appliedTimingOffsetMs = learnedAnimationTimingOffsetMs;
+
+  startLineAnimation(lineData, config, currentTime, appliedTimingOffsetMs);
+  if (lineData.lyricElement.dataset.instrumental === "true") {
+    startInstrumentalAnimations(lineData, config, currentTime, appliedTimingOffsetMs);
+    return;
+  }
+
+  for (const part of lineData.parts) {
+    startWordAnimations(part, config, currentTime, appliedTimingOffsetMs);
+  }
+}
+
+function startWordExitAnimation(part: PartData, config: AnimationConfig): void {
+  resetPartAnimations(part);
+
+  const fadeDuration = config.enabled.highlightFade ? config.highlight.fadeOutDurationMs : 1;
+  const target = highlightTarget(part);
+  const animation = target.element.animate(fadeOutTextKeyframes(config), {
+    duration: fadeDuration,
+    easing: config.enabled.highlightFade ? config.highlight.fadeOutEasing : "linear",
+    fill: "none",
+    ...target.options,
+  });
+
+  part.animations = [animation];
+  animation.addEventListener(
+    "finish",
+    () => {
+      resetPartAnimations(part);
+    },
+    { once: true }
+  );
+}
+
+function startLineExitAnimations(lineData: LineData, config: AnimationConfig, currentTime: number): void {
+  startLineExitAnimation(lineData, config);
+
+  if (lineData.lyricElement.dataset.instrumental === "true") {
+    startInstrumentalExitAnimations(lineData, config, currentTime);
+    return;
+  }
+
+  for (const part of lineData.parts) {
+    if (currentTime >= part.time) {
+      startWordExitAnimation(part, config);
+    } else {
+      resetPartAnimations(part);
+    }
+  }
+}
+
+function animateInstrumentalChild(
+  lineData: LineData,
+  selector: string,
+  keyframes: Keyframe[],
+  options: KeyframeAnimationOptions,
+  timing?: AnimationTimingTrack
+): Animation | null {
+  const element = lineData.lyricElement.querySelector(selector) as Element | null;
+  if (!element) return null;
+
+  const animation = timing
+    ? trackLyricAnimationTiming(element.animate(keyframes, options), timing)
+    : element.animate(keyframes, options);
+  lineData.animations.push(animation);
+  return animation;
+}
+
+function startInstrumentalAnimations(
+  lineData: LineData,
+  config: AnimationConfig,
+  currentTime: number,
+  appliedTimingOffsetMs: number
+): void {
+  const rawElapsedMs = (currentTime - lineData.time) * 1000;
+  const durationMs = Math.max(lineData.duration * 1000, 1);
+  const fillFadeDuration = config.enabled.instrumental ? config.instrumental.fillFadeDurationMs : 1;
+
+  const fillAnimation = animateInstrumentalChild(
+    lineData,
+    INSTRUMENTAL_FILL_SELECTOR,
+    [{ opacity: 0 }, { opacity: 1 }],
+    {
+      duration: fillFadeDuration,
+      easing: config.enabled.instrumental ? config.instrumental.fillFadeEasing : "linear",
+      fill: "forwards",
+    },
+    { appliedTimingOffsetMs, offsetMs: 0 }
+  );
+
+  let fillTravelAnimation: Animation | null = null;
+  let waveFlattenAnimation: Animation | null = null;
+  let waveOscillationAnimation: Animation | null = null;
+  if (config.enabled.instrumental) {
+    fillTravelAnimation = animateInstrumentalChild(
+      lineData,
+      INSTRUMENTAL_WAVE_CLIP_SELECTOR,
+      [{ transform: config.instrumental.fillFrom }, { transform: config.instrumental.fillTo }],
+      {
+        duration: durationMs,
+        easing: config.instrumental.fillEasing,
+        fill: "both",
+      },
+      { appliedTimingOffsetMs, offsetMs: 0 }
+    );
+
+    waveFlattenAnimation = animateInstrumentalChild(
+      lineData,
+      INSTRUMENTAL_WAVE_PATH_SELECTOR,
+      [{ transform: config.instrumental.waveFrom }, { transform: config.instrumental.waveTo }],
+      {
+        duration: durationMs,
+        easing: config.instrumental.waveEasing,
+        fill: "both",
+      },
+      { appliedTimingOffsetMs, offsetMs: 0 }
+    );
+
+    waveOscillationAnimation = animateInstrumentalChild(
+      lineData,
+      INSTRUMENTAL_WAVE_PATH_SELECTOR,
+      [
+        { d: INSTRUMENTAL_WAVE_PATH_HIGH },
+        { d: INSTRUMENTAL_WAVE_PATH_LOW, offset: 0.5 },
+        { d: INSTRUMENTAL_WAVE_PATH_HIGH },
+      ],
+      {
+        duration: config.instrumental.waveOscillationDurationMs,
+        easing: config.instrumental.waveOscillationEasing,
+        iterations: Infinity,
+      },
+      {
+        appliedTimingOffsetMs,
+        offsetMs: 0,
+        wrapDurationMs: config.instrumental.waveOscillationDurationMs,
+      }
+    );
+  }
+
+  if (fillAnimation) {
+    fillAnimation.currentTime = correctedAnimationTimeMs(rawElapsedMs, appliedTimingOffsetMs, fillFadeDuration);
+  }
+  for (const animation of [fillTravelAnimation, waveFlattenAnimation]) {
+    if (animation) {
+      animation.currentTime = correctedAnimationTimeMs(rawElapsedMs, appliedTimingOffsetMs, durationMs);
+    }
+  }
+  if (waveOscillationAnimation) {
+    waveOscillationAnimation.currentTime = correctedWrappedAnimationTimeMs(
+      rawElapsedMs,
+      appliedTimingOffsetMs,
+      Math.max(config.instrumental.waveOscillationDurationMs, 1)
+    );
+  }
+}
+
+function startInstrumentalExitAnimations(lineData: LineData, config: AnimationConfig, currentTime: number): void {
+  if (currentTime < lineData.time) return;
+
+  const fadeDuration =
+    config.enabled.instrumental && config.enabled.highlightFade ? config.highlight.fadeOutDurationMs : 1;
+  animateInstrumentalChild(lineData, INSTRUMENTAL_FILL_SELECTOR, [{ opacity: 1 }, { opacity: 0 }], {
+    duration: fadeDuration,
+    easing: config.enabled.instrumental ? config.highlight.fadeOutEasing : "linear",
+    fill: "none",
+  });
+}
+
+let cachedDurations: Map<string, number> = new Map();
+const cachedCSSValues: Map<string, string> = new Map();
+
+export function clearAnimationStyleCache(): void {
+  cachedDurations.clear();
+  cachedCSSValues.clear();
+}
+
+if (typeof window !== "undefined" && window.matchMedia) {
+  window.matchMedia("(prefers-reduced-motion: reduce)").addEventListener("change", clearAnimationStyleCache);
+}
+
+function getCSSValue(lyricsElement: HTMLElement, property: string, fallback: string): string {
+  let value = cachedCSSValues.get(property);
+  if (value === undefined) {
+    value = window.getComputedStyle(lyricsElement).getPropertyValue(property).trim() || fallback;
+    cachedCSSValues.set(property, value);
+  }
+  return value;
+}
 
 /**
  * Gets and caches a css duration.
@@ -130,11 +1145,475 @@ export let cachedDurations: Map<string, number> = new Map();
 function getCSSDurationInMs(lyricsElement: HTMLElement, property: string): number {
   let duration = cachedDurations.get(property);
   if (duration === undefined) {
-    duration = toMs(window.getComputedStyle(lyricsElement).getPropertyValue(property));
+    duration = toMs(getCSSValue(lyricsElement, property, "0ms"));
     cachedDurations.set(property, duration);
   }
 
   return duration;
+}
+
+function getCSSDurationWithFallback(lyricsElement: HTMLElement, property: string, fallback: string): number {
+  return Math.max(toMs(getCSSValue(lyricsElement, property, fallback)), 1);
+}
+
+function getCSSNumber(lyricsElement: HTMLElement, property: string, fallback: number): number {
+  const value = Number.parseFloat(getCSSValue(lyricsElement, property, `${fallback}`));
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function getCSSBoolean(lyricsElement: HTMLElement, property: string, fallback: boolean): boolean {
+  const value = getCSSValue(lyricsElement, property, fallback ? "1" : "0").toLowerCase();
+  if (value === "false" || value === "off" || value === "none") return false;
+  const numericValue = Number.parseFloat(value);
+  if (Number.isFinite(numericValue)) return numericValue > 0;
+  return fallback;
+}
+
+function getCSSOffset(lyricsElement: HTMLElement, property: string, fallback: number): number {
+  return Math.max(0, Math.min(1, getCSSNumber(lyricsElement, property, fallback)));
+}
+
+function readAnimationConfig(lyricsElement: HTMLElement): AnimationConfig {
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  const scrollDurationMs = getCSSDurationWithFallback(lyricsElement, "--blyrics-lyric-scroll-duration", "650ms");
+  const scrollEasing = getCSSValue(
+    lyricsElement,
+    "--blyrics-lyric-scroll-timing-function",
+    "cubic-bezier(0.86, 0, 0.2, 1)"
+  );
+
+  return {
+    enabled: {
+      lineScale: getCSSBoolean(lyricsElement, "--blyrics-animate-line-scale", true),
+      wordWobble: getCSSBoolean(lyricsElement, "--blyrics-animate-word-wobble", true),
+      highlightSwipe: getCSSBoolean(lyricsElement, "--blyrics-animate-highlight-swipe", true),
+      highlightGlow: getCSSBoolean(lyricsElement, "--blyrics-animate-highlight-glow", true),
+      highlightFade: getCSSBoolean(lyricsElement, "--blyrics-animate-highlight-fade", true),
+      scroll: getCSSBoolean(lyricsElement, "--blyrics-animate-scroll", true),
+      instrumental: getCSSBoolean(lyricsElement, "--blyrics-animate-instrumental", true),
+    },
+    line: {
+      durationMs: getCSSDurationWithFallback(lyricsElement, "--blyrics-scale-transition-duration", "0.166s"),
+      enterEasing: getCSSValue(lyricsElement, "--blyrics-line-enter-easing", "ease"),
+      exitEasing: getCSSValue(lyricsElement, "--blyrics-line-exit-easing", "ease"),
+      enterFrom: getCSSValue(lyricsElement, "--blyrics-line-enter-transform-from", "scale(var(--blyrics-scale))"),
+      enterTo: getCSSValue(lyricsElement, "--blyrics-line-enter-transform-to", "scale(var(--blyrics-active-scale))"),
+      exitFrom: getCSSValue(lyricsElement, "--blyrics-line-exit-transform-from", "scale(var(--blyrics-active-scale))"),
+      exitTo: getCSSValue(lyricsElement, "--blyrics-line-exit-transform-to", "scale(var(--blyrics-scale))"),
+    },
+    highlight: {
+      fadeInDurationMs: getCSSDurationWithFallback(
+        lyricsElement,
+        "--blyrics-lyric-highlight-fade-in-duration",
+        "0.33s"
+      ),
+      fadeOutDurationMs: getCSSDurationWithFallback(
+        lyricsElement,
+        "--blyrics-lyric-highlight-fade-out-duration",
+        "0.5s"
+      ),
+      fadeInEasing: getCSSValue(lyricsElement, "--blyrics-lyric-highlight-fade-in-easing", "ease"),
+      fadeOutEasing: getCSSValue(lyricsElement, "--blyrics-lyric-highlight-fade-out-easing", "ease"),
+      swipeEasing: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-easing", "linear"),
+      swipeStartFrom: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-start-from", "-0.2"),
+      swipeEndFrom: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-end-from", "-0.1"),
+      swipeStartTo: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-start-to", "1.4"),
+      swipeEndTo: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-end-to", "1.5"),
+      glowFrom: getCSSValue(
+        lyricsElement,
+        "--blyrics-highlight-glow-filter-from",
+        "drop-shadow(0 0 0.8rem var(--blyrics-glow-color))"
+      ),
+      glowTo: getCSSValue(
+        lyricsElement,
+        "--blyrics-highlight-glow-filter-to",
+        "drop-shadow(0 0 0 var(--blyrics-glow-color))"
+      ),
+      glowDurationRatio: getCSSNumber(lyricsElement, "--blyrics-highlight-glow-duration-ratio", 1.2),
+      glowMinDurationMs: getCSSDurationWithFallback(lyricsElement, "--blyrics-highlight-glow-min-duration", "1.2s"),
+      glowEasing: getCSSValue(lyricsElement, "--blyrics-highlight-glow-easing", "ease"),
+    },
+    word: {
+      wobbleDurationMs: getCSSDurationWithFallback(lyricsElement, "--blyrics-wobble-duration", "1s"),
+      wobbleEasing: getCSSValue(lyricsElement, "--blyrics-word-wobble-easing", "ease"),
+      wobblePeakEasing: getCSSValue(lyricsElement, "--blyrics-word-wobble-peak-easing", "ease-in-out"),
+      wobbleEndEasing: getCSSValue(lyricsElement, "--blyrics-word-wobble-end-easing", "ease-out"),
+      wobbleFrom: getCSSValue(lyricsElement, "--blyrics-word-wobble-transform-from", "scaleX(1)"),
+      wobblePeak: getCSSValue(
+        lyricsElement,
+        "--blyrics-word-wobble-transform-peak",
+        "translateX(0.05em) scaleX(1.025)"
+      ),
+      wobbleSettle: getCSSValue(lyricsElement, "--blyrics-word-wobble-transform-settle", "translateX(0) scaleX(1)"),
+      wobbleTo: getCSSValue(lyricsElement, "--blyrics-word-wobble-transform-to", "scaleX(1)"),
+      wobblePeakOffset: getCSSOffset(lyricsElement, "--blyrics-word-wobble-peak-offset", 0.125),
+      wobbleSettleOffset: getCSSOffset(lyricsElement, "--blyrics-word-wobble-settle-offset", 0.75),
+    },
+    instrumental: {
+      fillFadeDurationMs: getCSSDurationWithFallback(
+        lyricsElement,
+        "--blyrics-instrumental-fill-fade-duration",
+        "150ms"
+      ),
+      fillFadeEasing: getCSSValue(lyricsElement, "--blyrics-instrumental-fill-fade-easing", "ease"),
+      fillFrom: getCSSValue(lyricsElement, "--blyrics-instrumental-fill-transform-from", "translateY(78%)"),
+      fillTo: getCSSValue(lyricsElement, "--blyrics-instrumental-fill-transform-to", "translateY(-4%)"),
+      fillEasing: getCSSValue(lyricsElement, "--blyrics-instrumental-fill-easing", "linear"),
+      waveFrom: getCSSValue(lyricsElement, "--blyrics-instrumental-wave-transform-from", "scaleY(1.2)"),
+      waveTo: getCSSValue(lyricsElement, "--blyrics-instrumental-wave-transform-to", "scaleY(0.0001)"),
+      waveEasing: getCSSValue(lyricsElement, "--blyrics-instrumental-wave-easing", "ease-in"),
+      waveOscillationDurationMs: getCSSDurationWithFallback(
+        lyricsElement,
+        "--blyrics-instrumental-wave-oscillation-duration",
+        "1.25s"
+      ),
+      waveOscillationEasing: getCSSValue(
+        lyricsElement,
+        "--blyrics-instrumental-wave-oscillation-easing",
+        "ease-in-out"
+      ),
+    },
+    scroll: {
+      durationMs: scrollDurationMs,
+      easing: scrollEasing,
+    },
+    lineScroll: {
+      durationMs: scrollDurationMs,
+      easing: scrollEasing,
+      differentialEffects: !prefersReducedMotion,
+    },
+  };
+}
+
+function readScrollTiming(scrollDurationMs: number): { earlyScrollConsiderS: number; queueScrollMs: number } {
+  const totalMs = Math.max(0, scrollDurationMs + SCROLL_TIMING_BUFFER_MS);
+  const earlyScrollConsiderWasSet = EARLY_SCROLL_CONSIDER.isManuallySet();
+  const queueScrollWasSet = QUEUE_SCROLL_THRESHOLD.isManuallySet();
+
+  if (earlyScrollConsiderWasSet && queueScrollWasSet) {
+    return {
+      earlyScrollConsiderS: Math.max(0, EARLY_SCROLL_CONSIDER.getNumberValue()),
+      queueScrollMs: Math.max(0, QUEUE_SCROLL_THRESHOLD.getNumberValue()),
+    };
+  }
+
+  if (earlyScrollConsiderWasSet) {
+    const earlyScrollConsiderS = Math.max(0, EARLY_SCROLL_CONSIDER.getNumberValue());
+    return {
+      earlyScrollConsiderS,
+      queueScrollMs: Math.min(Math.max(0, totalMs - earlyScrollConsiderS * 1000), MAX_AUTO_QUEUE_SCROLL_THRESHOLD_MS),
+    };
+  }
+
+  if (queueScrollWasSet) {
+    const queueScrollMs = Math.max(0, QUEUE_SCROLL_THRESHOLD.getNumberValue());
+    return {
+      earlyScrollConsiderS: Math.max(0, (totalMs - queueScrollMs) / 1000),
+      queueScrollMs,
+    };
+  }
+
+  const queueScrollMs = Math.min(totalMs * AUTO_QUEUE_SCROLL_RATIO, MAX_AUTO_QUEUE_SCROLL_THRESHOLD_MS);
+  return {
+    earlyScrollConsiderS: Math.max(0, (totalMs - queueScrollMs) / 1000),
+    queueScrollMs,
+  };
+}
+
+function clearLineScrollAnimations(): void {
+  const records = lineScrollAnimations;
+  lineScrollAnimations = [];
+  for (const record of records) {
+    record.animation.cancel();
+    clearLineScrollInlineProperties(record.lineElement, record.token);
+  }
+}
+
+function removeLineScrollAnimation(record: LineScrollAnimationRecord): void {
+  const index = lineScrollAnimations.indexOf(record);
+  if (index !== -1) {
+    lineScrollAnimations.splice(index, 1);
+  }
+  clearLineScrollInlineProperties(record.lineElement, record.token);
+}
+
+function trackLineScrollAnimation(animation: Animation, lineElement: HTMLElement, token: number): void {
+  const record: LineScrollAnimationRecord = { animation, lineElement, token };
+  lineScrollAnimations.push(record);
+
+  animation.addEventListener("finish", () => removeLineScrollAnimation(record), { once: true });
+  animation.addEventListener("cancel", () => removeLineScrollAnimation(record), { once: true });
+}
+
+function lineScrollSide(relativeIndex: number, scrollDeltaPx: number): LineScrollSide {
+  const isScrollingUp = scrollDeltaPx < 0;
+  if (relativeIndex < 0) return isScrollingUp ? "below" : "above";
+  if (relativeIndex > 0) return isScrollingUp ? "above" : "below";
+  return "active";
+}
+
+function setLineScrollSettingProperty(
+  lineElement: HTMLElement,
+  property: string,
+  setting: ReturnType<typeof registerThemeSetting>
+): void {
+  const value = setting.getStringValue().trim();
+  if (value) {
+    lineElement.style.setProperty(property, value);
+  } else {
+    lineElement.style.removeProperty(property);
+  }
+}
+
+function setLineScrollStyleProperties(lineElement: HTMLElement): void {
+  for (const [property, setting] of LINE_SCROLL_STYLE_SETTINGS) {
+    setLineScrollSettingProperty(lineElement, property, setting);
+  }
+}
+
+function lineScrollTranslate(side: LineScrollSide, state: LineScrollKeyframe, useDifferentialEffects: boolean): string {
+  const sideProperty = `--blyrics-line-scroll-${side}-translate-y-${state}`;
+  const sharedProperty = `--blyrics-line-scroll-translate-y-${state}`;
+  const fallback = state === "start" ? "var(--blyrics-line-scroll-delta-px, 0px)" : "0px";
+
+  if (useDifferentialEffects) {
+    return `0 var(${sideProperty}, var(${sharedProperty}, ${fallback}))`;
+  }
+
+  return `0 var(${sharedProperty}, ${fallback})`;
+}
+
+function computedTranslate(lineElement: HTMLElement): string {
+  const translate = window.getComputedStyle(lineElement).translate.trim();
+  return translate && translate !== "none" ? translate : "0px 0px";
+}
+
+function restoreInlineStyleProperty(
+  lineElement: HTMLElement,
+  property: string,
+  previousValue: string,
+  previousPriority: string
+): void {
+  if (previousValue) {
+    lineElement.style.setProperty(property, previousValue, previousPriority);
+  } else {
+    lineElement.style.removeProperty(property);
+  }
+}
+
+function resolveLineScrollTranslate(
+  lineElement: HTMLElement,
+  side: LineScrollSide,
+  state: LineScrollKeyframe,
+  useDifferentialEffects: boolean
+): string {
+  const previousTranslate = lineElement.style.getPropertyValue("translate");
+  const previousPriority = lineElement.style.getPropertyPriority("translate");
+
+  lineElement.style.setProperty("translate", lineScrollTranslate(side, state, useDifferentialEffects), "important");
+  const translate = computedTranslate(lineElement);
+  restoreInlineStyleProperty(lineElement, "translate", previousTranslate, previousPriority);
+
+  return translate;
+}
+
+function clearLineScrollInlineProperties(lineElement: HTMLElement, token?: number): void {
+  if (token !== undefined && lineScrollElementTokens.get(lineElement) !== token) {
+    return;
+  }
+
+  for (const property of LINE_SCROLL_INLINE_PROPERTIES) {
+    lineElement.style.removeProperty(property);
+  }
+  lineScrollElementTokens.delete(lineElement);
+}
+
+function resolveLineScrollDuration(
+  lineElement: HTMLElement,
+  side: LineScrollSide,
+  fallbackMs: number,
+  useDifferentialEffects: boolean
+): number {
+  const previousDuration = lineElement.style.transitionDuration;
+  const previousPriority = lineElement.style.getPropertyPriority("transition-duration");
+  const durationProperty = useDifferentialEffects
+    ? `var(--blyrics-line-scroll-${side}-duration, var(--blyrics-line-scroll-duration, ${fallbackMs}ms))`
+    : `var(--blyrics-line-scroll-duration, ${fallbackMs}ms)`;
+
+  lineElement.style.setProperty("transition-duration", durationProperty, "important");
+  const durationMs = toMs(window.getComputedStyle(lineElement).transitionDuration.split(",")[0].trim());
+
+  if (previousDuration) {
+    lineElement.style.setProperty("transition-duration", previousDuration, previousPriority);
+  } else {
+    lineElement.style.removeProperty("transition-duration");
+  }
+
+  return durationMs > 0 ? durationMs : fallbackMs;
+}
+
+function resolveLineScrollKeyframeEasing(
+  lineElement: HTMLElement,
+  side: LineScrollSide,
+  keyframe: LineScrollKeyframe,
+  fallback: string,
+  useDifferentialEffects: boolean
+): string {
+  const previousEasing = lineElement.style.transitionTimingFunction;
+  const previousPriority = lineElement.style.getPropertyPriority("transition-timing-function");
+  const easingProperty = useDifferentialEffects
+    ? `var(--blyrics-line-scroll-${side}-${keyframe}-easing, var(--blyrics-line-scroll-${keyframe}-easing, var(--blyrics-line-scroll-timing-function, ${fallback})))`
+    : `var(--blyrics-line-scroll-${keyframe}-easing, var(--blyrics-line-scroll-timing-function, ${fallback}))`;
+
+  lineElement.style.setProperty("transition-timing-function", easingProperty, "important");
+  const easing = window.getComputedStyle(lineElement).transitionTimingFunction.trim();
+
+  if (previousEasing) {
+    lineElement.style.setProperty("transition-timing-function", previousEasing, previousPriority);
+  } else {
+    lineElement.style.removeProperty("transition-timing-function");
+  }
+
+  return easing || fallback;
+}
+
+function isLineVisibleDuringScroll(
+  lineData: LineScrollItem,
+  fromScrollTop: number,
+  toScrollTop: number,
+  viewportHeight: number
+): boolean {
+  const visibleTop = Math.min(fromScrollTop, toScrollTop);
+  const visibleBottom = Math.max(fromScrollTop + viewportHeight, toScrollTop + viewportHeight);
+  const lineTop = lineData.position;
+  const lineBottom = lineData.position + lineData.height;
+  return lineBottom >= visibleTop && lineTop <= visibleBottom;
+}
+
+function clearVisibleLyricWillChange(): void {
+  for (const element of visibleWillChangeElements) {
+    element.style.removeProperty("will-change");
+  }
+  visibleWillChangeElements = new Set();
+}
+
+function updateVisibleLyricWillChange(
+  lines: LineScrollItem[],
+  fromScrollTop: number,
+  toScrollTop: number,
+  viewportHeight: number
+): void {
+  const nextVisibleElements = new Set<HTMLElement>();
+
+  for (const line of lines) {
+    if (isLineVisibleDuringScroll(line, fromScrollTop, toScrollTop, viewportHeight)) {
+      line.lyricElement.style.setProperty("will-change", LINE_SCROLL_WILL_CHANGE_VALUE);
+      nextVisibleElements.add(line.lyricElement);
+    }
+  }
+
+  for (const element of visibleWillChangeElements) {
+    if (!nextVisibleElements.has(element)) {
+      element.style.removeProperty("will-change");
+    }
+  }
+
+  visibleWillChangeElements = nextVisibleElements;
+}
+
+function getLineScrollItems(lines: LineData[], lyricsElement: HTMLElement): LineScrollItem[] {
+  const footer = lyricsElement.querySelector(`:scope > .${FOOTER_CLASS}`) as HTMLElement | null;
+  if (!footer) return lines;
+
+  const footerBounds = getRelativeLayoutBounds(lyricsElement, footer);
+  return [
+    ...lines,
+    {
+      lyricElement: footer,
+      position: footerBounds.y,
+      height: footerBounds.height,
+    },
+  ];
+}
+
+function animateLineScrollOffsets(
+  lines: LineScrollItem[],
+  activeLineIndex: number,
+  scrollDeltaPx: number,
+  fromScrollTop: number,
+  toScrollTop: number,
+  viewportHeight: number,
+  config: AnimationConfig
+): void {
+  if (!config.enabled.scroll || activeLineIndex < 0) {
+    return;
+  }
+
+  const scrollDistancePx = Math.abs(scrollDeltaPx);
+
+  for (let index = 0; index < lines.length; index++) {
+    if (!isLineVisibleDuringScroll(lines[index], fromScrollTop, toScrollTop, viewportHeight)) {
+      continue;
+    }
+
+    const lineElement = lines[index].lyricElement;
+    const relativeIndex = index - activeLineIndex;
+    const side = lineScrollSide(relativeIndex, scrollDeltaPx);
+
+    lineElement.style.setProperty(LINE_SCROLL_INDEX_PROPERTY, String(index));
+    lineElement.style.setProperty(LINE_SCROLL_ACTIVE_INDEX_PROPERTY, String(activeLineIndex));
+    lineElement.style.setProperty(LINE_SCROLL_RELATIVE_INDEX_PROPERTY, String(relativeIndex));
+    lineElement.style.setProperty(LINE_SCROLL_ABS_RELATIVE_INDEX_PROPERTY, String(Math.abs(relativeIndex)));
+    lineElement.style.setProperty(LINE_SCROLL_SIDE_PROPERTY, side);
+    lineElement.style.setProperty(LINE_SCROLL_DELTA_PROPERTY, `${scrollDeltaPx}px`);
+    lineElement.style.setProperty(LINE_SCROLL_DISTANCE_PROPERTY, `${scrollDistancePx}px`);
+    setLineScrollStyleProperties(lineElement);
+    const token = ++lineScrollAnimationToken;
+    lineScrollElementTokens.set(lineElement, token);
+
+    const durationMs = resolveLineScrollDuration(
+      lineElement,
+      side,
+      config.lineScroll.durationMs,
+      config.lineScroll.differentialEffects
+    );
+    const startEasing = resolveLineScrollKeyframeEasing(
+      lineElement,
+      side,
+      "start",
+      config.lineScroll.easing,
+      config.lineScroll.differentialEffects
+    );
+    const endEasing = resolveLineScrollKeyframeEasing(
+      lineElement,
+      side,
+      "end",
+      config.lineScroll.easing,
+      config.lineScroll.differentialEffects
+    );
+    const startTranslate = resolveLineScrollTranslate(
+      lineElement,
+      side,
+      "start",
+      config.lineScroll.differentialEffects
+    );
+    const endTranslate = resolveLineScrollTranslate(lineElement, side, "end", config.lineScroll.differentialEffects);
+
+    const animation = lineElement.animate(
+      [
+        { translate: startTranslate, easing: startEasing },
+        { translate: endTranslate, easing: endEasing },
+      ] as Keyframe[],
+      {
+        composite: "add",
+        duration: durationMs,
+        easing: "linear",
+        fill: "none",
+      }
+    );
+
+    trackLineScrollAnimation(animation, lineElement, token);
+  }
 }
 
 // -- Skip Scrolls Decay --------------------------
@@ -345,6 +1824,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
   // Don't tick lyrics if they're not visible
   if (tabSelector.getAttribute("aria-selected") !== "true" || !isPlayerOpen) {
     animEngineState.doneFirstInstantScroll = false;
+    clearVisibleLyricWillChange();
     return;
   }
 
@@ -376,16 +1856,28 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
 
     currentTime -= AppState.globalLyricOffset + AppState.lyricOffset;
 
-    const lyricScrollTime = currentTime + getCSSDurationInMs(lyricsElement, "--blyrics-scroll-timing-offset") / 1000;
+    const lyricScrollTime =
+      correctedScrollTimeS(currentTime) + getCSSDurationInMs(lyricsElement, "--blyrics-scroll-timing-offset") / 1000;
+    const animationConfig = readAnimationConfig(lyricsElement);
+    const scrollTiming = readScrollTiming(animationConfig.scroll.durationMs);
 
     // Read layout values before the loop writes class changes, to avoid forced reflow
     const tabRenderer = document.querySelector(TAB_RENDERER_SELECTOR) as HTMLElement | null;
-    if (!tabRenderer) return;
+    if (!tabRenderer) {
+      clearVisibleLyricWillChange();
+      return;
+    }
     if (tabRenderer !== observedTabRenderer) {
       setupTabRendererObserver(tabRenderer);
     }
     const tabRendererHeight = cachedTabRendererHeight ?? tabRenderer.getBoundingClientRect().height;
     let scrollTop = tabRenderer.scrollTop;
+    if (animationConfig.enabled.scroll) {
+      updateVisibleLyricWillChange(lines, scrollTop, scrollTop, tabRendererHeight);
+    } else {
+      clearVisibleLyricWillChange();
+      clearLineScrollAnimations();
+    }
 
     let activeElems = [] as LineData[];
     const linesToAnimate: LineData[] = [];
@@ -400,7 +1892,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
       }
 
       if (
-        lyricScrollTime >= time - EARLY_SCROLL_CONSIDER.getNumberValue() &&
+        lyricScrollTime >= time - scrollTiming.earlyScrollConsiderS &&
         (lyricScrollTime < nextTime || lyricScrollTime < time + lineData.duration)
       ) {
         activeElems.push(lineData);
@@ -437,36 +1929,59 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
       if (currentTime + setUpAnimationEarlyTime >= time && currentTime < effectiveEndTime) {
         lineData.isSelected = true;
 
-        const timeDelta = currentTime - time;
-        const animationTimingOffset = (now - lineData.animationStartTimeMs) / 1000 - timeDelta;
-        lineData.accumulatedOffsetMs = lineData.accumulatedOffsetMs / 1.08;
-        lineData.accumulatedOffsetMs += animationTimingOffset * 1000 * 0.4;
-        if (lineData.isAnimating && Math.abs(lineData.accumulatedOffsetMs) > 100 && isPlaying) {
-          lineData.isAnimating = false;
-          // console.warn("[BLyrics-diag] DRIFT RESET", {
-          //   accumulatedOffsetMs: lineData.accumulatedOffsetMs.toFixed(1),
-          //   animationTimingOffset: (animationTimingOffset * 1000).toFixed(1),
-          // });
-        }
-
         if (isPlaying !== lineData.isAnimationPlayStatePlaying) {
           lineData.isAnimationPlayStatePlaying = isPlaying;
-          const children = [lineData, ...lineData.parts];
-          if (!isPlaying) {
-            children.forEach(part => {
-              if (part.animationStartTimeMs > now) {
-                part.lyricElement.classList.remove(ANIMATING_CLASS);
-                part.lyricElement.classList.remove(PRE_ANIMATING_CLASS);
-              } else {
-                part.lyricElement.classList.add(PAUSED_CLASS);
-              }
-            });
-          } else {
-            children.forEach(part => {
-              part.lyricElement.classList.remove(PAUSED_CLASS);
-            });
-            lineData.isAnimating = false; // reset the animation
+          setAnimationsPlayState(lineData, isPlaying);
+          if (isPlaying) lineData.isAnimating = false; // reset the animation against current media time
+        }
+
+        const nativeTimingSample = lineNativeTimingSample(lineData, currentTime);
+        let usedNativeTimingSampleForDrift = false;
+        lineData.accumulatedOffsetMs = lineData.accumulatedOffsetMs / ANIMATION_TIMING_ACCUMULATION_DECAY;
+        if (nativeTimingSample !== null && canUseTimingSampleForDrift(nativeTimingSample, isPlaying)) {
+          usedNativeTimingSampleForDrift = true;
+          const learnedOffsetMs = learnAnimationTimingOffset(nativeTimingSample);
+          const residualOffsetMs = nativeTimingSample.offsetMs;
+          lineData.accumulatedOffsetMs += residualOffsetMs * ANIMATION_TIMING_ACCUMULATION_WEIGHT;
+          if (shouldLogAnimationTiming(lineData, nativeTimingSample, now)) {
+            logAnimationTiming(
+              "sample",
+              lineData,
+              index,
+              nativeTimingSample,
+              currentTime,
+              lineData.accumulatedOffsetMs,
+              learnedOffsetMs,
+              residualOffsetMs
+            );
           }
+        } else if (nativeTimingSample !== null && shouldLogAnimationTiming(lineData, nativeTimingSample, now)) {
+          logAnimationTiming(
+            "ignored-sample",
+            lineData,
+            index,
+            nativeTimingSample,
+            currentTime,
+            lineData.accumulatedOffsetMs
+          );
+        }
+        if (
+          lineData.isAnimating &&
+          usedNativeTimingSampleForDrift &&
+          Math.abs(lineData.accumulatedOffsetMs) > ANIMATION_TIMING_RESET_THRESHOLD_MS &&
+          isPlaying
+        ) {
+          if (nativeTimingSample !== null) {
+            logAnimationTiming(
+              "drift-reset",
+              lineData,
+              index,
+              nativeTimingSample,
+              currentTime,
+              lineData.accumulatedOffsetMs
+            );
+          }
+          resetLineAnimationState(lineData);
         }
 
         if (!lineData.isAnimating) {
@@ -474,67 +1989,44 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
           linesToAnimate.push(lineData);
         }
       } else {
+        const staleAnimationEndTime = effectiveEndTime + animationConfig.highlight.fadeOutDurationMs / 1000 + 0.05;
         if (lineData.isSelected) {
-          const children = [lineData, ...lineData.parts];
-          children.forEach(part => {
-            part.lyricElement.style.setProperty("--blyrics-swipe-delay", "");
-            part.lyricElement.style.setProperty("--blyrics-anim-delay", "");
-            part.lyricElement.classList.remove(ANIMATING_CLASS);
-            part.lyricElement.classList.remove(PRE_ANIMATING_CLASS);
-            part.lyricElement.classList.remove(PAUSED_CLASS);
-            part.animationStartTimeMs = Infinity;
-          });
-
+          if (isPlaying || timeJumped) {
+            if (currentTime > staleAnimationEndTime) {
+              logAnimationCleanup("selected-stale-reset", lineData, index, currentTime, staleAnimationEndTime);
+              resetLineAnimationState(lineData);
+            } else {
+              startLineExitAnimations(lineData, animationConfig, currentTime);
+              markLineAnimationsStopped(lineData);
+            }
+          } else {
+            setAnimationsPlayState(lineData, false);
+            lineData.isAnimationPlayStatePlaying = false;
+          }
           lineData.isSelected = false;
-          lineData.isAnimating = false;
+        } else if (hasLineAnimations(lineData) && (timeJumped || currentTime > staleAnimationEndTime)) {
+          logAnimationCleanup(
+            timeJumped ? "time-jump-reset" : "stale-reset",
+            lineData,
+            index,
+            currentTime,
+            staleAnimationEndTime
+          );
+          resetLineAnimationState(lineData);
         }
       }
       return true;
     });
 
-    // Batched animation to avoid multiple reflows and bring reflows from O(n) to O(1)
     if (linesToAnimate.length > 0) {
-      // Prepare: set delays and add pre animating class
       for (const lineData of linesToAnimate) {
-        // const isReset = lineData.animationStartTimeMs !== Infinity;
-        // console.warn("[BLyrics-diag] ANIM " + (isReset ? "RESET" : "START"), {
-        //   wordCount: lineData.parts.length,
-        // });
-        const children = [lineData, ...lineData.parts];
-        for (const part of children) {
-          const timeDelta = currentTime - part.time;
-          const swipeAnimationDelay = -timeDelta - part.duration * 0.1 + "s";
-          const everythingElseDelay = -timeDelta + "s";
-
-          part.lyricElement.classList.remove(ANIMATING_CLASS);
-          part.lyricElement.classList.remove(PAUSED_CLASS);
-          part.lyricElement.style.setProperty("--blyrics-swipe-delay", swipeAnimationDelay);
-          part.lyricElement.style.setProperty("--blyrics-anim-delay", everythingElseDelay);
-          part.lyricElement.classList.add(PRE_ANIMATING_CLASS);
-        }
-      }
-
-      // Single reflow to flush all pending class/style changes
-      reflow(linesToAnimate[0].lyricElement);
-
-      // Activate: add animating class and update state
-      for (const lineData of linesToAnimate) {
-        const children = [lineData, ...lineData.parts];
-        for (const part of children) {
-          const timeDelta = currentTime - part.time;
-          part.lyricElement.classList.add(ANIMATING_CLASS);
-          part.animationStartTimeMs = now - timeDelta * 1000;
-        }
+        startLineAnimations(lineData, animationConfig, currentTime);
         lineData.isAnimating = true;
         lineData.lastAnimSetupAt = now;
-        lineData.isAnimationPlayStatePlaying = true;
+        lineData.isAnimationPlayStatePlaying = isPlaying;
         lineData.accumulatedOffsetMs = 0;
+        if (!isPlaying) setAnimationsPlayState(lineData, false);
       }
-
-      // console.warn("[BLyrics-diag] BATCH ANIM", {
-      //   lines: linesToAnimate.length,
-      //   totalParts: linesToAnimate.reduce((s, l) => s + l.parts.length + 1, 0),
-      // });
     }
 
     if (animEngineState.scrollResumeTime < Date.now() || animEngineState.scrollPos === -1) {
@@ -570,7 +2062,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
       let scrollPos = avgPos - scrollPosOffset;
 
       // Make sure the first selected line is stays visible
-      scrollPos = Math.min(scrollPos, activeElems[0].position);
+      scrollPos = Math.min(scrollPos, lyricPositions[0]);
 
       // Make sure bottom of last active lyric is visible
       scrollPos = Math.max(scrollPos, lastActiveLyric.position - tabRendererHeight + lastActiveLyric.height);
@@ -688,22 +2180,21 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
           animEngineState.lastScrollDebugContext.activeElms = activeElems;
 
           if (smoothScroll && Math.abs(scrollTop - scrollPos) > 2) {
-            // console.warn("[BLyrics-diag] SCROLL REFLOW", {
-            //   delta: Math.abs(scrollTop - scrollPos).toFixed(0),
-            // });
-            lyricsElement.style.transitionTimingFunction = "";
-            lyricsElement.style.transitionProperty = "";
-            lyricsElement.style.transitionDuration = "";
-
-            let scrollTime = getCSSDurationInMs(lyricsElement, "transition-duration");
-
-            lyricsElement.style.transition = "none";
-            lyricsElement.style.transform = `translate(0px, ${-(scrollTop - scrollPos)}px)`;
-            reflow(lyricsElement);
-            lyricsElement.style.transition = "";
-            lyricsElement.style.transform = "translate(0px, 0px)";
-
-            animEngineState.nextScrollAllowedTime = scrollTime + Date.now() + 20;
+            const scrollDeltaPx = scrollPos - scrollTop;
+            if (animationConfig.enabled.scroll) {
+              updateVisibleLyricWillChange(lines, scrollTop, scrollPos, tabRendererHeight);
+              const lineScrollItems = getLineScrollItems(lines, lyricsElement);
+              animateLineScrollOffsets(
+                lineScrollItems,
+                lines.indexOf(lastActiveLyric),
+                scrollDeltaPx,
+                scrollTop,
+                scrollPos,
+                tabRendererHeight,
+                animationConfig
+              );
+              animEngineState.nextScrollAllowedTime = animationConfig.scroll.durationMs + Date.now() + 20;
+            }
           }
 
           scrollTop = scrollPos;
@@ -711,10 +2202,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
           tabRenderer.scrollTop = scrollTop;
           animEngineState.skipScrolls += 1;
           animEngineState.skipScrollsDecayTimes.push(Date.now() + 2000);
-        } else if (
-          animEngineState.nextScrollAllowedTime - Date.now() < QUEUE_SCROLL_THRESHOLD.getNumberValue() ||
-          timeJumped
-        ) {
+        } else if (animEngineState.nextScrollAllowedTime - Date.now() < scrollTiming.queueScrollMs || timeJumped) {
           // just missed out on being able to scroll, queue this once we finish our current lyric
           animEngineState.queuedScroll = true;
         }

--- a/src/modules/ui/animationEngineDebug.ts
+++ b/src/modules/ui/animationEngineDebug.ts
@@ -18,8 +18,6 @@ function createDebugCanvas() {
   canvas = document.createElement("canvas");
   canvas.id = CANVAS_ID;
   canvas.style.position = "fixed";
-  // canvas.style.top = "0";
-  // canvas.style.left = "0";
   canvas.style.width = "100%";
   canvas.style.height = "100%";
   canvas.style.order = "100";

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -1,6 +1,5 @@
 import {
   AD_PLAYING_ATTR,
-  BACKGROUND_LYRIC_CLASS,
   DISCORD_INVITE_URL,
   DISCORD_LOGO_SRC,
   DOCK_CLASS,
@@ -8,7 +7,6 @@ import {
   FOOTER_CLASS,
   FOOTER_NOT_VISIBLE_LOG,
   GENIUS_LOGO_SRC,
-  HAS_TRAILING_SPACE_CLASS,
   HIDDEN_CLASS,
   HOMEPAGE_DOMAIN,
   HOMEPAGE_ICON_URL,
@@ -31,11 +29,10 @@ import {
   type SyncType,
   TAB_RENDERER_SELECTOR,
   TRANSLATED_LYRICS_CLASS,
-  WORD_CLASS,
 } from "@constants";
 import { AppState } from "@core/appState";
 import { t } from "@core/i18n";
-import { disconnectResizeObserver } from "@modules/lyrics/injectLyrics";
+import { disconnectResizeObserver, WORD_HIGHLIGHT_CLASS } from "@modules/lyrics/injectLyrics";
 import type { ThumbnailElement } from "@modules/lyrics/requestSniffer/NextResponse";
 import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
 import {
@@ -51,7 +48,7 @@ import { getRequest, setRequest } from "@modules/unison/lyricsRequestTracker";
 import { getTrustTier } from "@modules/unison/trustTier";
 import type { UnisonLyricsRequest } from "@modules/unison/types";
 import { requestLyrics } from "@modules/unison/unisonApi";
-import { log } from "@utils";
+import { getRelativeLayoutBounds, log } from "@utils";
 import { generatePetName } from "@/core/keyIdentity";
 import { byId, deleteVote, type UnisonData, vote } from "../lyrics/providers/unison";
 import { buildControlsSegment, closeSourceMenu } from "./lyricsDock/controls";
@@ -249,28 +246,6 @@ function createRequestSyncedButton(meta: RequestButtonMeta): HTMLElement {
   return container;
 }
 
-// Word spans hold no whitespace; gaps are rendered from HAS_TRAILING_SPACE_CLASS, which is set only
-// where the source had a space. Reconstructing from it keeps words spaced ("I'll meet you") while
-// leaving syllables of one word fused ("divide", not "di vi de").
-function wordsToText(words: NodeListOf<Element>): string {
-  let out = "";
-  let prevBackground: boolean | null = null;
-  for (const w of words) {
-    const isBackground = w.classList.contains(BACKGROUND_LYRIC_CLASS);
-    if (prevBackground !== null && isBackground !== prevBackground) out += " ";
-    out += (w.textContent ?? "") + (w.classList.contains(HAS_TRAILING_SPACE_CLASS) ? " " : "");
-    prevBackground = isBackground;
-  }
-  return out.replace(/\s+/g, " ").trim();
-}
-
-function extractLineText(root: DocumentFragment | Element): string {
-  const main = wordsToText(root.querySelectorAll(`.${WORD_CLASS}`));
-  const romanized = root.querySelector(`.${ROMANIZED_LYRICS_CLASS}`)?.textContent?.trim();
-  const translated = root.querySelector(`.${TRANSLATED_LYRICS_CLASS}`)?.textContent?.trim();
-  return [main, romanized, translated].filter(Boolean).join("\n");
-}
-
 let lyricsObserver: MutationObserver | null = null;
 let adStateObserver: MutationObserver | null = null;
 /**
@@ -288,8 +263,6 @@ export function createLyricsWrapper(): HTMLElement {
 
   if (existingWrapper) {
     existingWrapper.replaceChildren();
-    existingWrapper.style.top = "";
-    existingWrapper.style.transition = "";
     return existingWrapper;
   }
 
@@ -304,10 +277,12 @@ export function createLyricsWrapper(): HTMLElement {
     const range = selection.getRangeAt(0);
     const fragment = range.cloneContents();
 
+    fragment.querySelectorAll(`.${WORD_HIGHLIGHT_CLASS}`).forEach(el => el.remove());
+
     const lineElements = fragment.querySelectorAll(".blyrics--line");
 
     if (lineElements.length === 0) {
-      const text = extractLineText(fragment) || fragment.textContent?.replace(/\s+/g, " ").trim();
+      const text = fragment.textContent?.replace(/\s+/g, " ").trim();
       if (text && e.clipboardData) {
         e.preventDefault();
         e.clipboardData.setData("text/plain", text);
@@ -318,8 +293,14 @@ export function createLyricsWrapper(): HTMLElement {
     const lines: string[] = [];
 
     for (const line of lineElements) {
-      const text = extractLineText(line);
-      if (text) lines.push(text);
+      const mainLine = Array.from(line.children).find(child => child.classList.contains("blyrics-line-main"));
+      const mainText = mainLine?.textContent?.replace(/\s+/g, " ").trim();
+
+      const romanized = line.querySelector(`.${ROMANIZED_LYRICS_CLASS}`)?.textContent?.trim();
+      const translated = line.querySelector(`.${TRANSLATED_LYRICS_CLASS}`)?.textContent?.trim();
+
+      const lineParts = [mainText, romanized, translated].filter(Boolean);
+      if (lineParts.length > 0) lines.push(lineParts.join("\n"));
     }
 
     if (lines.length > 0) {
@@ -1607,29 +1588,33 @@ function observeFooterForRecalc(footer: HTMLElement): void {
 }
 
 export function setExtraHeight() {
-  const lyricsElement = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement;
-  const lyricsHeight = lyricsElement.getBoundingClientRect().height;
-  const tabRenderer = document.querySelector(TAB_RENDERER_SELECTOR) as HTMLElement;
+  const lyricsElement = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement | undefined;
+  const tabRenderer = document.querySelector(TAB_RENDERER_SELECTOR) as HTMLElement | null;
+  if (!lyricsElement || !tabRenderer) return;
+
   const tabRendererHeight = tabRenderer.getBoundingClientRect().height;
   const scrollPosOffsetRatio = SCROLL_POS_OFFSET_RATIO.getNumberValue();
+  const currentPaddingBottom = Number.parseFloat(window.getComputedStyle(lyricsElement).paddingBottom) || 0;
+  const lyricsHeightWithoutBottomPadding = Math.max(0, lyricsElement.scrollHeight - currentPaddingBottom);
 
-  const firstLyric = document.querySelector("#blyrics-wrapper > div > div:nth-child(1)");
+  const lyricLines = lyricsElement.querySelectorAll<HTMLElement>(":scope > .blyrics--line");
+  const firstLyric = lyricLines[0] ?? null;
+  const lastLyric = lyricLines[lyricLines.length - 1] ?? null;
+  const firstLyricHeight = firstLyric ? getRelativeLayoutBounds(lyricsElement, firstLyric).height : 0;
+  const lastLyricBounds = lastLyric ? getRelativeLayoutBounds(lyricsElement, lastLyric) : null;
 
-  const paddingTop = Math.max(
-    0,
-    tabRendererHeight * scrollPosOffsetRatio - (firstLyric?.getBoundingClientRect().height || 0) / 2
-  );
+  const paddingTop = Math.max(0, tabRendererHeight * scrollPosOffsetRatio - firstLyricHeight / 2);
 
   document.documentElement.style.setProperty("--blyrics-padding-top", paddingTop + "px");
 
-  const footer = document.querySelector("#blyrics-wrapper > div > div.blyrics-footer");
-  const lastLyric = document.querySelector(".blyrics--line:not(:has(~ .blyrics--line))");
+  const lastLyricTargetContentHeight = lastLyricBounds
+    ? lastLyricBounds.y + lastLyricBounds.height / 2 + tabRendererHeight * (1 - scrollPosOffsetRatio)
+    : tabRendererHeight;
 
-  let extraHeight = Math.max(
-    tabRendererHeight * (1 - scrollPosOffsetRatio) -
-      (footer?.getBoundingClientRect().height || 0) -
-      (lastLyric?.getBoundingClientRect().height || 0) / 2,
-    tabRendererHeight - lyricsHeight
+  const extraHeight = Math.max(
+    lastLyricTargetContentHeight - lyricsHeightWithoutBottomPadding,
+    tabRendererHeight - lyricsHeightWithoutBottomPadding,
+    0
   );
 
   document.documentElement.style.setProperty("--blyrics-padding-bottom", Math.ceil(extraHeight) + "px");

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -21,7 +21,7 @@ import {
   animationEngine,
   animEngineState,
   getResumeScrollElement,
-  resetActiveAnimations,
+  noteAnimationVisibilityChange,
 } from "@modules/ui/animationEngine";
 import { adjustLyricOffset, OFFSET_STEP, OFFSET_STEP_LARGE } from "@modules/ui/lyricsDock/offset";
 import {
@@ -281,9 +281,7 @@ export function initializeLyrics(): void {
   hasInitializedLyrics = true;
 
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") {
-      resetActiveAnimations();
-    }
+    noteAnimationVisibilityChange();
   });
 
   // @ts-ignore

--- a/src/modules/ui/styleInjector.ts
+++ b/src/modules/ui/styleInjector.ts
@@ -3,7 +3,7 @@ import { decompressString, isCompressed } from "@core/compression";
 import { compileRicsToStyles, getLocalStorage, getSyncStorage, loadChunkedStyles } from "@core/storage";
 import { setThemeSettings } from "@modules/settings/themeOptions";
 import { log } from "@utils";
-import { cachedDurations } from "./animationEngine";
+import { clearAnimationStyleCache } from "./animationEngine";
 
 let hasSubscribedToStyles = false;
 
@@ -42,7 +42,7 @@ export function applyCustomStyles(css: string): void {
     styleTag.textContent = css;
     document.head.appendChild(styleTag);
   }
-  cachedDurations.clear();
+  clearAnimationStyleCache();
 }
 
 interface CSSStorageData {


### PR DESCRIPTION
https://github.com/user-attachments/assets/381a9e49-7216-473f-8a04-1a0fcf5d3809

### TL;DR

Replaces the CSS class + transition-based lyric animation system with the Web Animations API (WAAPI), rebuilds the lyric DOM structure to use proper inline text flow with bidi support, and exposes all animation visual values as CSS variables so themes can customize them without touching JavaScript.

### What changed?

**Animation engine (`animationEngine.ts`)**
- All lyric timing — line scale enter/exit, word highlight swipe, glow, fade-in/fade-out, word wobble, instrumental fill/wave travel, and scroll smoothing — is now driven by `element.animate()` instead of CSS class toggling and `transition-delay` tricks.
- Pause/resume is handled by pausing/resuming the active `Animation` objects rather than adding `.blyrics--paused` and freezing transitions.
- Seeking and drift resets cancel and recreate animations from the correct playback position using `animation.currentTime`.
- An `AnimationConfig` object is read from CSS variables once per tick, so all keyframe values, durations, easings, and enable flags remain in CSS and are cache-invalidated when styles change or `prefers-reduced-motion` fires.
- Scroll smoothing uses `element.animate()` instead of a CSS transition + forced reflow pattern.
- `.blyrics--animating`, `.blyrics--pre-animating`, `.blyrics--paused`, and `--blyrics-anim-delay` / `--blyrics-swipe-delay` are removed from the default timing path.

**DOM structure (`injectLyrics.ts`)**
- Each `.blyrics--line` now contains a `.blyrics-line-main` block and, when primary background vocals are present, a separate `.blyrics-background-line` block.
- Words are wrapped in `.blyrics-bidi-run` (inline, preserves logical DOM order) and `.blyrics-word-group` (inline-block for LTR, `display: contents` inside `.blyrics-bidi-sensitive` rows).
- Rows containing RTL script receive `.blyrics-bidi-sensitive`, which switches word groups to `display: contents` and word spans to `display: inline` so the browser's Unicode Bidirectional Algorithm can order and wrap the line correctly without reversing DOM order.
- Long words that need internal `<wbr>` break points get a `.blyrics-word-highlight` child element as a real overlay so the highlight wraps at the same points as the visible text, instead of relying solely on `::after`.
- Line-synced words (zero-duration) receive `.blyrics-line-synced-word` and fade in without the rich-sync gradient swipe.
- Flexbox layout, CSS `order`, `.blyrics--break` spacers, and `HAS_TRAILING_SPACE_CLASS` are removed; layout is normal inline text flow.
- Translated and romanized lines are appended as `div.blyrics--translated.blyrics-content-line` and `div.blyrics--romanized.blyrics-content-line` directly inside the line element without flex-order break elements.
- Translations and romanizations that were already cached are injected in a `queueMicrotask` after the main lyrics are rendered and committed.

**CSS variables (`variables.css`, `lyrics.css`)**
- Seven `--blyrics-animate-*` flags (`line-scale`, `word-wobble`, `highlight-swipe`, `highlight-glow`, `highlight-fade`, `scroll`, `instrumental`) control which effects are active; `1` enables, `0` disables.
- All keyframe values for line enter/exit transforms, swipe gradient start/end positions, glow filter values and duration ratios, word wobble transforms and keyframe offsets, and instrumental fill/wave transforms are now CSS variables.
- A `prefers-reduced-motion: reduce` block disables the vestibular triggers (line scale zoom, translateX word wobble, instrumental translateY fill) and flattens the scale delta; scroll, karaoke swipe, glow, and opacity fades are intentionally left on.
- `@property` initial values for `--lyric-transition-amount-start` and `--lyric-transition-amount-end` are set to the resting positions (`-0.2` / `-0.1`) so the gradient starts hidden without needing a reset rule.
- RTL gradient direction is applied via a selector on `.blyrics-rtl .blyrics-word-highlight` and `.blyrics-rtl.blyrics--word::after` rather than a separate class-toggled rule.

**Documentation (`STYLING.md`, `STYLING-SKILL.md`)**
- Both documents are updated to reflect the new DOM structure, CSS variable catalogue, animation timing model, bidi layout rules, and best practices.
- Theme cookbook examples for disabling animations, blur effects, user-scroll state, and long-word glow are updated to use the new selectors and flag variables.
- The "Do NOT Modify" and "Best Practices" sections are updated to remove references to removed classes and add RTL inline-flow guidance.

**Turkish locale** added to the generated locale list.

### How to test?

1. Open YouTube Music with the extension loaded and navigate to a song with richsynced lyrics. Verify the karaoke swipe, glow, word wobble, line scale, and scroll all play correctly in sync.
2. Seek to a mid-song position and confirm animations resume from the correct point without visual glitches.
3. Pause and resume playback; confirm animations freeze and resume cleanly without the highlight jumping.
4. Enable `prefers-reduced-motion: reduce` in the OS or browser and confirm line scale zoom and word wobble are disabled while the karaoke swipe and scroll remain active.
5. Test a song with line-synced-only lyrics and confirm words fade in word by word without a swipe effect.
6. Test a song with RTL lyrics (Arabic or Hebrew) and confirm correct visual word order, wrapping, and highlight timing.
7. Test a song with an instrumental break and confirm the fill travel and wave animations play and stop correctly.
8. Apply a custom theme that sets `--blyrics-animate-highlight-swipe: 0` and confirm words become fully highlighted instantly at their word time.
9. Confirm that setting `--blyrics-animate-scroll: 0` makes scroll position changes instant.
10. Verify that translated and romanized lines appear correctly and that cached translations are injected without blocking the initial render.

### Why make this change?

The previous system scheduled animations by writing `transition-delay` values and toggling CSS classes, which required forced reflows to flush style changes before the transition could start, made pause/resume fragile (freezing transitions with an astronomically large duration), and made seeking require a full class teardown and re-setup cycle. Moving to WAAPI gives precise, seekable, pausable animations that are composited off the main thread where possible, eliminates the forced-reflow batching workaround, and allows all visual parameters to live in CSS variables so theme authors can customize every aspect of the animation without patching JavaScript. The DOM restructuring to normal inline text flow fixes bidi ordering for RTL languages, which was broken by the previous flexbox + `order` approach, and the `.blyrics-word-highlight` overlay fixes the karaoke highlight on long words that need internal wrap points.