### PR TITLE
fix: localized "and"

### DIFF
--- a/public/earlyInject.js
+++ b/public/earlyInject.js
@@ -6,6 +6,45 @@
 /** Store reference to original fetch function */
 const originalFetch = window.fetch;
 
+// -- English byline override --------------------------
+function dispatchSniffResponse(url, requestJson, responseJson, status) {
+  document.dispatchEvent(
+    new CustomEvent("blyrics-send-response", {
+      detail: { url, requestJson, responseJson, status, timestamp: Date.now() },
+    })
+  );
+}
+
+/**
+ * Re-fetches a /next request forcing the English locale so the request sniffer reads
+ * canonical (non-localized) artist and album names. Reuses the page's auth via originalFetch.
+ *
+ * @param {string} url - Original /next request URL
+ * @param {string} requestBodyText - Original request body (JSON string)
+ * @param {Headers} headers - Original request headers
+ * @returns {Promise<object>} Parsed English /next response
+ */
+async function fetchEnglishNext(url, requestBodyText, headers) {
+  const body = JSON.parse(requestBodyText);
+  if (!body?.context?.client) {
+    throw new Error("Missing client context");
+  }
+  body.context.client.hl = "en";
+
+  const englishUrl = url.replace(/([?&]hl=)[^&]+/i, "$1en");
+  const englishHeaders = new Headers(headers);
+  englishHeaders.delete("content-encoding");
+  englishHeaders.delete("content-length");
+
+  const response = await originalFetch(englishUrl, {
+    method: "POST",
+    headers: englishHeaders,
+    body: JSON.stringify(body),
+    credentials: "include",
+  });
+  return response.json();
+}
+
 /**
  * Overrides the global fetch function to intercept YouTube Music API requests.
  * Extracts and dispatches song data for lyrics synchronization.
@@ -93,16 +132,22 @@ window.fetch = async function (request, init) {
             responseJson = { error: "Failed to parse response JSON" };
           }
 
-          const event = new CustomEvent("blyrics-send-response", {
-            detail: {
-              url: clonedResponseForJson.url || urlString,
-              requestJson: requestJson,
-              responseJson: responseJson,
-              status: clonedResponseForJson.status,
-              timestamp: Date.now(),
-            },
-          });
-          document.dispatchEvent(event);
+          const eventUrl = clonedResponseForJson.url || urlString;
+          const status = clonedResponseForJson.status;
+          const isNext = urlString.startsWith("https://music.youtube.com/youtubei/v1/next");
+          const origHl = requestJson?.context?.client?.hl;
+
+          if (isNext && origHl && origHl !== "en") {
+            fetchEnglishNext(urlString, awaitedTexts[0], originalRequestForJson.headers).then(
+              englishJson => dispatchSniffResponse(eventUrl, requestJson, englishJson, status),
+              error => {
+                console.error("Better Lyrics: English /next fetch failed, using localized response:", error);
+                dispatchSniffResponse(eventUrl, requestJson, responseJson, status);
+              }
+            );
+          } else {
+            dispatchSniffResponse(eventUrl, requestJson, responseJson, status);
+          }
         })
         .catch(error => {
           console.error(

--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -26,10 +26,7 @@ function isInstrumentalOnly(lyrics: Lyric[]): boolean {
 }
 
 function normalizeArtist(artist: string): string {
-  return artist
-    .trim()
-    .replace(", & ", ", ")
-    .replace(/\s*[,،、，､፣]\s*/gu, ", ");
+  return artist.trim().replace(", & ", ", ");
 }
 
 export type LyricSourceResultWithMeta = LyricSourceResult & {

--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -124,7 +124,7 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
 
     if (matchingSong) {
       song = matchingSong.title;
-      artist = matchingSong.artist;
+      artist = matchingSong.artist || artist;
 
       if (isMusicVideo && matchingSong.counterpartVideoId && matchingSong.segmentMap) {
         log("Switching VideoId to Audio Id");

--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -25,6 +25,13 @@ function isInstrumentalOnly(lyrics: Lyric[]): boolean {
   return /^\[?instrumental\s*only\]?$/i.test(lyrics[0].words.trim());
 }
 
+function normalizeArtist(artist: string): string {
+  return artist
+    .trim()
+    .replace(", & ", ", ")
+    .replace(/\s*[,،、，､፣]\s*/gu, ", ");
+}
+
 export type LyricSourceResultWithMeta = LyricSourceResult & {
   song: string;
   artist: string;
@@ -144,8 +151,7 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
     }
 
     song = song.trim();
-    artist = artist.trim();
-    artist = artist.replace(", & ", ", ");
+    artist = normalizeArtist(artist);
     let album = await getSongAlbum(videoId, signal);
     if (!album) {
       album = "";
@@ -346,8 +352,7 @@ export async function preFetchLyrics(
   }
 
   song = song.trim();
-  artist = artist.trim();
-  artist = artist.replace(", & ", ", ");
+  artist = normalizeArtist(artist);
   let album = await getSongAlbum(videoId, signal);
   if (!album) {
     album = "";

--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -343,7 +343,7 @@ export async function preFetchLyrics(
 
   if (matchingSong) {
     song = matchingSong.title;
-    artist = matchingSong.artist;
+    artist = matchingSong.artist || artist;
 
     if (isMusicVideo && matchingSong.counterpartVideoId && matchingSong.segmentMap) {
       swappedVideoId = true;

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -238,6 +238,20 @@ export function setupRequestSniffer(): void {
                   artists.push(run.text);
                 }
               }
+
+              if (artists.length === 0) {
+                // Topic uploads list every artist in a single unlinked run before the first separator
+                const bulletIndex = longByLineText.runs.findIndex(run => run.text.trim() === "•");
+                const runs = bulletIndex === -1 ? longByLineText.runs : longByLineText.runs.slice(0, bulletIndex);
+                return [
+                  runs
+                    .map(run => run.text)
+                    .join("")
+                    .trim(),
+                  album,
+                ];
+              }
+
               return [artists.join(", "), album];
             }
 

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -236,9 +236,9 @@ export function setupRequestSniffer(): void {
                   }
                   return (
                     trimmed.length > 0 &&
-                    (trimmed !== r.text ||
+                    (trimmed === r.text ||
                       (r.navigationEndpoint?.browseEndpoint.browseEndpointContextSupportedConfigs
-                        .browseEndpointContextMusicConfig.pageType || "") !== "MUSIC_PAGE_TYPE_ARTIST") &&
+                        .browseEndpointContextMusicConfig.pageType || "") === "MUSIC_PAGE_TYPE_ARTIST") &&
                     !hasVideoWord
                   );
                 })

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -234,7 +234,13 @@ export function setupRequestSniffer(): void {
                   if (hasVideoWord) {
                     byLineIsVideo = true;
                   }
-                  return trimmed.length > 0 && trimmed == r.text && !hasVideoWord;
+                  return (
+                    trimmed.length > 0 &&
+                    (trimmed !== r.text ||
+                      (r.navigationEndpoint?.browseEndpoint.browseEndpointContextSupportedConfigs
+                        .browseEndpointContextMusicConfig.pageType || "") !== "MUSIC_PAGE_TYPE_ARTIST") &&
+                    !hasVideoWord
+                  );
                 })
                 .map(r => r.text);
 

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -234,7 +234,7 @@ export function setupRequestSniffer(): void {
                   if (hasVideoWord) {
                     byLineIsVideo = true;
                   }
-                  return trimmed.length > 0 && trimmed !== "•" && trimmed !== "&" && !hasVideoWord;
+                  return trimmed.length > 0 && trimmed == r.text && !hasVideoWord;
                 })
                 .map(r => r.text);
 

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -225,35 +225,20 @@ export function setupRequestSniffer(): void {
             let primaryId = primaryRenderer?.videoId;
             let primaryTitle = primaryRenderer?.title.runs[0].text;
 
-            function extractByLineInfo(longByLineText: LongBylineText) {
-              let byLineIsVideo = false;
-              let longByLine = longByLineText.runs
-                .filter(r => {
-                  let trimmed = r.text.trim();
-                  let hasVideoWord = trimmed.includes("views") || trimmed.includes("likes");
-                  if (hasVideoWord) {
-                    byLineIsVideo = true;
-                  }
-                  return (
-                    trimmed.length > 0 &&
-                    (trimmed === r.text ||
-                      (r.navigationEndpoint?.browseEndpoint.browseEndpointContextSupportedConfigs
-                        .browseEndpointContextMusicConfig.pageType || "") === "MUSIC_PAGE_TYPE_ARTIST") &&
-                    !hasVideoWord
-                  );
-                })
-                .map(r => r.text);
-
-              let artist: string;
+            function extractByLineInfo(longByLineText: LongBylineText): [string, string] {
+              const artists: string[] = [];
               let album = "";
-              if (byLineIsVideo) {
-                artist = longByLine?.join(", ");
-              } else {
-                // Last elm is year, second to last is album, rest is artists
-                album = longByLine[longByLine?.length - 2];
-                artist = longByLine?.slice(0, -2).join(", ");
+              for (const run of longByLineText.runs) {
+                const browse = run.navigationEndpoint?.browseEndpoint;
+                const pageType =
+                  browse?.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType;
+                if (pageType === "MUSIC_PAGE_TYPE_ALBUM") {
+                  album = run.text;
+                } else if (browse) {
+                  artists.push(run.text);
+                }
               }
-              return [artist, album];
+              return [artists.join(", "), album];
             }
 
             let [primaryArtist, primaryAlbum] = extractByLineInfo(primaryRenderer?.longBylineText);


### PR DESCRIPTION
# Description

This fixes the localized "and" by:
> Patch 1: ~~Ruling out possibilities that artists **cannot** have leading and/or trailing whitespaces. Of course, this might affect some artists that could have shattered that possiblity, so a failsafe is placed by checking if the artists have a channel page.~~
> Doesn't work, because CJK characters can have whitespaces in it

> Patch 2 (@boidushya): ~~Artists usually have a channel link, and we're only grabbing the ones that have those channel links~~
> Doesn't work, because some artists doesn't have a channel link connected

> Patch 3: ~~Patch 2, but with additional fallback~~
> That would just make the localized "and" doesn't apply to all songs

> Patch 4: ~~Using `Intl.ListFormat` to be used as a list of separators and separate the artists by that way instead~~
> A band could have the same "and" as a one artists, and it would be detected as a separator, leading to a commafier (for example: `Love and Death` -> `Love, Death`)

> Patch 5 (@boidushya): ~~Using a list of commas for separating artists~~
> Some languages tend to use a localized "and" at the end of a list, not a comma

> Patch 6: ~~Using `/player` to check for tags that usually include the artists name in it~~
> Some tracks doesn't include some of the artists name

> Patch 7 (@boidushya) - **current fix**: Re-requesting `/next` with an `en-US` locale
> Seems like it's the most robust way of getting the artists list. Going with that

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue (if applicable)

Realized this issue still exists because of https://github.com/better-lyrics/better-lyrics/issues/404#issuecomment-4759793938
Fixes #404 (issue)

## Checklist

- [x] I have performed a self-review of my code
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
