### PR TITLE
Various perf improvements to the animation system

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1,41 +1,30 @@
 /**
- * @fileoverview YouTube Music player integration script for BetterLyrics.
- * Handles real-time player state monitoring and event dispatching.
+ * @fileoverview YouTube Music player integration for Better Lyrics.
+ * Publishes authoritative metadata/state snapshots without driving every
+ * animation tick across the MAIN/ISOLATED world boundary.
  */
 
-/**
- * Interval ID for the lyrics tick timer.
- * @type {number|null|undefined}
- */
-let tickLyricsInterval;
+const PLAYER_SNAPSHOT_INTERVAL_MS = 1000;
+const VIDEO_STATE_EVENTS = [
+  "loadedmetadata",
+  "durationchange",
+  "play",
+  "playing",
+  "pause",
+  "waiting",
+  "seeking",
+  "seeked",
+  "ratechange",
+  "ended",
+  "emptied",
+];
 
-/**
- * Last recorded player time to detect changes.
- * @type {number}
- */
-let lastPlayerTime = 0;
-
-/**
- * Last recorded player timestamp to interpolate time.
- * @type {number}
- */
-let lastPlayerTimestamp = 0;
-
-let lastSentPlaying = null;
-let pausedTickCounter = 0;
-
+let snapshotInterval;
 let cachedContentRect = null;
 let playerResizeObserver = null;
-let lastVideoId = null;
+let observedPlayer = null;
 let observedVideoElement = null;
 
