### PR TITLE
Disable native lyrics focus and remove `doneFirstInstantScroll` workaround

### DIFF
--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -42,6 +42,7 @@ import {
   renderLoader,
   setExtraHeight,
 } from "@modules/ui/dom";
+import { disableNativeLyricsFocus } from "@modules/ui/nativeLyricsFocus";
 import { getRelativeLayoutBounds, langCodesMatch, languageMatchesAny, log } from "@utils";
 
 let disableRichsync = registerThemeSetting("blyrics-disable-richsync", false, true);
@@ -113,7 +114,6 @@ function getResizeObserver(): ResizeObserver {
             (entry.target.clientWidth !== AppState.lyricData.lyricWidth ||
               entry.target.clientHeight !== AppState.lyricData.lyricHeight)
           ) {
-            animEngineState.doneFirstInstantScroll = false;
             animEngineState.nextScrollAllowedTime = 0;
             calculateLyricPositions();
           }
@@ -609,6 +609,7 @@ function injectLyrics(data: LyricSourceResultWithMeta, keepLoaderVisible = false
 
   const lyrics = data.lyrics!;
   cleanup();
+  disableNativeLyricsFocus();
 
   let lyricsWrapper = createLyricsWrapper();
 

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -117,10 +117,6 @@ interface AnimEngineState {
   lastEventCreationTime: number;
   lastActiveElements: LineData[];
   queuedScroll: boolean;
-  /**
-   * Track if this is the first new tick to avoid rescrolls when opening the lyrics
-   */
-  doneFirstInstantScroll: boolean;
   lastScrollDebugContext: {
     activeElms: LineData[];
     centers: number[];
@@ -141,7 +137,6 @@ export let animEngineState: AnimEngineState = {
   lastTime: 0,
   lastPlayState: false,
   lastEventCreationTime: -1,
-  doneFirstInstantScroll: true,
   lastActiveElements: [],
   queuedScroll: false,
   lastScrollDebugContext: {
@@ -170,7 +165,6 @@ export function resetAnimEngineState(): void {
   animEngineState.lastActiveElements = [];
   animEngineState.lastScrollDebugContext.activeElms = [];
   animEngineState.lastScrollDebugContext.centers = [];
-  animEngineState.doneFirstInstantScroll = false;
   animEngineState.queuedScroll = false;
   animEngineState.passiveScrollAccumulatedTime = 0;
   animEngineState.passiveLastWallTime = 0;
@@ -1823,7 +1817,6 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
     playerState === "MINIPLAYER_IN_PLAYER_PAGE";
   // Don't tick lyrics if they're not visible
   if (tabSelector.getAttribute("aria-selected") !== "true" || !isPlayerOpen) {
-    animEngineState.doneFirstInstantScroll = false;
     clearVisibleLyricWillChange();
     return;
   }
@@ -2162,14 +2155,6 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
             animEngineState.lastScrollDebugContext.lyricScrollTime
           );
         }
-      }
-
-      if (scrollTop === 0 && !animEngineState.doneFirstInstantScroll) {
-        // For some reason when the panel is opened our pos is set to zero. This instant scrolls to the correct position
-        // to avoid always scrolling from the top when the panel is opened.
-        smoothScroll = false;
-        animEngineState.doneFirstInstantScroll = true;
-        animEngineState.nextScrollAllowedTime = 0;
       }
 
       if (animEngineState.wasUserScrolling || newLyricSelected || animEngineState.queuedScroll) {

--- a/src/modules/ui/nativeLyricsFocus.ts
+++ b/src/modules/ui/nativeLyricsFocus.ts
@@ -1,0 +1,75 @@
+import { log } from "@utils";
+
+const NATIVE_LYRICS_SHELF_SELECTOR = "#tab-renderer ytmusic-description-shelf-renderer";
+const NATIVE_LYRICS_HEADER_SELECTOR =
+  "#tab-renderer ytmusic-description-shelf-renderer yt-formatted-string.header.ytmusic-description-shelf-renderer";
+
+let observer: MutationObserver | null = null;
+let applyScheduled = false;
+
+function applyNativeLyricsFocusDisabled(): void {
+  applyScheduled = false;
+
+  const shelves = document.querySelectorAll<HTMLElement>(NATIVE_LYRICS_SHELF_SELECTOR);
+  for (const shelf of shelves) {
+    if (!shelf.hasAttribute("inert")) {
+      shelf.setAttribute("inert", "");
+    }
+    if (shelf.getAttribute("aria-hidden") !== "true") {
+      shelf.setAttribute("aria-hidden", "true");
+    }
+  }
+
+  const headers = document.querySelectorAll<HTMLElement>(NATIVE_LYRICS_HEADER_SELECTOR);
+  for (const header of headers) {
+    if (header.hasAttribute("tabindex")) {
+      header.removeAttribute("tabindex");
+    }
+  }
+}
+
+function scheduleApply(): void {
+  if (applyScheduled) {
+    return;
+  }
+
+  applyScheduled = true;
+  requestAnimationFrame(applyNativeLyricsFocusDisabled);
+}
+
+function shouldHandleMutation(mutation: MutationRecord): boolean {
+  if (!(mutation.target instanceof Element)) {
+    return true;
+  }
+
+  return !mutation.target.closest("#blyrics-wrapper, #blyrics-loader, #blyrics-ad-overlay");
+}
+
+function handleMutations(mutations: MutationRecord[]): void {
+  log("Native lyrics focus observer fired", { mutationCount: mutations.length });
+
+  if (mutations.some(shouldHandleMutation)) {
+    scheduleApply();
+  }
+}
+
+export function disableNativeLyricsFocus(): void {
+  applyNativeLyricsFocusDisabled();
+
+  if (observer) {
+    return;
+  }
+
+  const tabRenderer = document.getElementById("tab-renderer");
+  if (!tabRenderer) {
+    return;
+  }
+
+  observer = new MutationObserver(handleMutations);
+  observer.observe(tabRenderer, {
+    attributeFilter: ["aria-hidden", "inert", "tabindex"],
+    attributes: true,
+    childList: true,
+    subtree: true,
+  });
+}


### PR DESCRIPTION
### TL;DR

Prevents native YouTube Music lyrics from receiving keyboard focus or being interacted with when BetterLyrics lyrics are active.

### What changed?

A new `nativeLyricsFocus` module was introduced that marks the native lyrics shelf as `inert` and `aria-hidden` when BetterLyrics injects its own lyrics, and restores the original attribute state when BetterLyrics cleans up. A `MutationObserver` watches the tab renderer to reapply these attributes if YouTube Music resets them. Additionally, the `tabindex` attribute is removed from native lyrics headers to prevent them from being reachable via tab navigation.

The `doneFirstInstantScroll` tracking logic was also removed from the animation engine, along with the workaround that forced an instant scroll when the scroll position was zero on panel open.

### How to test?

1. Open YouTube Music and navigate to a track with lyrics.
2. Verify that BetterLyrics renders its lyrics panel.
3. Use keyboard Tab navigation and confirm that the native lyrics shelf is not focusable while BetterLyrics lyrics are displayed.
4. Navigate away from the lyrics tab or trigger a cleanup and confirm the native lyrics shelf becomes focusable again.
5. Reopen the lyrics panel and confirm the scroll position initializes correctly without jumping from the top.

### Why make this change?

When BetterLyrics is active, the native lyrics shelf remains in the DOM and is reachable via keyboard and assistive technology, creating a confusing duplicate experience. By marking the native shelf as inert and aria-hidden while BetterLyrics is active, focus and screen reader interaction are scoped exclusively to the BetterLyrics lyrics. The `doneFirstInstantScroll` workaround was removed as it is no longer needed now that focus and scroll behavior are handled more cleanly.