### PR TITLE
feat(ci): republish from original build artifact when available

### DIFF
--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   publish:
@@ -24,6 +25,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{ inputs.version }}
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -44,12 +46,43 @@ jobs:
             echo "release_type=" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build extension
+      - name: Find original release run for this tag
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PARENT_SHA=$(git rev-parse "v${{ inputs.version }}^1")
+          echo "Tag v${{ inputs.version }} was cut on top of $PARENT_SHA"
+          RUN_ID=$(gh run list --workflow=release.yml --status=success --limit=100 \
+            --json databaseId,headSha \
+            --jq "[.[] | select(.headSha==\"$PARENT_SHA\") | .databaseId] | first")
+          if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+            echo "No successful release run found for that SHA; will rebuild from tag."
+          else
+            echo "Found release run: $RUN_ID"
+            echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download original build artifact
+        id: download
+        if: steps.source.outputs.run_id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.platform }}-build
+          path: dist/${{ inputs.platform }}
+          run-id: ${{ steps.source.outputs.run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rebuild extension (fallback)
+        if: steps.download.outcome != 'success'
         env:
           RELEASE_TYPE: ${{ steps.meta.outputs.release_type }}
           SOURCEMAPS_API_KEY: ${{ secrets.SOURCEMAPS_API_KEY }}
           SOURCEMAPS_BASE_URL: ${{ env.SOURCEMAPS_API_URL }}
-        run: npm run build:ci
+        run: |
+          echo "Rebuilding from tag v${{ inputs.version }} (no artifact available)."
+          npm run build:ci
 
       - name: Publish to Chrome Web Store
         if: inputs.platform == 'chrome'

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -82,6 +82,7 @@ jobs:
           SOURCEMAPS_BASE_URL: ${{ env.SOURCEMAPS_API_URL }}
         run: |
           echo "Rebuilding from tag v${{ inputs.version }} (no artifact available)."
+          rm -rf "dist/${{ inputs.platform }}"
           npm run build:ci
 
       - name: Publish to Chrome Web Store


### PR DESCRIPTION
The republish workflow previously rebuilt from the tag on every run. Now it tries to reuse the build artifact from the original release run first.

Flow:
- Tag missing: `actions/checkout` fails the job loudly. No silent fallback to master.
- Tag present: resolve the tag's parent commit (which equals the original release run's head SHA) and look up the matching `release.yml` run. Download `<platform>-build` from it.
- Artifact present (within 90-day retention): publish that exact build. Bit-identical to what users originally got.
- Artifact missing or expired: rebuild from the tag.

No new inputs; same `platform` + `version` dispatch as before.

## Test plan
- [ ] Dispatch for chrome / v2.3.1: downloads `chrome-build` from original run, publishes
- [ ] Dispatch for a version older than 90 days: falls back to rebuild, publishes
- [ ] Dispatch for a nonexistent version: job fails at checkout