### PR TITLE
fix: strip key from edge manifest in CI build

### DIFF
--- a/tooling/build-and-patch.ts
+++ b/tooling/build-and-patch.ts
@@ -1,4 +1,6 @@
 import { execSync } from "child_process";
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
 
 const browsers = ["chrome", "edge", "firefox"];
 
@@ -8,6 +10,14 @@ try {
   for (const browser of browsers) {
     console.log(`Building for ${browser}...`);
     execSync(`extension build --browser ${browser} --polyfill`, { stdio: "inherit" });
+
+    if (browser === "edge") {
+      console.log("Removing key field from manifest.json for edge...");
+      const manifestPath = join(`dist/${browser}`, "manifest.json");
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+      delete manifest.key;
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+    }
 
     console.log(`Copying sourcemaps for ${browser}...`);
     execSync(`mkdir -p sourcemaps_for_upload/${browser}`, { stdio: "inherit" });


### PR DESCRIPTION
## Summary
- `tooling/build-release-zip.ts` already strips the `key` field from the Edge build manifest, but the CI path (`build:ci` → `tooling/build-and-patch.ts`) didn't, so Edge zips uploaded by the release workflow still contained `key`
- Edge Add-ons rejects manifests with `key` (`The manifest shouldn't contain the key field.`), which broke the v2.3.0 manual upload
- Apply the same delete-after-build step in `build-and-patch.ts`

## Test plan
- [ ] next release run produces an `edge-vX.Y.Z.zip` whose `manifest.json` has no `key` field
- [ ] manual Edge Add-ons upload accepts the zip