-/**
- * Writes the video's intrinsic aspect ratio (from the <video> element's
- * videoWidth/videoHeight) to a CSS variable so styles can resize the player
- * to match it (eliminating black bars). Removes the variable when no real
- * video frame is available so CSS falls back to its default.
- * @param {HTMLVideoElement | null} video
- */
 const updateVideoAspectRatioVar = video => {
   if (video && video.videoWidth > 0 && video.videoHeight > 0) {
     document.documentElement.style.setProperty(
@@ -47,163 +36,139 @@ const updateVideoAspectRatioVar = video => {
   }
 };
 
-const handleVideoResize = () => updateVideoAspectRatioVar(observedVideoElement);
+const publishPlayerSnapshot = () => {
+  const player = observedPlayer;
+  if (!player?.isConnected) return;
 
-/**
- * Finds the <video> inside the player and (re)attaches a resize listener so
- * we react to intrinsic-dimension changes (loadedmetadata, quality switches).
- * @param {HTMLElement} player
- */
-const attachVideoListener = player => {
-  const video = player && player.querySelector("video");
-  if (video !== observedVideoElement) {
-    if (observedVideoElement) {
-      observedVideoElement.removeEventListener("resize", handleVideoResize);
+  try {
+    const { video_id, title, author } = player.getVideoData();
+    const duration = player.getDuration();
+    if (
+      !video_id ||
+      typeof title !== "string" ||
+      !title.trim() ||
+      typeof author !== "string" ||
+      !author.trim() ||
+      !Number.isFinite(duration) ||
+      duration <= 0
+    ) {
+      return;
     }
-    observedVideoElement = video || null;
-    if (observedVideoElement) {
-      observedVideoElement.addEventListener("resize", handleVideoResize);
+
+    if (!cachedContentRect && typeof player.getVideoContentRect === "function") {
+      cachedContentRect = player.getVideoContentRect();
     }
+
+    const { isPlaying, isBuffering, isSeeking, isUiSeeking } = player.getPlayerStateObject();
+    document.dispatchEvent(
+      new CustomEvent("blyrics-send-player-time", {
+        detail: {
+          currentTime: player.getCurrentTime(),
+          videoId: video_id,
+          song: title,
+          artist: author,
+          duration,
+          audioTrackData: player.getAudioTrack(),
+          browserTime: Date.now(),
+          playing: isPlaying && !isBuffering && !isSeeking && !isUiSeeking,
+          playbackRate: observedVideoElement?.playbackRate ?? 1,
+          contentRect: cachedContentRect ?? { width: 0, height: 0 },
+        },
+      })
+    );
+  } catch (error) {
+    console.log(error);
   }
-  updateVideoAspectRatioVar(observedVideoElement);
 };
 
-/**
- * Sets up a ResizeObserver on the player element to cache the content rect.
- * This avoids querying the DOM layout every 20ms which causes performance drops.
- * @param {HTMLElement} player
- */
-const setupResizeObserver = player => {
-  if (playerResizeObserver) {
-    playerResizeObserver.disconnect();
+const handleVideoStateChange = () => {
+  updateVideoAspectRatioVar(observedVideoElement);
+  publishPlayerSnapshot();
+};
+
+const detachVideoListeners = () => {
+  if (!observedVideoElement) return;
+  observedVideoElement.removeEventListener("resize", handleVideoStateChange);
+  for (const event of VIDEO_STATE_EVENTS) {
+    observedVideoElement.removeEventListener(event, handleVideoStateChange);
+  }
+  observedVideoElement = null;
+};
+
+const attachVideoListeners = player => {
+  const video = player?.querySelector("video") ?? null;
+  if (video === observedVideoElement) return;
+
+  detachVideoListeners();
+  observedVideoElement = video;
+  if (!video) {
+    updateVideoAspectRatioVar(null);
+    return;
+  }
+
+  video.addEventListener("resize", handleVideoStateChange);
+  for (const event of VIDEO_STATE_EVENTS) {
+    video.addEventListener(event, handleVideoStateChange);
+  }
+  updateVideoAspectRatioVar(video);
+};
+
+const handlePlayerStateChange = () => publishPlayerSnapshot();
+
+const detachPlayer = () => {
+  if (observedPlayer && typeof observedPlayer.removeEventListener === "function") {
+    observedPlayer.removeEventListener("onStateChange", handlePlayerStateChange);
+  }
+  playerResizeObserver?.disconnect();
+  playerResizeObserver = null;
+  detachVideoListeners();
+  observedPlayer = null;
+  cachedContentRect = null;
+};
+
+const attachPlayer = player => {
+  if (player === observedPlayer) {
+    attachVideoListeners(player);
+    return;
+  }
+
+  detachPlayer();
+  observedPlayer = player;
+
+  if (typeof player.addEventListener === "function") {
+    player.addEventListener("onStateChange", handlePlayerStateChange);
   }
 
   playerResizeObserver = new ResizeObserver(() => {
-    if (player && typeof player.getVideoContentRect === "function") {
+    if (typeof player.getVideoContentRect === "function") {
       cachedContentRect = player.getVideoContentRect();
     }
-    attachVideoListener(player);
+    attachVideoListeners(player);
   });
-
   playerResizeObserver.observe(player);
-  attachVideoListener(player);
-};
-// ------------------------------------------
-
-/**
- * Starts the lyrics tick interval to monitor YouTube Music player state.
- * Dispatches custom events with player information every 20ms for real-time sync.
- * Automatically stops the previous interval if one exists.
- */
-const startLyricsTick = () => {
-  stopLyricsTick();
-
-  let player = document.getElementById("movie_player");
-  if (player) {
-    setupResizeObserver(player);
-  }
-
-  tickLyricsInterval = setInterval(function () {
-    if (!player || !player.isConnected) {
-      player = document.getElementById("movie_player");
-      if (player) {
-        setupResizeObserver(player);
-      }
-    } else {
-      try {
-        const now = Date.now();
-
-        const { video_id, title, author } = player.getVideoData();
-
-        // Update the cached rect when the video changes, as aspect ratios might shift
-        if (video_id !== lastVideoId) {
-          lastVideoId = video_id;
-          if (typeof player.getVideoContentRect === "function") {
-            cachedContentRect = player.getVideoContentRect();
-          }
-          attachVideoListener(player);
-        }
-
-        const audioTrackData = player.getAudioTrack();
-        const duration = player.getDuration();
-        const { isPlaying, isBuffering } = player.getPlayerStateObject();
-
-        // Use the cached contentRect. Fallback if it hasn't been cached yet.
-        let contentRect = cachedContentRect;
-        if (!contentRect && typeof player.getVideoContentRect === "function") {
-          contentRect = player.getVideoContentRect();
-          cachedContentRect = contentRect;
-        }
-
-        const currentTime = player.getCurrentTime();
-        const playing = isPlaying && !isBuffering;
-
-        // Throttle events when paused: only send every ~500ms instead of every 20ms
-        if (!playing) {
-          pausedTickCounter++;
-          const stateChanged = lastSentPlaying !== playing;
-          const timeChanged = currentTime !== lastPlayerTime;
-          if (!stateChanged && !timeChanged && pausedTickCounter < 25) {
-            return;
-          }
-          pausedTickCounter = 0;
-        }
-        lastSentPlaying = playing;
-
-        // Extrapolate the current time
-        if (currentTime !== lastPlayerTime || !playing) {
-          lastPlayerTime = currentTime;
-          lastPlayerTimestamp = now;
-        }
-
-        const timeDiff = (now - lastPlayerTimestamp) / 1000;
-        const time = currentTime + timeDiff;
-
-        document.dispatchEvent(
-          new CustomEvent("blyrics-send-player-time", {
-            detail: {
-              currentTime: time,
-              videoId: video_id,
-              song: title,
-              artist: author,
-              duration: duration,
-              audioTrackData: audioTrackData,
-              browserTime: now,
-              playing: playing,
-              contentRect,
-            },
-          })
-        );
-      } catch (e) {
-        console.log(e);
-        stopLyricsTick();
-      }
-    }
-  }, 20);
+  attachVideoListeners(player);
 };
 
-/**
- * Stops the lyrics tick interval, clears the timer, and cleans up observers.
- * Called when the page is unloaded or when an error occurs.
- */
-const stopLyricsTick = () => {
-  if (tickLyricsInterval) {
-    clearInterval(tickLyricsInterval);
-    tickLyricsInterval = null;
-  }
+const checkPlayerAndPublish = () => {
+  const player = document.getElementById("movie_player");
+  if (player) attachPlayer(player);
+  else if (observedPlayer) detachPlayer();
 
-  if (playerResizeObserver) {
-    playerResizeObserver.disconnect();
-    playerResizeObserver = null;
-  }
-
-  if (observedVideoElement) {
-    observedVideoElement.removeEventListener("resize", handleVideoResize);
-    observedVideoElement = null;
-  }
+  // Intentionally unconditional. If the initial document_end snapshot races
+  // isolated-world initialization, the next 1 Hz snapshot still initializes
+  // lyrics instead of being suppressed as a duplicate.
+  publishPlayerSnapshot();
 };
 
-window.addEventListener("unload", stopLyricsTick);
+const stopPlayerBridge = () => {
+  if (snapshotInterval) {
+    clearInterval(snapshotInterval);
+    snapshotInterval = null;
+  }
+  detachPlayer();
+};
+
+window.addEventListener("unload", stopPlayerBridge);
 
 document.addEventListener("blyrics-seek-to", event => {
   const player = document.getElementById("movie_player");
@@ -214,4 +179,5 @@ document.addEventListener("blyrics-seek-to", event => {
   }
 });
 
-startLyricsTick();
+checkPlayerAndPublish();
+snapshotInterval = setInterval(checkPlayerAndPublish, PLAYER_SNAPSHOT_INTERVAL_MS);

--- a/src/core/appState.ts
+++ b/src/core/appState.ts
@@ -15,6 +15,7 @@ export interface PlayerDetails {
   audioTrackData: any;
   browserTime: number;
   playing: boolean;
+  playbackRate?: number;
   contentRect: {
     width: number;
     height: number;

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -25,6 +25,7 @@ const SCROLL_TIMING_RATIO_BASE_DURATION_MS = 750;
 const SCROLL_TIMING_RATIO_BASE_EARLY_SCROLL_CONSIDER_S = 0.62;
 const SCROLL_TIMING_RATIO_BASE_QUEUE_SCROLL_THRESHOLD_MS = 150;
 const MAX_AUTO_QUEUE_SCROLL_THRESHOLD_MS = 200;
+const SCROLL_PREPARE_LEAD_MS = 120;
 const SCROLL_TIMING_RATIO_BASE_TOTAL_MS =
   SCROLL_TIMING_RATIO_BASE_EARLY_SCROLL_CONSIDER_S * 1000 + SCROLL_TIMING_RATIO_BASE_QUEUE_SCROLL_THRESHOLD_MS;
 const SCROLL_TIMING_BUFFER_MS = SCROLL_TIMING_RATIO_BASE_TOTAL_MS - SCROLL_TIMING_RATIO_BASE_DURATION_MS;
@@ -86,6 +87,7 @@ let tabRendererResizeObserver: ResizeObserver | null = null;
 let observedTabRenderer: HTMLElement | null = null;
 let lineScrollAnimations: LineScrollAnimationRecord[] = [];
 let lineScrollAnimationToken = 0;
+let pendingLineScroll: PendingLineScroll | null = null;
 const lineScrollElementTokens = new WeakMap<HTMLElement, number>();
 let visibleWillChangeElements = new Set<HTMLElement>();
 let animationTimingVisibilityLogUntil = 0;
@@ -153,6 +155,7 @@ export let animEngineState: AnimEngineState = {
  * Called when song is switched or cleaned up
  */
 export function resetAnimEngineState(): void {
+  cancelPendingLineScroll();
   clearLineScrollAnimations();
   clearVisibleLyricWillChange();
   if (AppState.lyricData) {
@@ -169,7 +172,6 @@ export function resetAnimEngineState(): void {
   animEngineState.passiveScrollAccumulatedTime = 0;
   animEngineState.passiveLastWallTime = 0;
   stopPassiveScrollLoop();
-  clearAnimationStyleCache();
 }
 
 function resetPartAnimations(part: PartData): void {
@@ -1108,10 +1110,16 @@ function startInstrumentalExitAnimations(lineData: LineData, config: AnimationCo
 
 let cachedDurations: Map<string, number> = new Map();
 const cachedCSSValues: Map<string, string> = new Map();
+let cachedAnimationSettings: {
+  config: AnimationConfig;
+  scrollTiming: { earlyScrollConsiderS: number; queueScrollMs: number };
+} | null = null;
 
 export function clearAnimationStyleCache(): void {
+  cancelPendingLineScroll();
   cachedDurations.clear();
   cachedCSSValues.clear();
+  cachedAnimationSettings = null;
 }
 
 if (typeof window !== "undefined" && window.matchMedia) {
@@ -1314,6 +1322,20 @@ function readScrollTiming(scrollDurationMs: number): { earlyScrollConsiderS: num
   };
 }
 
+function getAnimationSettings(lyricsElement: HTMLElement): {
+  config: AnimationConfig;
+  scrollTiming: { earlyScrollConsiderS: number; queueScrollMs: number };
+} {
+  if (!cachedAnimationSettings) {
+    const config = readAnimationConfig(lyricsElement);
+    cachedAnimationSettings = {
+      config,
+      scrollTiming: readScrollTiming(config.scroll.durationMs),
+    };
+  }
+  return cachedAnimationSettings;
+}
+
 function clearLineScrollAnimations(): void {
   const records = lineScrollAnimations;
   lineScrollAnimations = [];
@@ -1377,8 +1399,8 @@ function lineScrollTranslate(side: LineScrollSide, state: LineScrollKeyframe, us
   return `0 var(${sharedProperty}, ${fallback})`;
 }
 
-function computedTranslate(lineElement: HTMLElement): string {
-  const translate = window.getComputedStyle(lineElement).translate.trim();
+function normalizedTranslate(translateValue: string): string {
+  const translate = translateValue.trim();
   return translate && translate !== "none" ? translate : "0px 0px";
 }
 
@@ -1395,20 +1417,10 @@ function restoreInlineStyleProperty(
   }
 }
 
-function resolveLineScrollTranslate(
-  lineElement: HTMLElement,
-  side: LineScrollSide,
-  state: LineScrollKeyframe,
-  useDifferentialEffects: boolean
-): string {
-  const previousTranslate = lineElement.style.getPropertyValue("translate");
-  const previousPriority = lineElement.style.getPropertyPriority("translate");
-
-  lineElement.style.setProperty("translate", lineScrollTranslate(side, state, useDifferentialEffects), "important");
-  const translate = computedTranslate(lineElement);
-  restoreInlineStyleProperty(lineElement, "translate", previousTranslate, previousPriority);
-
-  return translate;
+function lineScrollDurationProperty(side: LineScrollSide, fallbackMs: number, useDifferentialEffects: boolean): string {
+  return useDifferentialEffects
+    ? `var(--blyrics-line-scroll-${side}-duration, var(--blyrics-line-scroll-duration, ${fallbackMs}ms))`
+    : `var(--blyrics-line-scroll-duration, ${fallbackMs}ms)`;
 }
 
 function clearLineScrollInlineProperties(lineElement: HTMLElement, token?: number): void {
@@ -1422,53 +1434,69 @@ function clearLineScrollInlineProperties(lineElement: HTMLElement, token?: numbe
   lineScrollElementTokens.delete(lineElement);
 }
 
-function resolveLineScrollDuration(
-  lineElement: HTMLElement,
-  side: LineScrollSide,
-  fallbackMs: number,
-  useDifferentialEffects: boolean
-): number {
-  const previousDuration = lineElement.style.transitionDuration;
-  const previousPriority = lineElement.style.getPropertyPriority("transition-duration");
-  const durationProperty = useDifferentialEffects
-    ? `var(--blyrics-line-scroll-${side}-duration, var(--blyrics-line-scroll-duration, ${fallbackMs}ms))`
-    : `var(--blyrics-line-scroll-duration, ${fallbackMs}ms)`;
-
-  lineElement.style.setProperty("transition-duration", durationProperty, "important");
-  const durationMs = toMs(window.getComputedStyle(lineElement).transitionDuration.split(",")[0].trim());
-
-  if (previousDuration) {
-    lineElement.style.setProperty("transition-duration", previousDuration, previousPriority);
-  } else {
-    lineElement.style.removeProperty("transition-duration");
-  }
-
-  return durationMs > 0 ? durationMs : fallbackMs;
-}
-
-function resolveLineScrollKeyframeEasing(
-  lineElement: HTMLElement,
+function lineScrollEasingProperty(
   side: LineScrollSide,
   keyframe: LineScrollKeyframe,
   fallback: string,
   useDifferentialEffects: boolean
 ): string {
-  const previousEasing = lineElement.style.transitionTimingFunction;
-  const previousPriority = lineElement.style.getPropertyPriority("transition-timing-function");
-  const easingProperty = useDifferentialEffects
+  return useDifferentialEffects
     ? `var(--blyrics-line-scroll-${side}-${keyframe}-easing, var(--blyrics-line-scroll-${keyframe}-easing, var(--blyrics-line-scroll-timing-function, ${fallback})))`
     : `var(--blyrics-line-scroll-${keyframe}-easing, var(--blyrics-line-scroll-timing-function, ${fallback}))`;
+}
 
-  lineElement.style.setProperty("transition-timing-function", easingProperty, "important");
-  const easing = window.getComputedStyle(lineElement).transitionTimingFunction.trim();
+interface PreparedLineScroll {
+  lineElement: HTMLElement;
+  side: LineScrollSide;
+  token: number;
+}
 
-  if (previousEasing) {
-    lineElement.style.setProperty("transition-timing-function", previousEasing, previousPriority);
-  } else {
-    lineElement.style.removeProperty("transition-timing-function");
+interface ResolvedLineScroll extends PreparedLineScroll {
+  durationMs: number;
+  startEasing: string;
+  endEasing: string;
+  startTranslate: string;
+  endTranslate: string;
+}
+
+interface LineScrollPlan {
+  items: ResolvedLineScroll[];
+}
+
+interface PendingLineScroll {
+  plan: LineScrollPlan;
+  activeLineElement: HTMLElement;
+  fromScrollTop: number;
+  toScrollTop: number;
+}
+
+/**
+ * Resolves one temporary computed-style probe for every visible line. Keeping
+ * each property in its own write/read/restore phase preserves the original
+ * resolver semantics while reducing N style flushes to one flush per probe.
+ */
+function batchResolveLineScrollProperty<T>(
+  items: PreparedLineScroll[],
+  property: string,
+  probeValue: (item: PreparedLineScroll) => string,
+  readValue: (style: CSSStyleDeclaration) => T
+): T[] {
+  const previous = items.map(item => ({
+    value: item.lineElement.style.getPropertyValue(property),
+    priority: item.lineElement.style.getPropertyPriority(property),
+  }));
+
+  for (const item of items) {
+    item.lineElement.style.setProperty(property, probeValue(item), "important");
   }
 
-  return easing || fallback;
+  const values = items.map(item => readValue(window.getComputedStyle(item.lineElement)));
+
+  for (let index = 0; index < items.length; index++) {
+    restoreInlineStyleProperty(items[index].lineElement, property, previous[index].value, previous[index].priority);
+  }
+
+  return values;
 }
 
 function isLineVisibleDuringScroll(
@@ -1530,7 +1558,7 @@ function getLineScrollItems(lines: LineData[], lyricsElement: HTMLElement): Line
   ];
 }
 
-function animateLineScrollOffsets(
+function prepareLineScrollOffsets(
   lines: LineScrollItem[],
   activeLineIndex: number,
   scrollDeltaPx: number,
@@ -1538,13 +1566,16 @@ function animateLineScrollOffsets(
   toScrollTop: number,
   viewportHeight: number,
   config: AnimationConfig
-): void {
+): LineScrollPlan | null {
   if (!config.enabled.scroll || activeLineIndex < 0) {
-    return;
+    return null;
   }
 
   const scrollDistancePx = Math.abs(scrollDeltaPx);
+  const prepared: PreparedLineScroll[] = [];
 
+  // Preserve the original windowing exactly: only lines intersecting the
+  // union of the old and new viewports receive scroll animations.
   for (let index = 0; index < lines.length; index++) {
     if (!isLineVisibleDuringScroll(lines[index], fromScrollTop, toScrollTop, viewportHeight)) {
       continue;
@@ -1565,48 +1596,156 @@ function animateLineScrollOffsets(
     const token = ++lineScrollAnimationToken;
     lineScrollElementTokens.set(lineElement, token);
 
-    const durationMs = resolveLineScrollDuration(
-      lineElement,
-      side,
-      config.lineScroll.durationMs,
-      config.lineScroll.differentialEffects
-    );
-    const startEasing = resolveLineScrollKeyframeEasing(
-      lineElement,
-      side,
-      "start",
-      config.lineScroll.easing,
-      config.lineScroll.differentialEffects
-    );
-    const endEasing = resolveLineScrollKeyframeEasing(
-      lineElement,
-      side,
-      "end",
-      config.lineScroll.easing,
-      config.lineScroll.differentialEffects
-    );
-    const startTranslate = resolveLineScrollTranslate(
-      lineElement,
-      side,
-      "start",
-      config.lineScroll.differentialEffects
-    );
-    const endTranslate = resolveLineScrollTranslate(lineElement, side, "end", config.lineScroll.differentialEffects);
+    prepared.push({ lineElement, side, token });
+  }
 
-    const animation = lineElement.animate(
+  const durations = batchResolveLineScrollProperty(
+    prepared,
+    "transition-duration",
+    item => lineScrollDurationProperty(item.side, config.lineScroll.durationMs, config.lineScroll.differentialEffects),
+    style => {
+      const durationMs = toMs(style.transitionDuration.split(",")[0].trim());
+      return durationMs > 0 ? durationMs : config.lineScroll.durationMs;
+    }
+  );
+  const startEasings = batchResolveLineScrollProperty(
+    prepared,
+    "transition-timing-function",
+    item =>
+      lineScrollEasingProperty(item.side, "start", config.lineScroll.easing, config.lineScroll.differentialEffects),
+    style => style.transitionTimingFunction.trim() || config.lineScroll.easing
+  );
+  const endEasings = batchResolveLineScrollProperty(
+    prepared,
+    "transition-timing-function",
+    item => lineScrollEasingProperty(item.side, "end", config.lineScroll.easing, config.lineScroll.differentialEffects),
+    style => style.transitionTimingFunction.trim() || config.lineScroll.easing
+  );
+  const startTranslates = batchResolveLineScrollProperty(
+    prepared,
+    "translate",
+    item => lineScrollTranslate(item.side, "start", config.lineScroll.differentialEffects),
+    style => normalizedTranslate(style.translate)
+  );
+  const endTranslates = batchResolveLineScrollProperty(
+    prepared,
+    "translate",
+    item => lineScrollTranslate(item.side, "end", config.lineScroll.differentialEffects),
+    style => normalizedTranslate(style.translate)
+  );
+
+  return {
+    items: prepared.map((item, index) => ({
+      ...item,
+      durationMs: durations[index],
+      startEasing: startEasings[index],
+      endEasing: endEasings[index],
+      startTranslate: startTranslates[index],
+      endTranslate: endTranslates[index],
+    })),
+  };
+}
+
+function startPreparedLineScroll(plan: LineScrollPlan): void {
+  for (const item of plan.items) {
+    if (!item.lineElement.isConnected || lineScrollElementTokens.get(item.lineElement) !== item.token) continue;
+
+    const animation = item.lineElement.animate(
       [
-        { translate: startTranslate, easing: startEasing },
-        { translate: endTranslate, easing: endEasing },
+        { translate: item.startTranslate, easing: item.startEasing },
+        { translate: item.endTranslate, easing: item.endEasing },
       ] as Keyframe[],
       {
         composite: "add",
-        duration: durationMs,
+        duration: item.durationMs,
         easing: "linear",
         fill: "none",
       }
     );
 
-    trackLineScrollAnimation(animation, lineElement, token);
+    trackLineScrollAnimation(animation, item.lineElement, item.token);
+  }
+}
+
+function discardLineScrollPlan(plan: LineScrollPlan): void {
+  for (const item of plan.items) {
+    clearLineScrollInlineProperties(item.lineElement, item.token);
+  }
+}
+
+export function cancelPendingLineScroll(): void {
+  if (!pendingLineScroll) return;
+  discardLineScrollPlan(pendingLineScroll.plan);
+  pendingLineScroll = null;
+}
+
+function pendingLineScrollMatches(activeLine: LineData, fromScrollTop: number, toScrollTop: number): boolean {
+  return !!(
+    pendingLineScroll &&
+    pendingLineScroll.activeLineElement === activeLine.lyricElement &&
+    Math.abs(pendingLineScroll.fromScrollTop - fromScrollTop) <= 2 &&
+    Math.abs(pendingLineScroll.toScrollTop - toScrollTop) <= 2
+  );
+}
+
+function commitOrPrepareLineScroll(
+  lines: LineScrollItem[],
+  activeLine: LineData,
+  scrollDeltaPx: number,
+  fromScrollTop: number,
+  toScrollTop: number,
+  viewportHeight: number,
+  config: AnimationConfig
+): void {
+  if (pendingLineScrollMatches(activeLine, fromScrollTop, toScrollTop)) {
+    const pending = pendingLineScroll!;
+    pendingLineScroll = null;
+    startPreparedLineScroll(pending.plan);
+    return;
+  }
+
+  cancelPendingLineScroll();
+  const plan = prepareLineScrollOffsets(
+    lines,
+    lines.findIndex(line => line.lyricElement === activeLine.lyricElement),
+    scrollDeltaPx,
+    fromScrollTop,
+    toScrollTop,
+    viewportHeight,
+    config
+  );
+  if (plan) startPreparedLineScroll(plan);
+}
+
+function prepareUpcomingLineScroll(
+  lines: LineScrollItem[],
+  activeLine: LineData,
+  scrollDeltaPx: number,
+  fromScrollTop: number,
+  toScrollTop: number,
+  viewportHeight: number,
+  config: AnimationConfig
+): void {
+  if (pendingLineScrollMatches(activeLine, fromScrollTop, toScrollTop)) return;
+
+  cancelPendingLineScroll();
+  const activeLineIndex = lines.findIndex(line => line.lyricElement === activeLine.lyricElement);
+  const plan = prepareLineScrollOffsets(
+    lines,
+    activeLineIndex,
+    scrollDeltaPx,
+    fromScrollTop,
+    toScrollTop,
+    viewportHeight,
+    config
+  );
+  if (plan) {
+    pendingLineScroll = {
+      plan,
+      activeLineElement: activeLine.lyricElement,
+      fromScrollTop,
+      toScrollTop,
+    };
   }
 }
 
@@ -1748,6 +1887,7 @@ function setupTabRendererObserver(element: HTMLElement) {
   }
 
   tabRendererResizeObserver = new ResizeObserver(() => {
+    cancelPendingLineScroll();
     if (element && element.isConnected) {
       cachedTabRendererHeight = element.getBoundingClientRect().height;
     }
@@ -1787,6 +1927,8 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
     Math.abs(
       currentTime - animEngineState.lastTime - (eventCreationTime - animEngineState.lastEventCreationTime) / 1000
     ) > TIME_JUMP_THRESHOLD;
+
+  if (timeJumped) cancelPendingLineScroll();
 
   animEngineState.lastTime = currentTime;
   animEngineState.lastPlayState = isPlaying;
@@ -1851,8 +1993,7 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
 
     const lyricScrollTime =
       correctedScrollTimeS(currentTime) + getCSSDurationInMs(lyricsElement, "--blyrics-scroll-timing-offset") / 1000;
-    const animationConfig = readAnimationConfig(lyricsElement);
-    const scrollTiming = readScrollTiming(animationConfig.scroll.durationMs);
+    const { config: animationConfig, scrollTiming } = getAnimationSettings(lyricsElement);
 
     // Read layout values before the loop writes class changes, to avoid forced reflow
     const tabRenderer = document.querySelector(TAB_RENDERER_SELECTOR) as HTMLElement | null;
@@ -1866,8 +2007,9 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
     const tabRendererHeight = cachedTabRendererHeight ?? tabRenderer.getBoundingClientRect().height;
     let scrollTop = tabRenderer.scrollTop;
     if (animationConfig.enabled.scroll) {
-      updateVisibleLyricWillChange(lines, scrollTop, scrollTop, tabRendererHeight);
+      updateVisibleLyricWillChange(lines, scrollTop, pendingLineScroll?.toScrollTop ?? scrollTop, tabRendererHeight);
     } else {
+      cancelPendingLineScroll();
       clearVisibleLyricWillChange();
       clearLineScrollAnimations();
     }
@@ -2157,6 +2299,29 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
         }
       }
 
+      const timeUntilUpcomingScrollMs = (lastActiveLyric.time - lyricScrollTime) * 1000;
+      if (
+        smoothScroll &&
+        animationConfig.enabled.scroll &&
+        !newLyricSelected &&
+        !animEngineState.wasUserScrolling &&
+        timeUntilUpcomingScrollMs > 0 &&
+        timeUntilUpcomingScrollMs <= SCROLL_PREPARE_LEAD_MS &&
+        Date.now() > animEngineState.nextScrollAllowedTime &&
+        Math.abs(scrollTop - scrollPos) > 2
+      ) {
+        updateVisibleLyricWillChange(lines, scrollTop, scrollPos, tabRendererHeight);
+        prepareUpcomingLineScroll(
+          getLineScrollItems(lines, lyricsElement),
+          lastActiveLyric,
+          scrollPos - scrollTop,
+          scrollTop,
+          scrollPos,
+          tabRendererHeight,
+          animationConfig
+        );
+      }
+
       if (animEngineState.wasUserScrolling || newLyricSelected || animEngineState.queuedScroll) {
         if (Date.now() > animEngineState.nextScrollAllowedTime) {
           animEngineState.queuedScroll = false;
@@ -2169,9 +2334,9 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
             if (animationConfig.enabled.scroll) {
               updateVisibleLyricWillChange(lines, scrollTop, scrollPos, tabRendererHeight);
               const lineScrollItems = getLineScrollItems(lines, lyricsElement);
-              animateLineScrollOffsets(
+              commitOrPrepareLineScroll(
                 lineScrollItems,
-                lines.indexOf(lastActiveLyric),
+                lastActiveLyric,
                 scrollDeltaPx,
                 scrollTop,
                 scrollPos,
@@ -2180,6 +2345,8 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
               );
               animEngineState.nextScrollAllowedTime = animationConfig.scroll.durationMs + Date.now() + 20;
             }
+          } else {
+            cancelPendingLineScroll();
           }
 
           scrollTop = scrollPos;
@@ -2227,6 +2394,7 @@ export function lyricsElementAdded(): void {
     return;
   }
   pendingLyricsUpdate = true;
+  cancelPendingLineScroll();
   requestAnimationFrame(() => {
     pendingLyricsUpdate = false;
     calculateLyricPositions();

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -20,6 +20,7 @@ import { onAutoSwitchEnabled, onFullScreenDisabled, wakeDockIdle } from "@module
 import {
   animationEngine,
   animEngineState,
+  cancelPendingLineScroll,
   getResumeScrollElement,
   noteAnimationVisibilityChange,
 } from "@modules/ui/animationEngine";
@@ -56,6 +57,38 @@ let hasInitializedHomepageFullscreen = false;
 let hasInitializedAltHover = false;
 let hasInitializedLyrics = false;
 let metadataAbortController: AbortController | null = null;
+const ANIMATION_ENGINE_INTERVAL_MS = 20;
+let animationFrameRequest: number | null = null;
+let lastAnimationEngineRun = -Infinity;
+let latestPlayerPlaying = false;
+let latestPlayerTime = 0;
+let latestPlayerSnapshotTime = 0;
+let latestPlayerDuration = 0;
+let latestPlaybackRate = 1;
+
+function runAnimationEngine(now: number, force = false): void {
+  if (!force && (!latestPlayerPlaying || now - lastAnimationEngineRun < ANIMATION_ENGINE_INTERVAL_MS)) return;
+
+  lastAnimationEngineRun = now;
+  const wallTime = Date.now();
+  const elapsedS = latestPlayerPlaying
+    ? (Math.max(0, wallTime - latestPlayerSnapshotTime) * latestPlaybackRate) / 1000
+    : 0;
+  const currentTime = Math.min(latestPlayerTime + elapsedS, latestPlayerDuration || Infinity);
+  if (AppState.suppressZeroTime < wallTime || currentTime !== 0) {
+    animationEngine(currentTime, wallTime, latestPlayerPlaying);
+  }
+}
+
+function animationFrameLoop(now: number): void {
+  runAnimationEngine(now);
+  animationFrameRequest = requestAnimationFrame(animationFrameLoop);
+}
+
+function startAnimationFrameLoop(): void {
+  if (animationFrameRequest !== null) return;
+  animationFrameRequest = requestAnimationFrame(animationFrameLoop);
+}
 
 async function requestWakeLock(): Promise<void> {
   if (!("wakeLock" in navigator)) {
@@ -282,11 +315,21 @@ export function initializeLyrics(): void {
 
   document.addEventListener("visibilitychange", () => {
     noteAnimationVisibilityChange();
+    if (document.visibilityState === "visible") {
+      runAnimationEngine(performance.now(), true);
+    }
   });
+
+  startAnimationFrameLoop();
 
   // @ts-ignore
   document.addEventListener("blyrics-send-player-time", (event: CustomEvent<PlayerDetails>) => {
     const detail = event.detail;
+    latestPlayerPlaying = detail.playing;
+    latestPlayerTime = detail.currentTime;
+    latestPlayerSnapshotTime = detail.browserTime;
+    latestPlayerDuration = Number(detail.duration);
+    latestPlaybackRate = detail.playbackRate ?? 1;
 
     const currentVideoId = detail.videoId;
     const currentVideoDetails = detail.song + " " + detail.artist;
@@ -384,8 +427,8 @@ export function initializeLyrics(): void {
       }
     }
 
-    if (AppState.suppressZeroTime < Date.now() || detail.currentTime !== 0) {
-      animationEngine(detail.currentTime, detail.browserTime, detail.playing);
+    if (document.visibilityState === "visible") {
+      runAnimationEngine(performance.now(), true);
     }
   });
 }
@@ -405,6 +448,7 @@ export function scrollEventHandler(): void {
     animEngineState.skipScrollsDecayTimes.shift();
     return;
   }
+  cancelPendingLineScroll();
   if (!isLoaderActive()) {
     if (animEngineState.scrollResumeTime < Date.now()) {
       log(PAUSING_LYRICS_SCROLL_LOG);


### PR DESCRIPTION
### TL;DR

Replaces the 20ms polling interval in `script.js` with event-driven player snapshots, and moves the animation tick loop into a `requestAnimationFrame` loop in the isolated world.

### What changed?

**Player bridge (`script.js`)**
- Removed the 20ms `setInterval` tick that continuously polled and dispatched player state. Replaced it with a 1 Hz snapshot interval (`PLAYER_SNAPSHOT_INTERVAL_MS = 1000`) that publishes authoritative metadata.
- Player state changes (play, pause, seek, rate change, etc.) now trigger immediate snapshots via event listeners attached directly to the `<video>` element and the player's `onStateChange` event, defined in `VIDEO_STATE_EVENTS`.
- Added `playbackRate` to the dispatched snapshot payload so the isolated world can interpolate time accurately.
- Cleaned up player/video attachment and detachment into explicit `attachPlayer`/`detachPlayer`/`attachVideoListeners`/`detachVideoListeners` helpers.

**Animation engine (`animationEngine.ts`)**
- Introduced a `requestAnimationFrame` loop in `observer.ts` that drives the animation engine at up to 50fps independently of player snapshot events. Time is interpolated from the last known snapshot using `playbackRate` and elapsed wall time.
- Added a `SCROLL_PREPARE_LEAD_MS = 120` look-ahead window: the engine now pre-computes line scroll animations slightly before the active lyric changes, storing them as a `PendingLineScroll`. When the scroll actually commits, the pre-computed plan is used directly, reducing layout work at the critical moment.
- Replaced per-line computed-style reads (one forced reflow per line) with `batchResolveLineScrollProperty`, which batches all writes, performs a single flush, reads all values, then restores — reducing style recalculations from N to one per property probe.
- Extracted `getAnimationSettings` to cache `AnimationConfig` and scroll timing per lyrics element, avoiding redundant reads every frame.
- `clearAnimationStyleCache` now also cancels any pending line scroll and clears the cached animation settings.
- `cancelPendingLineScroll` is called on time jumps, user scroll events, tab renderer resize, scroll disabled, and lyrics element changes to prevent stale pre-computed plans from being applied.

### How to test?

1. Open YouTube Music with Better Lyrics active and play a track. Verify lyrics scroll and highlight in sync as before.
2. Seek to different positions and confirm lyrics jump correctly without stale scroll animations.
3. Pause and resume playback and confirm the lyrics position remains accurate.
4. Change playback speed and verify lyric timing adjusts accordingly.
5. Manually scroll the lyrics panel and confirm auto-scroll resumes correctly after the resume delay.
6. Switch tracks and confirm no leftover scroll animations from the previous track appear.
7. Check browser DevTools performance profile to confirm reduced style recalculation and fewer cross-world events compared to the previous 20ms polling approach.

### Why make this change?

The previous architecture fired a cross-world `CustomEvent` every 20ms regardless of whether anything had changed, and drove every animation tick through that event. This caused unnecessary overhead from constant polling, redundant event dispatches when paused, and per-line forced style reflows on every scroll animation setup. By moving the animation loop into `requestAnimationFrame` on the isolated-world side and reducing the player bridge to event-driven snapshots plus a 1 Hz heartbeat, the extension avoids unnecessary cross-world traffic and layout thrashing while enabling smoother scroll animations through pre-computation.