### PR TITLE
fix: empty TTML spans + delete button border

### DIFF
--- a/src/modules/lyrics/providers/ttmlUtils.ts
+++ b/src/modules/lyrics/providers/ttmlUtils.ts
@@ -115,8 +115,8 @@ function parseLyricPart(p: ParagraphElementOrBackground[], beginTime: number, ig
           words: subPart["#text"],
           isBackground,
         });
-      } else if (subPart.span) {
-        let spanText = subPart.span[0]["#text"]!;
+      } else if (subPart.span && subPart.span[0]?.["#text"]) {
+        let spanText = subPart.span[0]["#text"];
         let startTimeMs = parseTime(subPart[":@"]?.["@_begin"]);
         let endTimeMs = parseTime(subPart[":@"]?.["@_end"]);
         let explicit = subPart[":@"]?.["@_explicit"] === "true" || subPart[":@"]?.["@_obscene"] === "true";

--- a/src/options/unison/unison.css
+++ b/src/options/unison/unison.css
@@ -675,7 +675,6 @@ kbd {
 .unison-vote-btn--delete {
   align-self: flex-start;
   color: rgba(239, 68, 68, 0.85);
-  border-color: rgba(239, 68, 68, 0.25);
 }
 
 .unison-vote-btn--delete:hover {


### PR DESCRIPTION
- Skip empty `<span>` elements during TTML word-sync parsing (was crashing on `subPart.span[0]["#text"]`).
- Drop red resting border on unison delete buttons; hover stays red.