### PR TITLE
feat(ui): squircle corners across options, marketplace and lyrics surfaces

### DIFF
--- a/public/css/blyrics/components.css
+++ b/public/css/blyrics/components.css
@@ -722,3 +722,13 @@ ytmusic-player-page:not([is-mweb-modernization-enabled]) #side-panel:has(.blyric
 		background-position: -200% 0;
 	}
 }
+
+/* -- Squircle corners ---------------------------- */
+/* Feature-gated: browsers without corner-shape keep the original radius above. */
+
+@supports (corner-shape: superellipse(1.6)) {
+	.blyrics-footer__container.blyrics-footer__unison-card {
+		border-radius: 1.75rem;
+		corner-shape: superellipse(1.6);
+	}
+}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -3,6 +3,7 @@ html {
     min-width: 600px;
     max-width: 600px;
     overflow: auto;
+    scrollbar-width: thin;
 }
 
 nav {
@@ -133,7 +134,7 @@ body {
     box-sizing: border-box;
     overflow: hidden;
     min-height: 3.5rem;
-    outline: 1px solid #48494b;
+    outline: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .theme-preview-card::before {
@@ -2265,4 +2266,37 @@ input.cm-textfield:focus-visible {
 
 .lang-exclusions-tab-content::-webkit-scrollbar-thumb:hover {
 	background: rgba(255, 255, 255, 0.3);
+}
+
+/* -- Squircle corners ---------------------------- */
+/* Feature-gated: browsers without corner-shape keep the original radii below. */
+
+@supports (corner-shape: superellipse(1.6)) {
+    .settings-group,
+    .modal,
+    .theme-preview-card {
+        border-radius: 1.5rem;
+    }
+
+    .text-group,
+    .sortable-item,
+    .theme-card,
+    .theme-deprecation-banner {
+        border-radius: 1rem;
+    }
+
+    .position-frame {
+        border-radius: 1.25rem;
+    }
+
+    .settings-group,
+    .text-group,
+    .sortable-item,
+    .modal,
+    .theme-preview-card,
+    .theme-card,
+    .theme-deprecation-banner,
+    .position-frame {
+        corner-shape: superellipse(1.6);
+    }
 }

--- a/src/options/store/store.css
+++ b/src/options/store/store.css
@@ -2004,3 +2004,35 @@ kbd.kbd-icon svg {
 .toast .toast-action kbd {
   margin-left: 0.5rem;
 }
+
+/* -- Squircle corners ---------------------------- */
+/* Feature-gated: browsers without corner-shape keep the original radii above. */
+
+@supports (corner-shape: superellipse(1.6)) {
+  .marketplace-filters {
+    border-radius: 1.5rem;
+  }
+
+  #your-themes-dropdown,
+  #status-css.toast {
+    border-radius: 1.25rem;
+  }
+
+  .store-card,
+  .store-filter-dropdown {
+    border-radius: 1rem;
+  }
+
+  .detail-shader-info {
+    border-radius: 0.75rem;
+  }
+
+  .marketplace-filters,
+  #your-themes-dropdown,
+  #status-css.toast,
+  .store-card,
+  .store-filter-dropdown,
+  .detail-shader-info {
+    corner-shape: superellipse(1.6);
+  }
+}

--- a/src/options/unison/unison.css
+++ b/src/options/unison/unison.css
@@ -777,6 +777,7 @@ kbd {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 0.5rem;
+  margin: 0;
   padding: 1.25rem;
   font-size: 0.8125rem;
   line-height: 1.7;
@@ -1332,4 +1333,32 @@ select.unison-input {
 .unison-filter-select option {
   background: #1a1a1c;
   color: rgba(255, 255, 255, 0.9);
+}
+
+/* -- Squircle corners ---------------------------- */
+/* Feature-gated: browsers without corner-shape keep the original radii above. */
+
+@supports (corner-shape: superellipse(1.6)) {
+  .unison-filters,
+  .unison-feedback {
+    border-radius: 1.5rem;
+  }
+
+  .unison-card,
+  .unison-report-dropdown,
+  .unison-detail-preview,
+  .unison-detail-pre,
+  .unison-preview-content {
+    border-radius: 1rem;
+  }
+
+  .unison-filters,
+  .unison-feedback,
+  .unison-card,
+  .unison-report-dropdown,
+  .unison-detail-preview,
+  .unison-detail-pre,
+  .unison-preview-content {
+    corner-shape: superellipse(1.6);
+  }
 }


### PR DESCRIPTION
Superellipse (squircle) corners on the main card, group, panel and modal surfaces across options, marketplace, Unison, and the lyrics footer's Unison card, with radii bumped to suit the fuller curve.

All gated behind `@supports (corner-shape: superellipse(1.6))`, so non-Chromium browsers keep today's radii (corner-shape is Chromium 139+).

Also: `.unison-detail-pre` zeroes its default `<pre>` margin to line up with the preview box, a softer theme-preview outline, and `scrollbar-width: thin` on options.

Follows #647.

<img width="671" height="188" alt="image" src="https://github.com/user-attachments/assets/efbd180a-4b32-403e-8344-5f9ac96b4b6a" />
<img width="1444" height="466" alt="image" src="https://github.com/user-attachments/assets/cebe9671-c66c-4c03-a736-6e7488dd6a3d" />
<img width="596" height="571" alt="image" src="https://github.com/user-attachments/assets/acadf18d-410c-4056-ba2e-8add0b456d9e" />
<img width="1459" height="385" alt="image" src="https://github.com/user-attachments/assets/ee405001-a091-4d27-83d4-840221c503e3" />

