### PR TITLE
Fix Polish localization typo

### DIFF
--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -926,7 +926,7 @@
     "description": "Footer button text linking to the Better Lyrics Shaders companion extension"
   },
   "lyrics_searching": {
-    "message": "Better Lyrics szuka tesktu piosenki...",
+    "message": "Better Lyrics szuka tekstu piosenki...",
     "description": "Loading message while searching for lyrics"
   },
   "lyrics_stillSearching": {


### PR DESCRIPTION
# Description

Fixed a typo in the Better Lyrics Polish localization.

## Previously:
Better Lyrics szuka te**sk**tu piosenki...

## Now (correct):
Better Lyrics szuka te**ks**tu piosenki...

## English version:
Better Lyrics is searching for lyrics...