### PR TITLE
fix(chrome): pass publisher id, add per-platform republish workflow

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -13,6 +13,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -1,0 +1,100 @@
+name: Publish Platform
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Platform to publish to"
+        type: choice
+        options: [chrome, edge, firefox]
+        required: true
+      version:
+        description: "Version to publish (e.g. 2.3.1, must match an existing tag)"
+        type: string
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout at tag
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.version }}
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.x"
+
+      - name: Install dependencies
+        run: |
+          npm install
+          npm install --no-save @biomejs/cli-linux-x64@2.0.4 @rspack/binding-linux-x64-gnu@1.5.8
+
+      - name: Detect release type
+        id: meta
+        run: |
+          if [[ "${{ inputs.version }}" == *canary* || "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "release_type=canary" >> $GITHUB_OUTPUT
+          else
+            echo "release_type=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build extension
+        env:
+          RELEASE_TYPE: ${{ steps.meta.outputs.release_type }}
+          SOURCEMAPS_API_KEY: ${{ secrets.SOURCEMAPS_API_KEY }}
+          SOURCEMAPS_BASE_URL: ${{ env.SOURCEMAPS_API_URL }}
+        run: npm run build:ci
+
+      - name: Publish to Chrome Web Store
+        if: inputs.platform == 'chrome'
+        env:
+          EXTENSION_ID: ${{ secrets.GOOGLE_EXTENSION_ID }}
+          PUBLISHER_ID: ${{ secrets.GOOGLE_PUBLISHER_ID }}
+          CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}
+        run: |
+          cd dist/chrome && zip -r "../chrome-v${{ inputs.version }}.zip" . && cd -
+          npx tsx tooling/publish-chrome.ts "dist/chrome-v${{ inputs.version }}.zip"
+
+      - name: Publish to Edge Add-ons
+        if: inputs.platform == 'edge'
+        env:
+          CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}
+          API_KEY: ${{ secrets.EDGE_API_KEY }}
+          PRODUCT_ID: ${{ secrets.EDGE_PRODUCT_ID }}
+        run: |
+          cd dist/edge && zip -r "../edge-v${{ inputs.version }}.zip" . && cd -
+          npx tsx tooling/publish-edge.ts "dist/edge-v${{ inputs.version }}.zip"
+
+      - name: Install web-ext
+        if: inputs.platform == 'firefox'
+        run: npm install -g web-ext
+
+      - name: Sign Firefox Add-on (Canary, unlisted)
+        if: inputs.platform == 'firefox' && steps.meta.outputs.release_type == 'canary'
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          web-ext sign --channel=unlisted \
+                       --api-key="$FIREFOX_JWT_ISSUER" \
+                       --api-secret="$FIREFOX_JWT_SECRET" \
+                       --artifacts-dir=dist/signed-firefox \
+                       --source-dir=dist/firefox
+
+      - name: Sign and Publish Firefox Add-on (Listed)
+        if: inputs.platform == 'firefox' && steps.meta.outputs.release_type == ''
+        env:
+          FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
+          FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          web-ext sign --channel=listed \
+                       --api-key="$FIREFOX_JWT_ISSUER" \
+                       --api-secret="$FIREFOX_JWT_SECRET" \
+                       --upload-source-code \
+                       --artifacts-dir=dist/signed-firefox \
+                       --source-dir=dist/firefox

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,7 @@ jobs:
         if: github.event.inputs.is_canary == 'false'
         env:
           EXTENSION_ID: ${{ secrets.GOOGLE_EXTENSION_ID }}
+          PUBLISHER_ID: ${{ secrets.GOOGLE_PUBLISHER_ID }}
           CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET}}
           REFRESH_TOKEN: ${{ secrets.GOOGLE_REFRESH_TOKEN }}

--- a/tooling/publish-chrome.ts
+++ b/tooling/publish-chrome.ts
@@ -34,5 +34,5 @@ try {
   console.log("Successfully published to Chrome Web Store.");
 } catch (error) {
   console.error("Failed to publish to Chrome Web Store:", error);
-  process.exit(0); // Exit gracefully as in the original script
+  process.exit(1);
 }

--- a/tooling/publish-chrome.ts
+++ b/tooling/publish-chrome.ts
@@ -3,11 +3,12 @@ import { execSync } from "child_process";
 const zipPath = process.argv[2] || "./dist/better-lyrics-chrome.zip";
 
 const extensionId = process.env.EXTENSION_ID;
+const publisherId = process.env.PUBLISHER_ID;
 const clientId = process.env.CLIENT_ID;
 const clientSecret = process.env.CLIENT_SECRET;
 const refreshToken = process.env.REFRESH_TOKEN;
 
-if (!extensionId || !clientId || !clientSecret || !refreshToken) {
+if (!extensionId || !publisherId || !clientId || !clientSecret || !refreshToken) {
   console.error("Missing environment variables for Chrome Web Store publishing.");
   process.exit(1);
 }
@@ -20,6 +21,7 @@ if (!zipPath) {
 const env = {
   ...process.env,
   EXTENSION_ID: extensionId,
+  PUBLISHER_ID: publisherId,
   CLIENT_ID: clientId,
   CLIENT_SECRET: clientSecret,
   REFRESH_TOKEN: refreshToken,


### PR DESCRIPTION
Three related fixes for the release pipeline.

**Chrome publisher id**
`chrome-webstore-upload` v6 (May 2026) migrated to Web Store API v2 and made `publisherId` mandatory. Wire `GOOGLE_PUBLISHER_ID` through the workflow env to the CLI as `PUBLISHER_ID`. Script also validates it's present.

**Chrome publish exit code**
The chrome script was catching all errors and exiting 0, so failed publishes reported as success. Flip to exit 1 so the workflow status is accurate and "Re-run failed jobs" works.

**Per-platform republish workflow**
New manually-dispatched workflow `publish-platform.yml`. Inputs: platform (choice: chrome / edge / firefox) and version. Checks out the matching tag, rebuilds, and runs the platform's existing publish step. No version bump, no tag, no asset shuffling. Use it when a single platform's publish fails and you want to retry that one without re-running the whole release.

## Test plan
- [ ] `GOOGLE_PUBLISHER_ID` repo secret set
- [ ] Next full release reaches "Successfully published to Chrome Web Store."
- [ ] `publish-platform` workflow run for chrome / v2.3.1 succeeds