### PR TITLE
fix: mobile side panel layout when unison dock is mounted

### DIFF
--- a/public/css/blyrics/components.css
+++ b/public/css/blyrics/components.css
@@ -440,7 +440,7 @@
 	background-color: hsla(0, 0%, 100%, 0.08);
 }
 
-#side-panel:has(.blyrics-unison-dock) {
+ytmusic-player-page:not([is-mweb-modernization-enabled]) #side-panel:has(.blyrics-unison-dock) {
 	position: relative;
 }
 


### PR DESCRIPTION
Mobile YT Music sets `#side-panel` to `position: fixed` with `top: var(--player-bar-height)` and a `translateY` transform (the slide-up bottom-sheet). Our `:has(.blyrics-unison-dock)` rule overrode it to `position: relative`, which activated YT's dormant `top: 64px` as an in-flow offset and shifted the loader, most visibly during the "Searching..." message.

Scope the rule to `:not([is-mweb-modernization-enabled])`. YT's `translateY` on `#side-panel` already provides a containing block for the absolutely-positioned dock on mobile, so we need no rule there. Desktop unchanged.

DOM probe on iPhone 14 Pro (430x932):
- no dock: `position: fixed, top: 64px, bottom: 4px`
- with dock (before): `position: relative, top: 64px, bottom: -64px` (broken)
- with dock (after): `position: fixed, top: 64px, bottom: 4px` (matches baseline)