### PR TITLE
fix: conflicting `store:` prefix on custom themes

### DIFF
--- a/src/options/editor/features/themes.ts
+++ b/src/options/editor/features/themes.ts
@@ -802,7 +802,7 @@ export async function handleSaveTheme() {
   }
 
   const themeName = await showPrompt("Save as Theme", "Enter a name for this theme:", "", "Theme name");
-  if (!themeName || themeName.trim() === "") {
+  if (!themeName || themeName.trim() === "" || themeName.trim().startsWith(STORE_THEME_PREFIX)) {
     return;
   }
 


### PR DESCRIPTION
# Description

An issue where the user that saved their custom theme with a name that is the same with the marketplace theme ID, using the `store:<theme-id>` format will bug out in terms of visual and possibly code handling for any sort of theme features

https://github.com/user-attachments/assets/50566549-17be-40c6-bf8d-e1d0466480f6

This fixes the issue by simply disallowing `store:` to be inputted from saving into a custom theme name

I could also write some extra lines so applied custom themes will have the `custom:` prefix on it but I might not have enough conscious to write it all down

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my code
