### PR TITLE
fix(options): add paste fallback for identity import

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -255,6 +255,30 @@
     "message": "Import Key",
     "description": "Import key button label"
   },
+  "options_identityImport_title": {
+    "message": "Import Identity",
+    "description": "Title of the import identity modal"
+  },
+  "options_identityImport_chooseFile": {
+    "message": "Choose File",
+    "description": "Label for the file picker button in the import identity modal"
+  },
+  "options_identityImport_or": {
+    "message": "or",
+    "description": "Divider between file picker and paste textarea in the import identity modal"
+  },
+  "options_identityImport_pastePlaceholder": {
+    "message": "Paste identity JSON here...",
+    "description": "Placeholder for the identity JSON textarea"
+  },
+  "options_identityImport_import": {
+    "message": "Import",
+    "description": "Confirm button label inside the import identity modal"
+  },
+  "options_alert_importEmpty": {
+    "message": "Paste identity JSON or choose a file first.",
+    "description": "Shown when the user clicks Import with no JSON provided"
+  },
 
   "options_modal_selectTheme": {
     "message": "Select a Theme",

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1827,6 +1827,76 @@ input.cm-textfield:focus-visible {
 	background: rgb(220, 38, 38);
 }
 
+/* -- Import Identity Modal --------------------------*/
+
+.import-identity-modal {
+	max-width: 480px;
+}
+
+.import-identity-file-btn {
+	width: 100%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.5rem;
+}
+
+.import-identity-file-btn svg {
+	flex-shrink: 0;
+}
+
+.modal-divider {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	margin: 1rem 0;
+	color: rgba(255, 255, 255, 0.4);
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.05em;
+}
+
+.modal-divider::before,
+.modal-divider::after {
+	content: "";
+	flex: 1;
+	height: 1px;
+	background: rgba(255, 255, 255, 0.1);
+}
+
+.modal-textarea {
+	width: 100%;
+	min-height: 8rem;
+	background: rgba(0, 0, 0, 0.1);
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 0.5rem;
+	padding: 0.75rem 1rem;
+	color: #fff;
+	font-size: 0.85rem;
+	font-family: "JetBrains Mono", Consolas, "Courier New", monospace;
+	line-height: 1.5;
+	outline: none;
+	resize: none;
+	transition: all 0.2s;
+	box-sizing: border-box;
+}
+
+.modal-textarea:focus {
+	border-color: rgba(255, 255, 255, 0.2);
+	background: rgba(0, 0, 0, 0.15);
+	box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.05);
+}
+
+.modal-textarea::placeholder {
+	color: rgba(255, 255, 255, 0.3);
+}
+
+.modal-textarea.dragging {
+	border-color: rgba(255, 255, 255, 0.35);
+	background: rgba(255, 255, 255, 0.05);
+	box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.08);
+}
+
 /* -- Unison Actions Modal --------------------------*/
 
 .unison-modal-row {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -572,6 +572,39 @@
 			</div>
 		</div>
 
+		<div id="import-identity-modal-overlay" class="modal-overlay">
+			<div class="modal import-identity-modal">
+				<div class="modal-header">
+					<h3 class="modal-title">__MSG_options_identityImport_title__</h3>
+					<button id="import-identity-modal-close" class="modal-close-btn" aria-label="Close">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+							<path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"></path>
+						</svg>
+					</button>
+				</div>
+				<div class="modal-body">
+					<button id="import-identity-file-btn" class="modal-btn modal-btn-secondary import-identity-file-btn">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="16" height="16">
+							<path fill-rule="evenodd" d="M12 2.25a.75.75 0 0 1 .75.75v11.69l3.22-3.22a.75.75 0 1 1 1.06 1.06l-4.5 4.5a.75.75 0 0 1-1.06 0l-4.5-4.5a.75.75 0 1 1 1.06-1.06l3.22 3.22V3a.75.75 0 0 1 .75-.75Zm-9 13.5a.75.75 0 0 1 .75.75v2.25a1.5 1.5 0 0 0 1.5 1.5h13.5a1.5 1.5 0 0 0 1.5-1.5V16.5a.75.75 0 0 1 1.5 0v2.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V16.5a.75.75 0 0 1 .75-.75Z" clip-rule="evenodd"></path>
+						</svg>
+						<span>__MSG_options_identityImport_chooseFile__</span>
+					</button>
+					<div class="modal-divider">
+						<span>__MSG_options_identityImport_or__</span>
+					</div>
+					<textarea id="import-identity-textarea" class="modal-textarea" rows="6" spellcheck="false" placeholder="__MSG_options_identityImport_pastePlaceholder__"></textarea>
+				</div>
+				<div class="modal-footer">
+					<button id="import-identity-cancel" class="modal-btn modal-btn-secondary">
+						__MSG_options_modal_cancel__
+					</button>
+					<button id="import-identity-confirm" class="modal-btn modal-btn-primary">
+						__MSG_options_identityImport_import__
+					</button>
+				</div>
+			</div>
+		</div>
+
 		<div id="theme-modal-overlay" class="modal-overlay">
 			<div class="modal theme-modal">
 				<div class="modal-header">

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -580,6 +580,7 @@ async function initIdentityUI(): Promise<void> {
 
   document.getElementById("export-identity-btn")?.addEventListener("click", handleExportIdentity);
   document.getElementById("import-identity-btn")?.addEventListener("click", handleImportIdentity);
+  initImportIdentityModal();
 }
 
 async function handleExportIdentity(): Promise<void> {
@@ -649,26 +650,124 @@ function fallbackDownloadIdentity(content: string, filename: string): void {
 }
 
 async function handleImportIdentity(): Promise<void> {
+  openImportIdentityModal();
+}
+
+// -- Import Identity Modal --------------------------
+
+function getImportIdentityModalElements() {
+  const overlay = document.getElementById("import-identity-modal-overlay");
+  const closeBtn = document.getElementById("import-identity-modal-close");
+  const fileBtn = document.getElementById("import-identity-file-btn");
+  const cancelBtn = document.getElementById("import-identity-cancel");
+  const confirmBtn = document.getElementById("import-identity-confirm");
+  const textarea = document.getElementById("import-identity-textarea") as HTMLTextAreaElement | null;
+  return { overlay, closeBtn, fileBtn, cancelBtn, confirmBtn, textarea };
+}
+
+function openImportIdentityModal(): void {
+  const { overlay, textarea } = getImportIdentityModalElements();
+  if (!overlay || !textarea) return;
+  textarea.value = "";
+  overlay.classList.add("active");
+  setTimeout(() => textarea.focus(), 100);
+}
+
+function closeImportIdentityModal(): void {
+  const { overlay } = getImportIdentityModalElements();
+  overlay?.classList.remove("active");
+}
+
+async function importIdentityFromJson(json: string): Promise<void> {
+  try {
+    const imported = await importIdentity(json);
+    updateIdentityDisplay(imported);
+    showAlert(t("options_alert_importSuccess"));
+    closeImportIdentityModal();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Invalid identity file";
+    showAlert(message);
+  }
+}
+
+function triggerIdentityFilePicker(): void {
   const input = document.createElement("input");
   input.type = "file";
-  input.accept = ".json";
+  input.accept = ".json,application/json";
+  input.style.display = "none";
 
-  input.onchange = async e => {
-    const file = (e.target as HTMLInputElement).files?.[0];
-    if (!file) return;
-
-    try {
-      const text = await file.text();
-      const imported = await importIdentity(text);
-      updateIdentityDisplay(imported);
-      showAlert(t("options_alert_importSuccess"));
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Invalid identity file";
-      showAlert(message);
-    }
+  const cleanup = (): void => {
+    input.remove();
   };
 
+  input.addEventListener("change", async event => {
+    try {
+      const file = (event.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      const text = await file.text();
+      await importIdentityFromJson(text);
+    } finally {
+      cleanup();
+    }
+  });
+
+  input.addEventListener("cancel", cleanup);
+
+  document.body.appendChild(input);
   input.click();
+}
+
+function initImportIdentityModal(): void {
+  const { overlay, closeBtn, fileBtn, cancelBtn, confirmBtn, textarea } = getImportIdentityModalElements();
+  if (!overlay || !closeBtn || !fileBtn || !cancelBtn || !confirmBtn || !textarea) return;
+
+  closeBtn.addEventListener("click", closeImportIdentityModal);
+  cancelBtn.addEventListener("click", closeImportIdentityModal);
+
+  overlay.addEventListener("click", e => {
+    if (e.target === overlay) closeImportIdentityModal();
+  });
+
+  document.addEventListener("keydown", e => {
+    if (e.key === "Escape" && overlay.classList.contains("active")) {
+      closeImportIdentityModal();
+    }
+  });
+
+  fileBtn.addEventListener("click", triggerIdentityFilePicker);
+
+  confirmBtn.addEventListener("click", async () => {
+    const json = textarea.value.trim();
+    if (!json) {
+      showAlert(t("options_alert_importEmpty"));
+      return;
+    }
+    await importIdentityFromJson(json);
+  });
+
+  textarea.addEventListener("dragover", e => {
+    if (!e.dataTransfer?.types.includes("Files")) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+    textarea.classList.add("dragging");
+  });
+
+  textarea.addEventListener("dragleave", () => {
+    textarea.classList.remove("dragging");
+  });
+
+  textarea.addEventListener("drop", async e => {
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) return;
+    e.preventDefault();
+    textarea.classList.remove("dragging");
+    try {
+      textarea.value = await file.text();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to read file";
+      showAlert(message);
+    }
+  });
 }
 
 function updateIdentityDisplay(identity: KeyIdentity): void {


### PR DESCRIPTION
## Overview

- Fixes #610 - Replace direct file picker with a modal exposing both a file chooser and a paste textarea (with drag-and-drop) so identity import works in the Firefox toolbar popup, where the popup auto-closes when the OS file dialog steals focus.


<img width="600" height="494" alt="image" src="https://github.com/user-attachments/assets/05f3d8f4-7950-4398-bb8e-fbee28b4fb53" />
