### PR TITLE
feat(auth): migrate sign-in to long-lived port

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1123,6 +1123,10 @@
     "message": "Invalid sign-in request.",
     "description": "Error state shown when the popup receives malformed parameters"
   },
+  "auth_sessionExpired": {
+    "message": "Sign-in expired. Please close this window and try again.",
+    "description": "Shown in the sign-in consent popup when the connection to the extension's service worker is lost before the user can approve or cancel."
+  },
   "lyrics_requestSyncedVersion": {
     "message": "Request a synced version",
     "description": "Button label asking the community to contribute synced lyrics for the current song"

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,9 @@
     "downloads"
   ],
   "optional_host_permissions": [],
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com https://fonts.googleapis.com; font-src 'self' data: https://cdn.fontshare.com https://fonts.gstatic.com; img-src 'self' data: https://blrcunison.vercel.app https://boidu.dev https://raw.githubusercontent.com https://placehold.co; connect-src https://unison.boidu.dev https://raw.githubusercontent.com https://api.github.com https://better-lyrics-themes-api.boidu.dev; frame-src https://better-lyrics-themes-api.boidu.dev;"
+  },
   "options_ui": {
     "page": "src/options/options.html",
     "open_in_tab": false

--- a/manifest.json
+++ b/manifest.json
@@ -29,7 +29,7 @@
   ],
   "optional_host_permissions": [],
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com https://fonts.googleapis.com; font-src 'self' data: https://cdn.fontshare.com https://fonts.gstatic.com; img-src 'self' data: https://blrcunison.vercel.app https://boidu.dev https://raw.githubusercontent.com https://placehold.co; connect-src https://unison.boidu.dev https://raw.githubusercontent.com https://api.github.com https://better-lyrics-themes-api.boidu.dev; frame-src https://better-lyrics-themes-api.boidu.dev;"
+    "extension_pages": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://api.fontshare.com https://fonts.googleapis.com; font-src 'self' data: https://cdn.fontshare.com https://fonts.gstatic.com; img-src 'self' data: https://blrcunison.vercel.app https://boidu.dev https://betterlyrics.org https://raw.githubusercontent.com https://placehold.co; connect-src https://unison.boidu.dev https://raw.githubusercontent.com https://api.github.com https://better-lyrics-themes-api.boidu.dev; frame-src https://better-lyrics-themes-api.boidu.dev;"
   },
   "options_ui": {
     "page": "src/options/options.html",

--- a/pages/auth.html
+++ b/pages/auth.html
@@ -48,7 +48,7 @@
         </label>
       </section>
 
-      <p class="auth-card__error" id="auth-error" hidden></p>
+      <p class="auth-card__error" id="auth-error" role="status" hidden></p>
     </main>
 
     <footer class="auth-page__footer">

--- a/pages/auth.html
+++ b/pages/auth.html
@@ -9,6 +9,7 @@
 			style-src 'self' 'unsafe-inline' https://api.fontshare.com;
 			font-src 'self' data: https://cdn.fontshare.com;
       img-src 'self' data: https://blrcunison.vercel.app https://boidu.dev;
+      connect-src https://unison.boidu.dev;
     " />
     <title>__MSG_auth_pageTitle__</title>
 		<link

--- a/pages/auth.html
+++ b/pages/auth.html
@@ -3,14 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="color-scheme" content="dark light" />
-    <meta http-equiv="Content-Security-Policy" content="
-      default-src 'self';
-      script-src 'self';
-			style-src 'self' 'unsafe-inline' https://api.fontshare.com;
-			font-src 'self' data: https://cdn.fontshare.com;
-      img-src 'self' data: https://blrcunison.vercel.app https://boidu.dev;
-      connect-src https://unison.boidu.dev;
-    " />
     <title>__MSG_auth_pageTitle__</title>
 		<link
 			href="https://api.fontshare.com/v2/css?f[]=satoshi@1&display=swap"

--- a/pages/auth.html
+++ b/pages/auth.html
@@ -48,7 +48,7 @@
         </label>
       </section>
 
-      <p class="auth-card__error" id="auth-error" role="status" hidden></p>
+      <p class="auth-card__error" id="auth-error" role="status"></p>
     </main>
 
     <footer class="auth-page__footer">

--- a/pages/marketplace.html
+++ b/pages/marketplace.html
@@ -1,15 +1,6 @@
 <html lang="en-US" style="width: unset; max-width: unset">
 	<head>
 		<meta name="color-scheme" content="dark" />
-		<meta http-equiv="Content-Security-Policy" content="
-			default-src 'self';
-			script-src 'self';
-			style-src 'self' 'unsafe-inline' https://api.fontshare.com;
-			font-src https://cdn.fontshare.com;
-			img-src 'self' https://raw.githubusercontent.com https://placehold.co data:;
-			connect-src https://raw.githubusercontent.com https://api.github.com https://better-lyrics-themes-api.boidu.dev;
-			frame-src https://better-lyrics-themes-api.boidu.dev;
-		" />
 		<title>__MSG_marketplace_pageTitle__</title>
 		<link
 			href="https://api.fontshare.com/v2/css?f[]=satoshi@1&display=swap"

--- a/pages/unison.html
+++ b/pages/unison.html
@@ -1,14 +1,6 @@
 <html lang="en-US" style="width: unset; max-width: unset">
 	<head>
 		<meta name="color-scheme" content="dark" />
-		<meta http-equiv="Content-Security-Policy" content="
-			default-src 'self';
-			script-src 'self';
-			style-src 'self' 'unsafe-inline' https://api.fontshare.com;
-			font-src https://cdn.fontshare.com;
-			img-src 'self' data:;
-			connect-src https://unison.boidu.dev;
-		" />
 		<title>__MSG_unison_pageTitle__</title>
 		<link
 			href="https://api.fontshare.com/v2/css?f[]=satoshi@1&display=swap"

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -131,10 +131,18 @@ export interface AuthPartner {
   iconUrl: string | null;
 }
 
-const AUTH_PARTNERS: readonly AuthPartner[] = [
-  { id: "unison", origin: "https://unison.boidu.dev", iconUrl: null },
-  { id: "blrcunison", origin: "https://blrcunison.vercel.app", iconUrl: "https://blrcunison.vercel.app/logo_mono.svg" },
-];
+const AUTH_PARTNER_METADATA: Record<string, Pick<AuthPartner, "id" | "iconUrl">> = {
+  "https://unison.boidu.dev": { id: "unison", iconUrl: null },
+  "https://blrcunison.vercel.app": { id: "blrcunison", iconUrl: "https://blrcunison.vercel.app/logo_mono.svg" },
+};
+
+const AUTH_PARTNERS: readonly AuthPartner[] = (chrome.runtime.getManifest().externally_connectable?.matches ?? [])
+  .map(match => match.replace(/\/\*$/, ""))
+  .map(origin => ({
+    origin,
+    id: AUTH_PARTNER_METADATA[origin]?.id ?? origin,
+    iconUrl: AUTH_PARTNER_METADATA[origin]?.iconUrl ?? null,
+  }));
 
 export function getAuthPartnerByOrigin(origin: string | undefined): AuthPartner | undefined {
   if (!origin) return undefined;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -123,6 +123,8 @@ export const AUTH_MESSAGE_TYPES = {
 
 export const AUTH_PORT_NAME_PREFIX = "bl-auth-popup:" as const;
 
+export const BL_AUTH_SITE_PORT_NAME = "bl-auth-site" as const;
+
 export interface AuthPartner {
   id: string;
   origin: string;

--- a/src/modules/auth/backgroundAuth.ts
+++ b/src/modules/auth/backgroundAuth.ts
@@ -1,4 +1,10 @@
-import { AUTH_MESSAGE_TYPES, AUTH_PORT_NAME_PREFIX, isAllowedAuthOrigin, LOG_PREFIX_AUTH } from "@constants";
+import {
+  AUTH_MESSAGE_TYPES,
+  AUTH_PORT_NAME_PREFIX,
+  BL_AUTH_SITE_PORT_NAME,
+  isAllowedAuthOrigin,
+  LOG_PREFIX_AUTH,
+} from "@constants";
 import { signPayload } from "@core/keyIdentity";
 import { isApproved, pruneExpired, rememberApproval } from "@modules/auth/approvedOrigins";
 
@@ -19,7 +25,7 @@ type ExternalResponse =
   | { ok: false; reason: "ORIGIN_MISMATCH" | "INVALID_REQUEST" | "USER_CANCELLED" | "USER_DISMISSED" | "SIGN_FAILED" };
 
 interface PendingRequest {
-  resolve: (response: ExternalResponse) => void;
+  sitePort: chrome.runtime.Port;
   origin: string;
   nonce: string;
   port: chrome.runtime.Port | null;
@@ -56,7 +62,14 @@ function resolveSlot(slot: PendingRequest, requestId: string, response: External
   if (slot.resolved) return;
   slot.resolved = true;
   pending.delete(requestId);
-  slot.resolve(response);
+
+  try {
+    slot.sitePort.postMessage(response);
+    slot.sitePort.disconnect();
+  } catch (err) {
+    console.warn(LOG_PREFIX_AUTH, "site port post failed", err);
+  }
+
   if (slot.windowId !== null) {
     chrome.windows.remove(slot.windowId).catch(err => console.warn(LOG_PREFIX_AUTH, "window remove failed", err));
   }
@@ -113,43 +126,78 @@ async function handlePortMessage(requestId: string, slot: PendingRequest, msg: P
 export function initBackgroundAuth(): void {
   pruneExpired().catch(err => console.warn(LOG_PREFIX_AUTH, "pruneExpired failed", err));
 
-  chrome.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {
-    void (async () => {
-      if (!isAllowedAuthOrigin(sender.origin)) {
-        sendResponse({ ok: false, reason: "ORIGIN_MISMATCH" });
-        return;
-      }
-      if (!isValidAuthRequest(message)) {
-        sendResponse({ ok: false, reason: "INVALID_REQUEST" });
-        return;
-      }
-      if (sender.origin !== message.origin) {
-        sendResponse({ ok: false, reason: "ORIGIN_MISMATCH" });
-        return;
-      }
+  chrome.runtime.onConnectExternal.addListener(sitePort => {
+    if (sitePort.name !== BL_AUTH_SITE_PORT_NAME) {
+      sitePort.disconnect();
+      return;
+    }
 
-      if (await isApproved(message.origin)) {
-        sendResponse(await signFor(message));
-        return;
-      }
+    const senderOrigin = sitePort.sender?.origin;
+    if (!isAllowedAuthOrigin(senderOrigin)) {
+      sitePort.disconnect();
+      return;
+    }
 
-      const requestId = crypto.randomUUID();
-      const windowId = await openConsentPopup(requestId, message);
-      if (windowId === null) {
-        sendResponse({ ok: false, reason: "USER_DISMISSED" });
-        return;
-      }
+    let handled = false;
 
-      pending.set(requestId, {
-        resolve: sendResponse,
-        origin: message.origin,
-        nonce: message.nonce,
-        port: null,
-        windowId,
-        resolved: false,
-      });
-    })();
-    return true;
+    sitePort.onMessage.addListener(message => {
+      if (handled) return;
+      handled = true;
+
+      void (async () => {
+        if (!isValidAuthRequest(message)) {
+          sitePort.postMessage({ ok: false, reason: "INVALID_REQUEST" });
+          sitePort.disconnect();
+          return;
+        }
+        if (senderOrigin !== message.origin) {
+          sitePort.postMessage({ ok: false, reason: "ORIGIN_MISMATCH" });
+          sitePort.disconnect();
+          return;
+        }
+
+        if (await isApproved(message.origin)) {
+          const signed = await signFor(message);
+          try {
+            sitePort.postMessage(signed);
+            sitePort.disconnect();
+          } catch (err) {
+            console.warn(LOG_PREFIX_AUTH, "site port post failed", err);
+          }
+          return;
+        }
+
+        const requestId = crypto.randomUUID();
+        const windowId = await openConsentPopup(requestId, message);
+        if (windowId === null) {
+          sitePort.postMessage({ ok: false, reason: "USER_DISMISSED" });
+          sitePort.disconnect();
+          return;
+        }
+
+        pending.set(requestId, {
+          sitePort,
+          origin: message.origin,
+          nonce: message.nonce,
+          port: null,
+          windowId,
+          resolved: false,
+        });
+      })().catch(err => console.warn(LOG_PREFIX_AUTH, "site port handler failed", err));
+    });
+
+    sitePort.onDisconnect.addListener(() => {
+      for (const [requestId, slot] of pending) {
+        if (slot.sitePort === sitePort && !slot.resolved) {
+          slot.resolved = true;
+          pending.delete(requestId);
+          if (slot.windowId !== null) {
+            chrome.windows.remove(slot.windowId).catch(() => {});
+          }
+          return;
+        }
+      }
+    });
   });
 
   chrome.runtime.onConnect.addListener(port => {

--- a/src/modules/auth/backgroundAuth.ts
+++ b/src/modules/auth/backgroundAuth.ts
@@ -28,7 +28,7 @@ interface PendingRequest {
   sitePort: chrome.runtime.Port;
   origin: string;
   nonce: string;
-  port: chrome.runtime.Port | null;
+  popupPort: chrome.runtime.Port | null;
   windowId: number | null;
   resolved: boolean;
 }
@@ -66,6 +66,7 @@ function resolveSlot(slot: PendingRequest, requestId: string, response: External
   try {
     slot.sitePort.postMessage(response);
     slot.sitePort.disconnect();
+    slot.popupPort?.disconnect();
   } catch (err) {
     console.warn(LOG_PREFIX_AUTH, "site port post failed", err);
   }
@@ -139,6 +140,7 @@ export function initBackgroundAuth(): void {
     }
 
     let handled = false;
+    let siteConnected = true;
 
     sitePort.onMessage.addListener(message => {
       if (handled) return;
@@ -158,6 +160,7 @@ export function initBackgroundAuth(): void {
 
         if (await isApproved(message.origin)) {
           const signed = await signFor(message);
+          if (!siteConnected) return;
           try {
             sitePort.postMessage(signed);
             sitePort.disconnect();
@@ -174,12 +177,16 @@ export function initBackgroundAuth(): void {
           sitePort.disconnect();
           return;
         }
+        if (!siteConnected) {
+          chrome.windows.remove(windowId).catch(err => console.warn(LOG_PREFIX_AUTH, "window remove failed", err));
+          return;
+        }
 
         pending.set(requestId, {
           sitePort,
           origin: message.origin,
           nonce: message.nonce,
-          port: null,
+          popupPort: null,
           windowId,
           resolved: false,
         });
@@ -187,12 +194,16 @@ export function initBackgroundAuth(): void {
     });
 
     sitePort.onDisconnect.addListener(() => {
+      siteConnected = false;
       for (const [requestId, slot] of pending) {
         if (slot.sitePort === sitePort && !slot.resolved) {
           slot.resolved = true;
           pending.delete(requestId);
+          slot.popupPort?.disconnect();
           if (slot.windowId !== null) {
-            chrome.windows.remove(slot.windowId).catch(() => {});
+            chrome.windows
+              .remove(slot.windowId)
+              .catch(err => console.warn(LOG_PREFIX_AUTH, "window remove failed", err));
           }
           return;
         }
@@ -209,7 +220,7 @@ export function initBackgroundAuth(): void {
       return;
     }
 
-    slot.port = port;
+    slot.popupPort = port;
 
     port.onMessage.addListener(msg => {
       if (!isValidPortMessage(msg)) return;

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -208,7 +208,7 @@ body {
   align-items: center;
   gap: 6px;
   min-height: 1.25rem;
-  margin: 12px 0 8px;
+  margin: 4px 0 16px;
   font-size: 0.8125rem;
   color: rgba(255, 255, 255, 0.55);
   transition: color 120ms ease;

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -208,7 +208,7 @@ body {
   align-items: center;
   gap: 6px;
   min-height: 1.25rem;
-  margin: 12px 0 0;
+  margin: 12px 0 8px;
   font-size: 0.8125rem;
   color: rgba(255, 255, 255, 0.55);
   transition: color 120ms ease;

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -105,7 +105,7 @@ body {
 }
 
 .auth-card__remember {
-  margin-bottom: 22px;
+  margin-bottom: 16px;
   font-size: 0.85rem;
   opacity: 0.85;
 }
@@ -208,7 +208,7 @@ body {
   align-items: center;
   gap: 6px;
   min-height: 1.25rem;
-  margin: 4px 0 16px;
+  margin: 0 0 16px;
   font-size: 0.8125rem;
   color: rgba(255, 255, 255, 0.55);
   transition: color 120ms ease;

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -94,6 +94,12 @@ body {
 .auth-card__subtitle {
   font-size: 0.92rem;
   margin: 0 0 14px;
+  min-height: 1.2em;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.auth-card__subtitle[data-ready] {
   opacity: 0.85;
 }
 

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -207,11 +207,19 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
-  min-height: 1.25rem;
-  margin: 0 0 16px;
+  max-height: 0;
+  margin: 0;
+  opacity: 0;
+  overflow: hidden;
   font-size: 0.8125rem;
   color: rgba(255, 255, 255, 0.55);
-  transition: color 120ms ease;
+  transition: max-height 220ms ease, margin 220ms ease, opacity 220ms ease, color 120ms ease;
+}
+
+.auth-card__error:not(:empty) {
+  max-height: 3rem;
+  margin: 0 0 16px;
+  opacity: 1;
 }
 
 .auth-card__error[data-state="error"] {

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -93,16 +93,15 @@ body {
 
 .auth-card__subtitle {
   font-size: 0.92rem;
+  margin: 0 0 14px;
   max-height: 0;
-  margin: 0;
   opacity: 0;
   overflow: hidden;
-  transition: max-height 220ms ease, margin 220ms ease, opacity 220ms ease;
+  transition: max-height 220ms ease, opacity 220ms ease;
 }
 
 .auth-card__subtitle[data-ready] {
   max-height: 3rem;
-  margin: 0 0 14px;
   opacity: 0.85;
 }
 

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -204,10 +204,20 @@ body {
 }
 
 .auth-card__error {
-  margin-top: 16px;
-  padding: 10px 12px;
-  border-radius: 8px;
-  background: rgba(242, 12, 50, 0.15);
-  color: #ff8a9c;
-  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 1.25rem;
+  margin: 12px 0 0;
+  font-size: 0.8125rem;
+  color: rgba(255, 255, 255, 0.55);
+  transition: color 120ms ease;
+}
+
+.auth-card__error[data-state="error"] {
+  color: #ff7961;
+}
+
+.auth-card__error[data-state="warning"] {
+  color: #f5b942;
 }

--- a/src/options/auth/auth.css
+++ b/src/options/auth/auth.css
@@ -93,13 +93,16 @@ body {
 
 .auth-card__subtitle {
   font-size: 0.92rem;
-  margin: 0 0 14px;
-  min-height: 1.2em;
+  max-height: 0;
+  margin: 0;
   opacity: 0;
-  transition: opacity 200ms ease;
+  overflow: hidden;
+  transition: max-height 220ms ease, margin 220ms ease, opacity 220ms ease;
 }
 
 .auth-card__subtitle[data-ready] {
+  max-height: 3rem;
+  margin: 0 0 14px;
   opacity: 0.85;
 }
 

--- a/src/options/auth/auth.ts
+++ b/src/options/auth/auth.ts
@@ -72,11 +72,54 @@ function bindStaticText(): void {
   if (cancel) cancel.textContent = t("auth_cancel");
 }
 
+function createStatusIcon(): SVGSVGElement {
+  const svgNs = "http://www.w3.org/2000/svg";
+  const svg = document.createElementNS(svgNs, "svg");
+  svg.setAttribute("xmlns", svgNs);
+  svg.setAttribute("viewBox", "0 0 16 16");
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("width", "14");
+  svg.setAttribute("height", "14");
+  svg.setAttribute("aria-hidden", "true");
+
+  const circle = document.createElementNS(svgNs, "circle");
+  circle.setAttribute("cx", "8");
+  circle.setAttribute("cy", "8");
+  circle.setAttribute("r", "6");
+  circle.setAttribute("stroke", "currentColor");
+  circle.setAttribute("stroke-width", "2");
+  svg.appendChild(circle);
+
+  const stem = document.createElementNS(svgNs, "line");
+  stem.setAttribute("x1", "8");
+  stem.setAttribute("y1", "5");
+  stem.setAttribute("x2", "8");
+  stem.setAttribute("y2", "9");
+  stem.setAttribute("stroke", "currentColor");
+  stem.setAttribute("stroke-width", "2");
+  stem.setAttribute("stroke-linecap", "round");
+  svg.appendChild(stem);
+
+  const dot = document.createElementNS(svgNs, "line");
+  dot.setAttribute("x1", "8");
+  dot.setAttribute("y1", "11.5");
+  dot.setAttribute("x2", "8");
+  dot.setAttribute("y2", "11.5");
+  dot.setAttribute("stroke", "currentColor");
+  dot.setAttribute("stroke-width", "2");
+  dot.setAttribute("stroke-linecap", "round");
+  svg.appendChild(dot);
+
+  return svg;
+}
+
 function showError(messageKey: string, state: "error" | "warning" = "error"): void {
   const error = document.getElementById("auth-error");
   if (!error) return;
-  error.textContent = t(messageKey);
   error.dataset.state = state;
+  const icon = createStatusIcon();
+  const text = document.createTextNode(t(messageKey));
+  error.replaceChildren(icon, text);
   error.hidden = false;
 }
 

--- a/src/options/auth/auth.ts
+++ b/src/options/auth/auth.ts
@@ -84,7 +84,6 @@ function showError(messageKey: string, state: "error" | "warning" = "error"): vo
   const icon = STATUS_ICON_TEMPLATE.cloneNode(true);
   const text = document.createTextNode(t(messageKey));
   error.replaceChildren(icon, text);
-  error.hidden = false;
 }
 
 async function bindDynamicText(params: RequestParams): Promise<void> {

--- a/src/options/auth/auth.ts
+++ b/src/options/auth/auth.ts
@@ -158,6 +158,23 @@ async function main(): Promise<void> {
 
   const port = chrome.runtime.connect({ name: `${AUTH_PORT_NAME_PREFIX}${params.requestId}` });
 
+  const heartbeat = window.setInterval(() => {
+    try {
+      port.postMessage({ type: "heartbeat" });
+    } catch {
+      window.clearInterval(heartbeat);
+    }
+  }, 15_000);
+
+  port.onDisconnect.addListener(() => {
+    window.clearInterval(heartbeat);
+    showError("auth_sessionExpired");
+    const approve = document.getElementById("auth-approve") as HTMLButtonElement | null;
+    const cancel = document.getElementById("auth-cancel") as HTMLButtonElement | null;
+    if (approve) approve.disabled = true;
+    if (cancel) cancel.disabled = true;
+  });
+
   await bindDynamicText(params);
   wireActions(port);
 }

--- a/src/options/auth/auth.ts
+++ b/src/options/auth/auth.ts
@@ -99,6 +99,7 @@ async function bindDynamicText(params: RequestParams): Promise<void> {
       console.warn(LOG_PREFIX_AUTH, "identity load failed", err);
       subtitle.textContent = t("auth_consentSubheading", "");
     }
+    subtitle.dataset.ready = "true";
   }
 }
 

--- a/src/options/auth/auth.ts
+++ b/src/options/auth/auth.ts
@@ -72,52 +72,16 @@ function bindStaticText(): void {
   if (cancel) cancel.textContent = t("auth_cancel");
 }
 
-function createStatusIcon(): SVGSVGElement {
-  const svgNs = "http://www.w3.org/2000/svg";
-  const svg = document.createElementNS(svgNs, "svg");
-  svg.setAttribute("xmlns", svgNs);
-  svg.setAttribute("viewBox", "0 0 16 16");
-  svg.setAttribute("fill", "none");
-  svg.setAttribute("width", "14");
-  svg.setAttribute("height", "14");
-  svg.setAttribute("aria-hidden", "true");
+const STATUS_ICON_MARKUP = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" width="14" height="14" aria-hidden="true"><path fill-rule="evenodd" d="M6.701 2.252a1.5 1.5 0 0 1 2.598 0l5.196 9.001A1.5 1.5 0 0 1 13.196 13.5H2.804a1.5 1.5 0 0 1-1.299-2.247l5.196-9.001ZM8 5.5a.75.75 0 0 1 .75.75v3a.75.75 0 0 1-1.5 0v-3A.75.75 0 0 1 8 5.5Zm0 6.5a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd"/></svg>`;
 
-  const circle = document.createElementNS(svgNs, "circle");
-  circle.setAttribute("cx", "8");
-  circle.setAttribute("cy", "8");
-  circle.setAttribute("r", "6");
-  circle.setAttribute("stroke", "currentColor");
-  circle.setAttribute("stroke-width", "2");
-  svg.appendChild(circle);
-
-  const stem = document.createElementNS(svgNs, "line");
-  stem.setAttribute("x1", "8");
-  stem.setAttribute("y1", "5");
-  stem.setAttribute("x2", "8");
-  stem.setAttribute("y2", "9");
-  stem.setAttribute("stroke", "currentColor");
-  stem.setAttribute("stroke-width", "2");
-  stem.setAttribute("stroke-linecap", "round");
-  svg.appendChild(stem);
-
-  const dot = document.createElementNS(svgNs, "line");
-  dot.setAttribute("x1", "8");
-  dot.setAttribute("y1", "11.5");
-  dot.setAttribute("x2", "8");
-  dot.setAttribute("y2", "11.5");
-  dot.setAttribute("stroke", "currentColor");
-  dot.setAttribute("stroke-width", "2");
-  dot.setAttribute("stroke-linecap", "round");
-  svg.appendChild(dot);
-
-  return svg;
-}
+const STATUS_ICON_TEMPLATE = new DOMParser().parseFromString(STATUS_ICON_MARKUP, "image/svg+xml")
+  .documentElement as unknown as SVGElement;
 
 function showError(messageKey: string, state: "error" | "warning" = "error"): void {
   const error = document.getElementById("auth-error");
   if (!error) return;
   error.dataset.state = state;
-  const icon = createStatusIcon();
+  const icon = STATUS_ICON_TEMPLATE.cloneNode(true);
   const text = document.createTextNode(t(messageKey));
   error.replaceChildren(icon, text);
   error.hidden = false;

--- a/src/options/auth/auth.ts
+++ b/src/options/auth/auth.ts
@@ -72,10 +72,11 @@ function bindStaticText(): void {
   if (cancel) cancel.textContent = t("auth_cancel");
 }
 
-function showError(messageKey: string): void {
+function showError(messageKey: string, state: "error" | "warning" = "error"): void {
   const error = document.getElementById("auth-error");
   if (!error) return;
   error.textContent = t(messageKey);
+  error.dataset.state = state;
   error.hidden = false;
 }
 
@@ -107,6 +108,7 @@ function wireActions(port: chrome.runtime.Port): void {
       port.postMessage({ result: "approve", remember: remember?.checked === true });
     } catch (err) {
       console.warn(LOG_PREFIX_AUTH, "approve post failed", err);
+      showError("auth_sessionExpired");
     }
   });
 
@@ -117,6 +119,7 @@ function wireActions(port: chrome.runtime.Port): void {
       port.postMessage({ result: "cancel" });
     } catch (err) {
       console.warn(LOG_PREFIX_AUTH, "cancel post failed", err);
+      showError("auth_sessionExpired");
     }
   });
 }


### PR DESCRIPTION
## Summary

Switches Sign-in-with-Better-Lyrics from one-shot `chrome.runtime.sendMessage` to a long-lived `chrome.runtime.Port` (`onConnectExternal`). Fixes the silent-hang failure mode when the MV3 service worker gets reaped mid-consent: the open port plus a 15s heartbeat from the popup keep the SW alive across the user's read-time, and the page sees an explicit `port.onDisconnect` if anything does go wrong anyway.

Payload shape is unchanged (`{type, nonce, origin}` request, `{ok, signedBody}` response). Partner sites need a small client refactor to switch from `sendMessage` to `connect`; integration spec drafted separately for `unison.boidu.dev` and `blrcunison.vercel.app`.

## What changed

- `manifest.json`: new `BL_AUTH_SITE_PORT_NAME = "bl-auth-site"` external port name. CSP from `auth.html`, `unison.html`, and `marketplace.html` consolidated into `content_security_policy.extension_pages`; per-page `<meta>` tags removed.
- `src/modules/auth/backgroundAuth.ts`: `onMessageExternal` replaced with `onConnectExternal`. State map stores `sitePort: Port` instead of a `sendResponse` callback. New `siteConnected` flag closes the orphaned-slot race when the site disconnects during `await openConsentPopup`. `resolveSlot` posts and disconnects on `sitePort`, then `popupPort`, then removes the window.
- `src/options/auth/auth.ts`: 15s heartbeat posts `{type: "heartbeat"}` on the popup's internal port (receiver filters it out, but receiving resets the SW idle timer). `port.onDisconnect` shows an error and disables Approve/Cancel. New `showError` builds an SVG warn icon inline via `DOMParser` (matches the nickname status pattern on master).
- `src/options/auth/auth.css`: error UI restyled to match the nickname palette. Accordion-expands via `:not(:empty)` so it takes zero space when empty.
- `_locales/en/messages.json`: one new key, `auth_sessionExpired`.

## Manual verification

Smoke-tested in Chrome via DevTools console probes from `unison.boidu.dev`:

- Happy path, Cancel, X-out, site-tab-close mid-flow, malformed payload, wrong port name: all expected responses.
- 2-minute wait with the popup open: SW stays `RUNNING` in `chrome://serviceworker-internals/`, Approve still resolves.
- Manual SW kill via the same internals page: popup shows the inline error, buttons disabled, page sees `DISCONNECT`.

## Notes for reviewers

- No new manifest permissions. `externally_connectable.matches` already covers both `sendMessage` and `connect` per Chromium's `message_service.cc` permission gate.
- `content_security_policy` isn't part of Chrome's permission warning system, so the new manifest CSP doesn't trigger an install or update banner.
- Partner sites still on `sendMessage` will break next release. Coordinating migration in separate PRs against their repos.
- Firefox: sign-in remains unsupported there (Firefox lacks `externally_connectable` web-page support per Bugzilla 1319168). Was unsupported before this PR too; revisit if anyone reports it.