### PR TITLE
fix: prevent crash when next byline has no runs

### DIFF
--- a/src/modules/lyrics/requestSniffer/NextResponse.ts
+++ b/src/modules/lyrics/requestSniffer/NextResponse.ts
@@ -165,7 +165,7 @@ interface LengthTextRun {
 }
 
 export interface LongBylineText {
-  readonly runs: PurpleRun[];
+  readonly runs?: PurpleRun[];
 }
 
 export interface PurpleRun {

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -228,7 +228,11 @@ export function setupRequestSniffer(): void {
             function extractByLineInfo(longByLineText: LongBylineText): [string, string] {
               const artists: string[] = [];
               let album = "";
-              for (const run of longByLineText.runs) {
+              const runs = longByLineText?.runs;
+              if (!runs) {
+                return ["", album];
+              }
+              for (const run of runs) {
                 const browse = run.navigationEndpoint?.browseEndpoint;
                 const pageType =
                   browse?.browseEndpointContextSupportedConfigs?.browseEndpointContextMusicConfig?.pageType;
@@ -241,10 +245,10 @@ export function setupRequestSniffer(): void {
 
               if (artists.length === 0) {
                 // Topic uploads list every artist in a single unlinked run before the first separator
-                const bulletIndex = longByLineText.runs.findIndex(run => run.text.trim() === "•");
-                const runs = bulletIndex === -1 ? longByLineText.runs : longByLineText.runs.slice(0, bulletIndex);
+                const bulletIndex = runs.findIndex(run => run.text.trim() === "•");
+                const namedRuns = bulletIndex === -1 ? runs : runs.slice(0, bulletIndex);
                 return [
-                  runs
+                  namedRuns
                     .map(run => run.text)
                     .join("")
                     .trim(),


### PR DESCRIPTION
## Overview

The localized-byline change looped over a /next entry's byline runs directly, but some entries come back without a runs array, so the loop threw "runs is not iterable" and took down the whole watch-next parse. Now it checks for the missing array and falls back to an empty byline, which the existing artist fallback already handles. Marked the field optional on the type too, since YouTube sometimes leaves it out.
