### PR TITLE
fix: cursor auto-hide and end-of-song scroll padding

### DIFF
--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -5,6 +5,7 @@ import { log, setUpLog } from "@core/utils";
 import { calculateLyricPositions } from "@modules/lyrics/injectLyrics";
 import { clearCache as clearTranslationCache } from "@modules/lyrics/translation";
 import { mountUnisonDock, reloadAlbumArt, unmountUnisonDock, updateUnisonDockPosition } from "@modules/ui/dom";
+import { isPlayerFullscreened, onFullscreenChange } from "@modules/ui/observer";
 import { applyCustomStyles, getAndApplyCustomStyles } from "@modules/ui/styleInjector";
 
 let hasInitializedMessageListener = false;
@@ -118,47 +119,75 @@ function onAutoHideCursor(
 
 let mouseTimer: number | null = null;
 let cursorEventListener: ((this: Document, ev: MouseEvent) => any) | null = null;
+let cursorAutoHideSettingEnabled = false;
+let fullscreenCursorHandlersRegistered = false;
+let cursorVisible = true;
+
+function detachCursorListener(): void {
+  if (mouseTimer) {
+    window.clearTimeout(mouseTimer);
+    mouseTimer = null;
+  }
+  if (cursorEventListener) {
+    document.removeEventListener("mousemove", cursorEventListener);
+    cursorEventListener = null;
+  }
+  document.getElementById("layout")?.removeAttribute("cursor-hidden");
+  cursorVisible = true;
+}
+
+function attachCursorListener(): void {
+  if (cursorEventListener) return;
+
+  cursorVisible = true;
+  document.getElementById("layout")?.removeAttribute("cursor-hidden");
+
+  function disappearCursor(): void {
+    mouseTimer = null;
+    if (cursorVisible) {
+      document.getElementById("layout")?.setAttribute("cursor-hidden", "");
+    }
+    cursorVisible = false;
+  }
+
+  function handleMouseMove(): void {
+    if (mouseTimer) {
+      window.clearTimeout(mouseTimer);
+    }
+    if (!cursorVisible) {
+      document.getElementById("layout")?.removeAttribute("cursor-hidden");
+      cursorVisible = true;
+    }
+    mouseTimer = window.setTimeout(disappearCursor, 3000);
+  }
+
+  cursorEventListener = handleMouseMove;
+  document.addEventListener("mousemove", handleMouseMove);
+  mouseTimer = window.setTimeout(disappearCursor, 3000);
+}
+
+function syncCursorListener(): void {
+  if (cursorAutoHideSettingEnabled && isPlayerFullscreened()) {
+    attachCursorListener();
+  } else {
+    detachCursorListener();
+  }
+}
 
 export function hideCursorOnIdle(): void {
+  if (!fullscreenCursorHandlersRegistered) {
+    fullscreenCursorHandlersRegistered = true;
+    onFullscreenChange(syncCursorListener, syncCursorListener);
+  }
+
   onAutoHideCursor(
     () => {
-      let cursorVisible = true;
-
-      function disappearCursor() {
-        mouseTimer = null;
-        if (cursorVisible) {
-          document.getElementById("layout")!.setAttribute("cursor-hidden", "");
-        }
-        cursorVisible = false;
-      }
-
-      function handleMouseMove() {
-        if (mouseTimer) {
-          window.clearTimeout(mouseTimer);
-        }
-        if (!cursorVisible) {
-          document.getElementById("layout")!.removeAttribute("cursor-hidden");
-          cursorVisible = true;
-        }
-        mouseTimer = window.setTimeout(disappearCursor, 3000);
-      }
-
-      if (cursorEventListener) {
-        document.removeEventListener("mousemove", cursorEventListener);
-      }
-
-      cursorEventListener = handleMouseMove;
-      document.addEventListener("mousemove", handleMouseMove);
+      cursorAutoHideSettingEnabled = true;
+      syncCursorListener();
     },
     () => {
-      if (mouseTimer) {
-        window.clearTimeout(mouseTimer);
-      }
-      document.getElementById("layout")!.removeAttribute("cursor-hidden");
-      if (cursorEventListener) {
-        document.removeEventListener("mousemove", cursorEventListener);
-        cursorEventListener = null;
-      }
+      cursorAutoHideSettingEnabled = false;
+      syncCursorListener();
     }
   );
 }

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -35,6 +35,7 @@ import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
 import {
   animEngineState,
   getResumeScrollElement,
+  lyricsElementAdded,
   reflow,
   resetAnimEngineState,
   SCROLL_POS_OFFSET_RATIO,
@@ -363,6 +364,7 @@ export function addFooter(
   const footer = document.createElement("div");
   footer.classList.add(FOOTER_CLASS);
   lyricsElement.appendChild(footer);
+  observeFooterForRecalc(footer);
   createFooter(song, artist, album, duration, videoId, showRequestButton);
 
   const footerLink = document.getElementById("betterLyricsFooterLink") as HTMLAnchorElement;
@@ -1311,6 +1313,18 @@ function getGeniusLink(song: string, artist: string): string {
   return `https://duckduckgo.com/?q=${query}`;
 }
 
+let footerResizeObserver: ResizeObserver | null = null;
+
+function observeFooterForRecalc(footer: HTMLElement): void {
+  if (footerResizeObserver) {
+    footerResizeObserver.disconnect();
+  }
+  footerResizeObserver = new ResizeObserver(() => {
+    lyricsElementAdded();
+  });
+  footerResizeObserver.observe(footer);
+}
+
 export function setExtraHeight() {
   const lyricsElement = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement;
   const lyricsHeight = lyricsElement.getBoundingClientRect().height;
@@ -1337,5 +1351,5 @@ export function setExtraHeight() {
     tabRendererHeight - lyricsHeight
   );
 
-  document.documentElement.style.setProperty("--blyrics-padding-bottom", extraHeight + "px");
+  document.documentElement.style.setProperty("--blyrics-padding-bottom", Math.ceil(extraHeight) + "px");
 }

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -93,15 +93,16 @@ function cleanupWakeLock(): void {
 
 type FullscreenCallback = () => void;
 
-function onFullscreenChange(onEnter: FullscreenCallback, onExit: FullscreenCallback): void {
+const fullscreenEnterCallbacks: FullscreenCallback[] = [];
+const fullscreenExitCallbacks: FullscreenCallback[] = [];
+
+function ensureFullscreenObserver(): void {
+  if (fullscreenObserver) return;
+
   const appLayout = document.querySelector("ytmusic-app-layout");
   if (!appLayout) {
-    setTimeout(() => onFullscreenChange(onEnter, onExit), 1000);
+    setTimeout(ensureFullscreenObserver, 1000);
     return;
-  }
-
-  if (fullscreenObserver) {
-    fullscreenObserver.disconnect();
   }
 
   let wasFullscreen = appLayout.hasAttribute("player-fullscreened");
@@ -110,15 +111,25 @@ function onFullscreenChange(onEnter: FullscreenCallback, onExit: FullscreenCallb
     const isFullscreen = appLayout.hasAttribute("player-fullscreened");
 
     if (!wasFullscreen && isFullscreen) {
-      onEnter();
+      fullscreenEnterCallbacks.forEach(cb => cb());
     } else if (wasFullscreen && !isFullscreen) {
-      onExit();
+      fullscreenExitCallbacks.forEach(cb => cb());
     }
 
     wasFullscreen = isFullscreen;
   });
 
   fullscreenObserver.observe(appLayout, { attributes: true, attributeFilter: ["player-fullscreened"] });
+}
+
+export function onFullscreenChange(onEnter: FullscreenCallback, onExit: FullscreenCallback): void {
+  fullscreenEnterCallbacks.push(onEnter);
+  fullscreenExitCallbacks.push(onExit);
+  ensureFullscreenObserver();
+}
+
+export function isPlayerFullscreened(): boolean {
+  return document.querySelector("ytmusic-app-layout")?.hasAttribute("player-fullscreened") ?? false;
 }
 
 export function setupWakeLockForFullscreen(): void {


### PR DESCRIPTION
## Overview
- Cursor auto-hide only runs while in fullscreen. Previously the 3s timer could expire silently before fullscreen was entered, so the cursor disappeared the moment you opened fullscreen instead of after a 3s grace.
- End-of-song scroll padding recomputes when the footer resizes (request button hydrating, Unison card mounting, etc.), and rounds up by 1px to absorb sub-pixel rounding. Fixes the last few lyrics not scrolling.
- `onFullscreenChange` now supports multiple subscribers.

## Test plan
- [ ] Idle on YT Music for more than 3s outside fullscreen, then enter fullscreen. Cursor stays visible for a full 3s before hiding.
- [ ] Exit fullscreen. Cursor visible immediately, `cursor-hidden` attribute cleared from `#layout`.
- [ ] Toggle auto-hide setting on/off while fullscreened. State updates immediately.
- [ ] Play a song to its end. Autoscroll continues smoothly through the final lines, last line centered around 37% from top.
- [ ] Play a song with translation/romanization enabled to end. Last line still scrolls correctly.
- [ ] Play a song that mounts a Unison card or hydrates the request button mid-playback. Padding adjusts without leaving last lyrics stuck.