### PR TITLE
Add negative caching for missing lyrics results

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -193,6 +193,7 @@ export const MUSIC_NOTES = "♪𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲" as const;
 export const BLYRICS_INSTRUMENTAL_GAP_MS = 5000;
 
 export const LYRICS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const LYRICS_NEGATIVE_CACHE_TTL_MS = 30 * 60 * 1000;
 
 export const OFFSET_STORAGE_PREFIX = "blyricsOffset_";
 

--- a/src/modules/lyrics/providers/shared.ts
+++ b/src/modules/lyrics/providers/shared.ts
@@ -1,4 +1,10 @@
-import { LYRIC_SOURCE_KEYS, LYRICS_CACHE_TTL_MS, PROVIDER_CONFIGS, PROVIDER_SWITCHED_LOG } from "@constants";
+import {
+  LYRIC_SOURCE_KEYS,
+  LYRICS_CACHE_TTL_MS,
+  LYRICS_NEGATIVE_CACHE_TTL_MS,
+  PROVIDER_CONFIGS,
+  PROVIDER_SWITCHED_LOG,
+} from "@constants";
 import { getTransientStorage, setTransientStorage } from "@core/storage";
 import { log } from "@utils";
 import unified from "./unified";
@@ -185,6 +191,17 @@ export function newSourceMap(): SourceMapType {
 
 export async function saveLyricsToCache(providerParameters: ProviderParameters, provider: LyricSourceKey) {
   let source = providerParameters.sourceMap[provider];
+  if (source.filled && !source.resultCached && !source.lyricSourceResult && provider !== "metadata") {
+    source.resultCached = true;
+    const cacheKey = `blyrics_${providerParameters.videoId}_${provider}`;
+    await setTransientStorage(
+      cacheKey,
+      JSON.stringify({ version: LYRIC_CACHE_VERSION, missing: true }),
+      LYRICS_NEGATIVE_CACHE_TTL_MS
+    );
+    return;
+  }
+
   if (
     source.filled &&
     !source.resultCached &&
@@ -218,8 +235,12 @@ export async function getLyrics(
       const data = JSON.parse(cachedData);
       if (data && data.version && data.version === LYRIC_CACHE_VERSION) {
         lyricSource.filled = true;
-        lyricSource.lyricSourceResult = data;
         lyricSource.resultCached = true;
+        if (data.missing === true) {
+          lyricSource.lyricSourceResult = null;
+          return null;
+        }
+        lyricSource.lyricSourceResult = data;
         return data;
       }
     }

--- a/src/modules/lyrics/providers/unified.ts
+++ b/src/modules/lyrics/providers/unified.ts
@@ -302,6 +302,7 @@ async function startStream(providerParameters: ProviderParameters, retryCount = 
   if (isrc) body.append("isrc", isrc);
   body.append("token", jwt);
 
+  let completedNormally = false;
   try {
     const response = await fetch(CUBEY_LYRICS_API_URL + "v2/lyrics", {
       method: "POST",
@@ -351,6 +352,7 @@ async function startStream(providerParameters: ProviderParameters, retryCount = 
         if (buffer.trim()) {
           await parseSSEMessage(buffer, providerParameters);
         }
+        completedNormally = true;
         break;
       }
     }
@@ -363,7 +365,7 @@ async function startStream(providerParameters: ProviderParameters, retryCount = 
   } finally {
     // Ensure all waiters are resolved (cleared) when stream ends
     MANAGED_KEYS.forEach(key => {
-      if (!providerParameters.sourceMap[key].filled) {
+      if (completedNormally && !providerParameters.sourceMap[key].filled) {
         providerParameters.sourceMap[key].filled = true;
       }
       resolveWaiter(providerParameters, key);

--- a/src/modules/lyrics/providers/unison.ts
+++ b/src/modules/lyrics/providers/unison.ts
@@ -120,16 +120,23 @@ export default async function unison(providerParameters: ProviderParameters): Pr
     headers: { "x-key-id": (await getIdentity()).keyId },
   });
 
-  providerParameters.sourceMap["unison-richsynced"].filled = true;
-  providerParameters.sourceMap["unison-synced"].filled = true;
-  providerParameters.sourceMap["unison-plain"].filled = true;
-
-  if (!response.ok) {
+  if (response.status === 404) {
+    providerParameters.sourceMap["unison-richsynced"].filled = true;
+    providerParameters.sourceMap["unison-synced"].filled = true;
+    providerParameters.sourceMap["unison-plain"].filled = true;
     providerParameters.sourceMap["unison-richsynced"].lyricSourceResult = null;
     providerParameters.sourceMap["unison-synced"].lyricSourceResult = null;
     providerParameters.sourceMap["unison-plain"].lyricSourceResult = null;
     return;
   }
+
+  if (!response.ok) {
+    return;
+  }
+
+  providerParameters.sourceMap["unison-richsynced"].filled = true;
+  providerParameters.sourceMap["unison-synced"].filled = true;
+  providerParameters.sourceMap["unison-plain"].filled = true;
 
   const responseData: UnisonResponse = await response.json().then(json => json.data);
 


### PR DESCRIPTION
### TL;DR

Adds negative caching for lyrics lookups that return no results, and fixes stream completion tracking to avoid incorrectly marking providers as filled on errors.

### What changed?

- Introduces a 30-minute negative cache TTL (`LYRICS_NEGATIVE_CACHE_TTL_MS`) for lyrics providers that return no results. When a provider is queried and returns nothing, a `{ missing: true }` entry is written to the cache so subsequent lookups skip the provider for 30 minutes instead of re-querying.
- When reading from cache, a `missing: true` entry is now recognized and treated as a confirmed "no lyrics" result, returning `null` immediately.
- In the unified stream provider, a `completedNormally` flag is introduced so that unfilled providers are only marked as filled when the stream ends cleanly — not when it ends due to an error or interruption.
- In the unison provider, a 404 response now explicitly marks all unison sources as filled with `null` results (confirmed missing), while other non-OK responses leave sources unfilled so they can be retried.

### How to test?

1. Play a track known to have no lyrics available from a specific provider and confirm the negative cache entry is written.
2. Play the same track again within 30 minutes and verify the provider is not re-queried (check network requests or logs).
3. Simulate a stream error in the unified provider and confirm unfilled sources are not incorrectly marked as filled.
4. Trigger a 404 from the unison provider and confirm all unison sources are marked filled with null. Trigger a 5xx and confirm sources remain unfilled.

### Why make this change?

Without negative caching, every playback of a track with no available lyrics triggers redundant network requests to all providers. This reduces unnecessary API calls and improves performance for tracks that consistently have no lyrics. The stream completion fix prevents a scenario where a failed stream incorrectly suppresses future lookup attempts by prematurely marking providers as filled.