### PR TITLE
feat(unison): credit uploaders, add submission language, and a fulfilled badge

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1489,6 +1489,32 @@
     "message": "Language",
     "description": "Language label in detail view"
   },
+  "unison_uploadedBy": {
+    "message": "Uploaded by",
+    "description": "Metadata row label in the Unison detail sidebar, before the uploader's name which links to their curator page"
+  },
+  "unison_languageUnspecified": {
+    "message": "Not specified",
+    "description": "Default option in the submission form's language dropdown, used when the submitter has not chosen a language"
+  },
+  "unison_fulfilledBadge": {
+    "message": "Requested & fulfilled",
+    "description": "Badge on the Unison detail page shown when this lyric answered a community request"
+  },
+  "unison_fulfilledNote": {
+    "message": "Someone wanted this on Better Lyrics, and $name$ came through with it.",
+    "description": "Sentence on the Unison detail page explaining that the lyric fulfilled a community request. $name$ is the uploader's display name",
+    "placeholders": {
+      "name": {
+        "content": "$1",
+        "example": "AcousticPrestoRemix"
+      }
+    }
+  },
+  "unison_fulfilledBoardLink": {
+    "message": "See the requests board",
+    "description": "Link on the Unison detail page that opens the community requests board (queue of most-wanted songs)"
+  },
   "unison_validationRequired": {
     "message": "Please fill in song, artist, video ID, and lyrics.",
     "description": "Validation error when required fields are missing"

--- a/biome.json
+++ b/biome.json
@@ -10,6 +10,7 @@
       "!**/*.js.map",
       "!**/dist",
       "!**/node_modules",
+      "!**/.claude",
       "!www/.next/**/*",
       "!src/options.html",
       "!src/core/generated/**",

--- a/pages/unison.html
+++ b/pages/unison.html
@@ -190,6 +190,10 @@
 								<span class="unison-field-label">__MSG_unison_album__</span>
 								<input type="text" id="unison-field-album" class="unison-input" placeholder="__MSG_unison_placeholder_album__" />
 							</label>
+							<label class="unison-field">
+								<span class="unison-field-label">__MSG_unison_language__</span>
+								<select id="unison-field-language" class="unison-input"></select>
+							</label>
 							<div class="unison-form-row unison-form-row--2x2">
 								<label class="unison-field">
 									<span class="unison-field-label">__MSG_unison_duration__</span>

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -45,6 +45,7 @@ import {
   toMs,
 } from "@modules/ui/animationEngine";
 import { getRequest, setRequest } from "@modules/unison/lyricsRequestTracker";
+import { getTrustTier } from "@modules/unison/trustTier";
 import type { UnisonLyricsRequest } from "@modules/unison/types";
 import { requestLyrics } from "@modules/unison/unisonApi";
 import { log } from "@utils";
@@ -722,13 +723,6 @@ function setScoreLine(refs: ScoreLineRefs, score: number, votes: number): void {
   refs.scoreLabel.textContent = ` ${t("unison_score_label")}`;
   refs.voteNum.textContent = String(votes);
   refs.voteLabel.textContent = ` ${votes === 1 ? t("unison_vote_singular") : t("unison_vote_plural")}`;
-}
-
-function getTrustTier(reputation: number): "new" | "trusted" | "veteran" | "expert" {
-  if (reputation < 0.5) return "new";
-  if (reputation < 1.5) return "trusted";
-  if (reputation < 1.85) return "veteran";
-  return "expert";
 }
 
 function shouldRenderShadersPromo(): boolean {

--- a/src/modules/unison/trustTier.ts
+++ b/src/modules/unison/trustTier.ts
@@ -1,0 +1,8 @@
+type UnisonTrustTier = "new" | "trusted" | "veteran" | "expert";
+
+export function getTrustTier(reputation: number): UnisonTrustTier {
+  if (reputation < 0.5) return "new";
+  if (reputation < 1.5) return "trusted";
+  if (reputation < 1.85) return "veteran";
+  return "expert";
+}

--- a/src/modules/unison/types.ts
+++ b/src/modules/unison/types.ts
@@ -1,5 +1,17 @@
 // -- API Response Types --------------------------
 
+export interface UnisonSubmitter {
+  keyId: string;
+  reputation: number;
+  displayName: string;
+}
+
+export interface UnisonFulfillment {
+  demand: number;
+  requestCount: number;
+  fulfilledAt: number;
+}
+
 export interface UnisonLyricsEntry {
   id: number;
   videoId: string;
@@ -15,6 +27,8 @@ export interface UnisonLyricsEntry {
   effectiveScore: number;
   voteCount: number;
   confidence: UnisonConfidence;
+  submitter?: UnisonSubmitter;
+  fulfilled?: UnisonFulfillment;
   userVote?: 1 | -1 | null;
 }
 

--- a/src/options/unison/unison.css
+++ b/src/options/unison/unison.css
@@ -627,6 +627,116 @@ kbd {
   color: rgba(255, 255, 255, 0.4);
 }
 
+/* -- Detail Uploader --------------------------  */
+
+.unison-uploader {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: 10rem;
+}
+
+.unison-uploader-link {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: rgb(165, 180, 252);
+  text-decoration: none;
+}
+
+.unison-uploader-link:hover {
+  text-decoration: underline;
+}
+
+.unison-uploader .unison-badge--tier {
+  flex-shrink: 0;
+}
+
+.unison-badge--tier {
+  height: auto;
+  padding: 0.2rem 0.6rem;
+  border-radius: 0.5rem;
+  letter-spacing: 0.04em;
+  background-color: hsla(0, 0%, 100%, 0.08);
+}
+
+.unison-badge--tier[data-tier="new"] {
+  color: hsl(220, 70%, 75%);
+  background-color: hsla(220, 70%, 60%, 0.15);
+}
+
+.unison-badge--tier[data-tier="trusted"] {
+  color: hsl(140, 55%, 70%);
+  background-color: hsla(140, 55%, 50%, 0.15);
+}
+
+.unison-badge--tier[data-tier="veteran"] {
+  color: hsl(280, 60%, 78%);
+  background-color: hsla(280, 60%, 60%, 0.18);
+}
+
+.unison-badge--tier[data-tier="expert"] {
+  color: hsl(45, 80%, 70%);
+  background-color: hsla(45, 80%, 55%, 0.2);
+}
+
+/* -- Detail Fulfilled --------------------------  */
+
+.unison-fulfilled {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.75rem;
+  border-radius: 0.5rem;
+  background: rgba(134, 239, 172, 0.06);
+  border: 1px solid rgba(134, 239, 172, 0.16);
+}
+
+.unison-fulfilled-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  align-self: flex-start;
+  font-size: 0.625rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgb(134, 239, 172);
+}
+
+.unison-fulfilled-badge .unison-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.unison-fulfilled-note {
+  margin: 0;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.unison-fulfilled-board-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  align-self: flex-start;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgb(134, 239, 172);
+  text-decoration: none;
+}
+
+.unison-fulfilled-board-link:hover {
+  text-decoration: underline;
+}
+
+.unison-fulfilled-board-link .unison-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
 /* -- Detail Voting --------------------------  */
 
 .unison-detail-voting {

--- a/src/options/unison/unisonPage.ts
+++ b/src/options/unison/unisonPage.ts
@@ -1,14 +1,16 @@
 import { XMLParser } from "fast-xml-parser";
-import { LOG_PREFIX_UNISON } from "@constants";
+import { LOG_PREFIX_UNISON, UNISON_API_BASE_URL } from "@constants";
 import { t } from "@core/i18n";
 import {
   DEFAULT_FEED_FILTERS,
   type FeedFilters,
   type ReportReason,
+  type UnisonConfidence,
   type UnisonFeedEntry,
   type UnisonFormat,
   type UnisonLyricsEntry,
   type UnisonSearchEntry,
+  type UnisonSubmitter,
   type VoteValue,
 } from "@modules/unison/types";
 import {
@@ -24,7 +26,8 @@ import {
   submitLyrics,
 } from "@modules/unison/unisonApi";
 import { UnisonErrorCode } from "@modules/unison/errorCodes";
-import { getDisplayName } from "@/core/keyIdentity";
+import { getTrustTier } from "@modules/unison/trustTier";
+import { generatePetName, getDisplayName } from "@/core/keyIdentity";
 
 // -- SVG Icons --------------------------
 
@@ -94,6 +97,7 @@ let submitFeedback: HTMLElement;
 let previewContent: HTMLElement;
 let lyricsTextarea: HTMLTextAreaElement;
 let formatSelect: HTMLSelectElement;
+let submitLanguageSelect: HTMLSelectElement;
 let composerLink: HTMLAnchorElement;
 
 // -- Feed State --------------------------
@@ -155,6 +159,16 @@ const DEV_STUB_BASE = {
   effectiveScore: 5,
   voteCount: 12,
   confidence: "high" as const,
+  submitter: {
+    keyId: "cea10b57de8e060ed1a180a00c2bc717a2ab4f231d88fd33ffa6a50a04f23b6e",
+    reputation: 1.6,
+    displayName: "DevCuratorStub",
+  },
+  fulfilled: {
+    demand: 42,
+    requestCount: 7,
+    fulfilledAt: 1718755200,
+  },
   userVote: null,
 };
 
@@ -266,6 +280,7 @@ export function initUnisonPage(): void {
   previewContent = document.getElementById("unison-preview-content") as HTMLElement;
   lyricsTextarea = document.getElementById("unison-field-lyrics") as HTMLTextAreaElement;
   formatSelect = document.getElementById("unison-field-format") as HTMLSelectElement;
+  submitLanguageSelect = document.getElementById("unison-field-language") as HTMLSelectElement;
   composerLink = document.getElementById("unison-composer-link") as HTMLAnchorElement;
 
   setupFeedTabs();
@@ -341,7 +356,47 @@ function applyActiveTabContent(): void {
 
 // -- Filter Bar --------------------------
 
-const LANGUAGE_OPTIONS = ["en", "ja", "ko", "es", "fr", "de", "it", "pt", "zh", "ru", "hi"];
+const LANGUAGE_OPTIONS = [
+  "en",
+  "es",
+  "fr",
+  "de",
+  "it",
+  "pt",
+  "nl",
+  "sv",
+  "da",
+  "no",
+  "fi",
+  "pl",
+  "cs",
+  "sk",
+  "hu",
+  "ro",
+  "el",
+  "tr",
+  "ru",
+  "uk",
+  "ja",
+  "ko",
+  "zh",
+  "zh-Hant",
+  "hi",
+  "bn",
+  "pa",
+  "ta",
+  "te",
+  "ur",
+  "id",
+  "ms",
+  "vi",
+  "th",
+  "fil",
+  "ar",
+  "he",
+  "fa",
+  "sw",
+];
 
 function setupFilterBar(): void {
   populateLanguageOptions();
@@ -396,7 +451,7 @@ function setupFilterBar(): void {
   });
 }
 
-function populateLanguageOptions(): void {
+function appendLanguageOptions(select: HTMLSelectElement): void {
   let displayNames: Intl.DisplayNames | null = null;
   try {
     displayNames = new Intl.DisplayNames(undefined, { type: "language" });
@@ -408,8 +463,35 @@ function populateLanguageOptions(): void {
     const opt = document.createElement("option");
     opt.value = code;
     opt.textContent = displayNames?.of(code) ?? code;
-    filterLanguageSelect.appendChild(opt);
+    select.appendChild(opt);
   }
+}
+
+function populateLanguageOptions(): void {
+  appendLanguageOptions(filterLanguageSelect);
+}
+
+function matchLanguageOption(lang: string): string | null {
+  const lower = lang.toLowerCase();
+  const exact = LANGUAGE_OPTIONS.find(code => code.toLowerCase() === lower);
+  if (exact) return exact;
+  const base = lower.split("-")[0];
+  return LANGUAGE_OPTIONS.find(code => code.toLowerCase().split("-")[0] === base) ?? null;
+}
+
+function detectTtmlLanguage(text: string): string | null {
+  const match = text.match(/<tt\b[^>]*\bxml:lang\s*=\s*["']([^"']+)["']/i);
+  return match ? match[1] : null;
+}
+
+function autoDetectLanguage(): void {
+  if (submitLanguageSelect.value) return;
+  const text = lyricsTextarea.value;
+  if (!text.trim()) return;
+  const lang = detectTtmlLanguage(text);
+  if (!lang) return;
+  const matched = matchLanguageOption(lang);
+  if (matched) submitLanguageSelect.value = matched;
 }
 
 function onFilterChange(): void {
@@ -792,19 +874,7 @@ function createLyricsCard(entry: UnisonSearchEntry | UnisonFeedEntry, options: L
   syncBadge.textContent = t(`unison_sync${entry.syncType[0].toUpperCase()}${entry.syncType.slice(1)}`);
   badges.appendChild(syncBadge);
 
-  const confidenceBadge = document.createElement("span");
-  confidenceBadge.className = `unison-badge unison-badge--confidence unison-badge--confidence-${entry.confidence}`;
-
-  const confidenceIconWrap = document.createElement("span");
-  confidenceIconWrap.className = "unison-confidence-icon";
-  confidenceIconWrap.appendChild(svgIcon(CONFIDENCE_ICON_KEY[entry.confidence]));
-
-  const confidenceLabel = document.createElement("span");
-  confidenceLabel.textContent = t(`unison_confidence_${entry.confidence}`);
-
-  confidenceBadge.appendChild(confidenceIconWrap);
-  confidenceBadge.appendChild(confidenceLabel);
-  badges.appendChild(confidenceBadge);
+  badges.appendChild(createConfidenceBadge(entry.confidence));
 
   const footer = document.createElement("div");
   footer.className = "unison-card-footer";
@@ -924,6 +994,7 @@ function renderDetail(entry: UnisonLyricsEntry, isOwn: boolean = false): void {
   if (entry.album) appendMetaRow(metaTable, t("unison_album"), entry.album);
   if (entry.language) appendMetaRow(metaTable, t("unison_language"), entry.language);
   if (entry.isrc) appendMetaRow(metaTable, "ISRC", entry.isrc);
+  if (entry.submitter) appendMetaRow(metaTable, t("unison_uploadedBy"), createUploaderCell(entry.submitter));
 
   const scoreRow = document.createElement("div");
   scoreRow.className = "unison-detail-score-row";
@@ -938,6 +1009,7 @@ function renderDetail(entry: UnisonLyricsEntry, isOwn: boolean = false): void {
 
   scoreRow.appendChild(scoreText);
   scoreRow.appendChild(voteText);
+  scoreRow.appendChild(createConfidenceBadge(entry.confidence));
 
   const votingRow = createDetailVoting(entry.id, entry.userVote, isOwn);
 
@@ -962,6 +1034,7 @@ function renderDetail(entry: UnisonLyricsEntry, isOwn: boolean = false): void {
   detailMeta.appendChild(artist);
   detailMeta.appendChild(metaTable);
   detailMeta.appendChild(scoreRow);
+  if (entry.fulfilled) detailMeta.appendChild(createFulfilledBlock(entry.submitter));
   detailMeta.appendChild(votingRow);
   if (isOwn) {
     detailMeta.appendChild(createDetailDeleteButton(entry.id));
@@ -978,15 +1051,87 @@ function renderDetail(entry: UnisonLyricsEntry, isOwn: boolean = false): void {
   detailLyrics.appendChild(pre);
 }
 
-function appendMetaRow(table: HTMLTableElement, label: string, value: string): void {
+function appendMetaRow(table: HTMLTableElement, label: string, value: string | HTMLElement): void {
   const tr = document.createElement("tr");
   const th = document.createElement("th");
   th.textContent = label;
   const td = document.createElement("td");
-  td.textContent = value;
+  if (typeof value === "string") {
+    td.textContent = value;
+  } else {
+    td.appendChild(value);
+  }
   tr.appendChild(th);
   tr.appendChild(td);
   table.appendChild(tr);
+}
+
+function createConfidenceBadge(confidence: UnisonConfidence): HTMLElement {
+  const badge = document.createElement("span");
+  badge.className = `unison-badge unison-badge--confidence unison-badge--confidence-${confidence}`;
+
+  const iconWrap = document.createElement("span");
+  iconWrap.className = "unison-confidence-icon";
+  iconWrap.appendChild(svgIcon(CONFIDENCE_ICON_KEY[confidence]));
+
+  const label = document.createElement("span");
+  label.textContent = t(`unison_confidence_${confidence}`);
+
+  badge.appendChild(iconWrap);
+  badge.appendChild(label);
+  return badge;
+}
+
+function createUploaderCell(submitter: UnisonSubmitter): HTMLElement {
+  const cell = document.createElement("span");
+  cell.className = "unison-uploader";
+
+  const link = document.createElement("a");
+  link.className = "unison-uploader-link";
+  link.href = `${UNISON_API_BASE_URL}/curator/${encodeURIComponent(submitter.keyId)}`;
+  link.target = "_blank";
+  link.rel = "noreferrer noopener";
+  link.textContent = submitter.displayName || generatePetName(submitter.keyId);
+
+  const tier = getTrustTier(submitter.reputation);
+  const tierBadge = document.createElement("span");
+  tierBadge.className = "unison-badge unison-badge--tier";
+  tierBadge.dataset.tier = tier;
+  tierBadge.textContent = t(`unison_tier_${tier}`);
+
+  cell.appendChild(link);
+  cell.appendChild(tierBadge);
+  return cell;
+}
+
+function createFulfilledBlock(submitter?: UnisonSubmitter): HTMLElement {
+  const block = document.createElement("div");
+  block.className = "unison-fulfilled";
+
+  const badge = document.createElement("span");
+  badge.className = "unison-fulfilled-badge";
+  badge.appendChild(svgIcon("success"));
+  badge.append(t("unison_fulfilledBadge"));
+  block.appendChild(badge);
+
+  const name = submitter ? submitter.displayName || generatePetName(submitter.keyId) : "";
+  if (name) {
+    const note = document.createElement("p");
+    note.className = "unison-fulfilled-note";
+    note.textContent = t("unison_fulfilledNote", [name]);
+    block.appendChild(note);
+  }
+
+  const boardLink = document.createElement("a");
+  boardLink.className = "unison-fulfilled-board-link";
+  boardLink.href = `${UNISON_API_BASE_URL}/queue`;
+  boardLink.target = "_blank";
+  boardLink.rel = "noreferrer noopener";
+  boardLink.appendChild(svgIcon("externalLink"));
+  boardLink.append(t("unison_fulfilledBoardLink"));
+  block.appendChild(boardLink);
+
+  return block;
 }
 
 function createDetailVoting(unisonId: number, userVote?: 1 | -1 | null, isOwn: boolean = false): HTMLElement {
@@ -1155,6 +1300,12 @@ function showReportMenu(unisonId: number, anchor: HTMLButtonElement): void {
 function setupSubmitForm(): void {
   submitBtn.addEventListener("click", handleSubmit);
 
+  const languageDefault = document.createElement("option");
+  languageDefault.value = "";
+  languageDefault.textContent = t("unison_languageUnspecified");
+  submitLanguageSelect.appendChild(languageDefault);
+  appendLanguageOptions(submitLanguageSelect);
+
   const durationField = document.getElementById("unison-field-duration") as HTMLInputElement | null;
   durationField?.addEventListener("blur", () => {
     if (!durationField.value.trim()) return;
@@ -1190,6 +1341,7 @@ function setupSubmitForm(): void {
   lyricsTextarea.addEventListener("input", () => {
     updatePreview();
     autoDetectFormat();
+    autoDetectLanguage();
   });
 
   lyricsTextarea.addEventListener("dragover", (e: DragEvent) => {
@@ -1217,6 +1369,7 @@ function setupSubmitForm(): void {
       lyricsTextarea.value = reader.result as string;
       updatePreview();
       autoDetectFormat();
+      autoDetectLanguage();
     };
     reader.readAsText(file);
   });
@@ -1438,6 +1591,7 @@ async function handleSubmit(): Promise<void> {
   const duration = parseDurationInput((document.getElementById("unison-field-duration") as HTMLInputElement).value);
   const videoId = (document.getElementById("unison-field-videoId") as HTMLInputElement).value.trim();
   const isrc = (document.getElementById("unison-field-isrc") as HTMLInputElement).value.trim();
+  const language = submitLanguageSelect.value;
   const lyrics = lyricsTextarea.value.trim();
   let format = formatSelect.value as UnisonFormat | "auto";
 
@@ -1461,6 +1615,7 @@ async function handleSubmit(): Promise<void> {
     format: format as UnisonFormat,
     album: album || undefined,
     isrc: isrc || undefined,
+    language: language || undefined,
   });
 
   submitBtn.disabled = false;


### PR DESCRIPTION
Unison detail page now credits the uploader: the name links to their curator page next to a trust badge styled like the player footer. It also shows confidence and flags lyrics that filled a community request.

The submission form gains a language picker (wider list, auto-fills from TTML) so new lyrics stop saving without a language.

<img width="309" height="571" alt="image" src="https://github.com/user-attachments/assets/318b3324-fe2d-40cb-a5bd-53ffb005e9b1" />
<img width="299" height="377" alt="image" src="https://github.com/user-attachments/assets/88450c4a-ea4b-456a-b13e-8d0312dfd2c7" />
