### PR TITLE
fix(RTL): punctuations separated from RTL leaving them mistakenly classified as non-RTL

### DIFF
--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -214,6 +214,11 @@ function splitLongPart(part: LyricPart, threshold: number): LyricPart[] {
     return acc;
   }, [] as string[]);
 
+  while (segments.length > 1 && !/[\p{L}\p{N}]/u.test(segments[0])) {
+    segments[1] = segments[0] + segments[1];
+    segments.shift();
+  }
+
   const totalChars = part.words.length;
   const subParts: LyricPart[] = [];
   let charsBefore = 0;


### PR DESCRIPTION
Fixing the `splitLongPart` segmentation algorithm for RTL-like texts that has open punctuations by joining the first segment to the next one if the first segment is not a letter or numbers of any script or language
But, truth be told, I have not tested it on other tracks though.

Although I fear this defeats the purpose of `Intl.Segmenter` as from brief understanding of what I've tested, I also realized the possiblity of `(Longtextlongtextlongtextlongtextlongtextlongtextlongtextlongtext)` would've been `( Longtextlongtextlongtextlongtextlongtextlongtextlongtextlongtext)` with the current implementation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if applicable)

| Before             | After              |
| ------------------ | ------------------ |
| <img width="526" height="178" alt="image" src="https://github.com/user-attachments/assets/899c83ab-58f9-4686-8547-1cf6fca13d64" /> | <img width="806" height="358" alt="image" src="https://github.com/user-attachments/assets/2a08b8d8-e7ff-47ba-bf96-1bd67ed1d409" /> |

## Checklist

- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
