### PR TITLE
fix: stop video-mode sizing rules from blowing up miniplayer

### DIFF
--- a/public/css/ytmusic/fullscreen.css
+++ b/public/css/ytmusic/fullscreen.css
@@ -69,9 +69,9 @@ ytmusic-player-page:not([is-mweb-modernization-enabled])[player-fullscreened]:no
   margin: 0 auto;
 }
 
-ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #movie_player,
-ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #song-media-window,
-ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #player.ytmusic-player-page {
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode]:not([player-ui-state=MINIPLAYER]) #movie_player,
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode]:not([player-ui-state=MINIPLAYER]) #song-media-window,
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode]:not([player-ui-state=MINIPLAYER]) #player.ytmusic-player-page {
   aspect-ratio: var(--blyrics-video-aspect-ratio);
   height: auto;
   min-height: 0;
@@ -87,9 +87,9 @@ ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode] #av-id {
 
 /* Cap #player width so width / aspect-ratio (its derived height) fits in the
    available vertical space. Without this, tall videos like 4:3 overflow on
-   wide screens — the bottom is hidden by the player bar in non-fullscreen, or
+   wide screens: the bottom is hidden by the player bar in non-fullscreen, or
    pushes the song-info off-screen in fullscreen. */
-ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode]:not([player-fullscreened]) #player.ytmusic-player-page {
+ytmusic-player-page:not([blyrics-dfs])[blyrics-video-mode]:not([player-fullscreened]):not([player-ui-state=MINIPLAYER]) #player.ytmusic-player-page {
   width: min(
     100%,
     calc((100vh - 80px - var(--ytmusic-player-page-vertical-padding) - var(--ytmusic-nav-bar-height) - var(--ytmusic-player-bar-height)) * (var(--blyrics-video-aspect-ratio)))


### PR DESCRIPTION
## Overview

- Exclude `player-ui-state="MINIPLAYER"` from the `[blyrics-video-mode]` rules in `public/css/ytmusic/fullscreen.css` that set aspect-ratio/height and viewport-derived width on `#player`.
- In miniplayer state with a music video active, those rules overrode YTM's sizing and stretched the player to full page width.
