### PR TITLE
fix: fade nav-bar and mini-guide backgrounds with player page close

### DIFF
--- a/public/css/ytmusic/general.css
+++ b/public/css/ytmusic/general.css
@@ -26,27 +26,30 @@ ytmusic-player-bar,
 }
 
 /* YouTube Music specific overrides */
-#layout[player-ui-state="PLAYER_PAGE_OPEN"] #mini-guide-background,
-#layout[player-ui-state="PLAYER_PAGE_OPEN"] #nav-bar-background,
 #layout[player-ui-state="PLAYER_PAGE_OPEN"] #guide-wrapper {
   background-color: transparent !important;
   border-color: transparent !important;
 }
 
-#layout[player-ui-state="PLAYER_PAGE_OPEN"] ytmusic-player-bar,
-#layout[player-ui-state="PLAYER_PAGE_OPEN"] #player-bar-background {
+#layout[player-ui-state="PLAYER_PAGE_OPEN"] #mini-guide-background,
+#layout[player-ui-state="PLAYER_PAGE_OPEN"] #nav-bar-background,
+#layout[player-ui-state="PLAYER_PAGE_OPEN"] #player-bar-background,
+ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #mini-guide-background,
+ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #nav-bar-background,
+ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #player-bar-background {
+  opacity: 0 !important;
+}
+
+#layout[player-ui-state="PLAYER_PAGE_OPEN"] ytmusic-player-bar {
   background: linear-gradient(0deg, transparent, transparent) !important;
 }
 
-ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #mini-guide-background,
-ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #nav-bar-background,
 ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #guide-wrapper {
   background-color: transparent !important;
   border-color: transparent !important;
 }
 
-ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] ytmusic-player-bar,
-ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] #player-bar-background {
+ytmusic-app[blyrics-stylized] #layout[player-ui-state="PLAYER_PAGE_OPEN"] ytmusic-player-bar {
   background: linear-gradient(0deg, #00000000, #00000000) !important;
 }
 


### PR DESCRIPTION
## Overview

The mini-guide and nav-bar backgrounds snapped to transparent when the player page closed, since YTM only transitions opacity on those elements, not background-color. Switched the background-only layers (plus the player bar background) to opacity: 0 so they fade out with YTM's own transition instead of flashing. The guide wrapper and the player bar itself keep transparent backgrounds, since those hold content and shouldn't fade with it.

Closes #697.
