### PR TITLE
fix: pass chrome webstore credentials via env vars

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "better-lyrics",
-    "version": "2.3.0.2",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "better-lyrics",
-            "version": "2.3.0.2",
+            "version": "2.3.0",
             "license": "GPL-3.0",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.20.3",

--- a/tooling/publish-chrome.ts
+++ b/tooling/publish-chrome.ts
@@ -17,16 +17,18 @@ if (!zipPath) {
   process.exit(1);
 }
 
+const env = {
+  ...process.env,
+  EXTENSION_ID: extensionId,
+  CLIENT_ID: clientId,
+  CLIENT_SECRET: clientSecret,
+  REFRESH_TOKEN: refreshToken,
+};
+
 try {
   execSync("npm install -g chrome-webstore-upload-cli");
-  execSync(
-    `chrome-webstore-upload upload --source ${zipPath} --extension-id ${extensionId} --client-id ${clientId} --client-secret ${clientSecret} --refresh-token ${refreshToken}`,
-    { stdio: "inherit" }
-  );
-  execSync(
-    `chrome-webstore-upload publish --extension-id ${extensionId} --client-id ${clientId} --client-secret ${clientSecret} --refresh-token ${refreshToken}`,
-    { stdio: "inherit" }
-  );
+  execSync(`chrome-webstore-upload upload --source ${zipPath}`, { stdio: "inherit", env });
+  execSync("chrome-webstore-upload publish", { stdio: "inherit", env });
   console.log("Successfully published to Chrome Web Store.");
 } catch (error) {
   console.error("Failed to publish to Chrome Web Store:", error);


### PR DESCRIPTION
## Summary
- chrome-webstore-upload-cli dropped `--client-id`, `--client-secret`, `--refresh-token` flags (see [issue #80](https://github.com/fregante/chrome-webstore-upload-cli/issues/80)); release workflow was failing on `npx tsx tooling/publish-chrome.ts`
- pass all four credentials through the `env` option on `execSync` instead, which is the now-required path
- also drop `--extension-id` flag in favour of the `EXTENSION_ID` env var for consistency

## Test plan
- [ ] next non-canary release run completes `publish-chrome` step without the "flags are no longer supported" error