### PR TITLE
perf(lyrics): index active lyric line selection

### DIFF
--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -9,6 +9,7 @@ import { t } from "@core/i18n";
 import { type LyricsData, processLyrics } from "@modules/lyrics/injectLyrics";
 import { stringSimilarity } from "@modules/lyrics/lyricParseUtils";
 import { registerThemeSetting } from "@modules/settings/themeOptions";
+import { invalidateActiveLineIndex } from "@modules/ui/activeLineIndex";
 import { flushLoader, renderLoader } from "@modules/ui/dom";
 import { log } from "@utils";
 import type { Lyric, LyricSourceResult, ProviderParameters } from "./providers/shared";
@@ -67,6 +68,7 @@ export function applySegmentMapToLyrics(lyricData: LyricsData | null, segmentMap
           part.lyricElement.dataset.time = String(part.time);
         });
       }
+      invalidateActiveLineIndex(lyricData.lines);
     }
   }
 }

--- a/src/modules/ui/activeLineIndex.selfcheck.ts
+++ b/src/modules/ui/activeLineIndex.selfcheck.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import {
+  collectActiveLineCandidates,
+  invalidateActiveLineIndex,
+  mergeSortedUniqueIndices,
+  type TimedLine,
+} from "./activeLineIndex";
+
+function fullScan(lines: TimedLine[], minimumEndTime: number, maximumStartTime: number): number[] {
+  const result: number[] = [];
+  for (let index = 0; index < lines.length; index++) {
+    const nextTime = lines[index + 1]?.time ?? Infinity;
+    const effectiveEnd = Math.max(nextTime, lines[index].time + lines[index].duration + 0.05);
+    if (lines[index].time <= maximumStartTime && effectiveEnd > minimumEndTime) result.push(index);
+  }
+  return result;
+}
+
+const candidates: number[] = [];
+
+function check(lines: TimedLine[], minimumEndTime: number, maximumStartTime: number, message: string): void {
+  collectActiveLineCandidates(lines, minimumEndTime, maximumStartTime, candidates);
+  assert.deepEqual(candidates, fullScan(lines, minimumEndTime, maximumStartTime), message);
+}
+
+check([], 0, 0, "empty array");
+check([{ time: 2, duration: 1 }], 1, 3, "one line");
+
+const cases: Array<[string, TimedLine[]]> = [
+  [
+    "normal sequential lines",
+    [
+      { time: 0, duration: 1 },
+      { time: 2, duration: 1 },
+      { time: 4, duration: 1 },
+    ],
+  ],
+  [
+    "overlapping lines",
+    [
+      { time: 0, duration: 5 },
+      { time: 2, duration: 4 },
+      { time: 3, duration: 1 },
+    ],
+  ],
+  [
+    "long-duration lines",
+    [
+      { time: 0, duration: 100 },
+      { time: 10, duration: 1 },
+      { time: 20, duration: 1 },
+    ],
+  ],
+  [
+    "zero-duration lines",
+    [
+      { time: 0, duration: 0 },
+      { time: 1, duration: 0 },
+      { time: 2, duration: 0 },
+    ],
+  ],
+];
+
+for (const [name, lines] of cases) {
+  for (const [minimumEndTime, maximumStartTime] of [
+    [-1, -0.5],
+    [0, 0],
+    [0.05, 0.05],
+    [1, 2],
+    [2, 2],
+    [4.05, 4.05],
+    [100, 101],
+  ]) {
+    check(lines, minimumEndTime, maximumStartTime, `${name}: ${minimumEndTime}..${maximumStartTime}`);
+  }
+}
+
+let seed = 0x5eed1234;
+function random(): number {
+  seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+  return seed / 0x100000000;
+}
+
+for (let set = 0; set < 100; set++) {
+  let time = random() * 2;
+  const lines = Array.from({ length: Math.floor(random() * 80) }, () => {
+    time += random() * 3;
+    return { time, duration: random() * 20 };
+  });
+  for (let window = 0; window < 30; window++) {
+    const minimumEndTime = random() * (time + 25) - 5;
+    const maximumStartTime = minimumEndTime + random() * 5;
+    check(lines, minimumEndTime, maximumStartTime, `random set ${set}, window ${window}`);
+  }
+}
+
+const mutatedLines = [
+  { time: 0, duration: 1 },
+  { time: 3, duration: 1 },
+  { time: 6, duration: 1 },
+];
+check(mutatedLines, 1, 4, "before timing mutation");
+mutatedLines[0].duration = 10;
+mutatedLines[1].time = 4;
+invalidateActiveLineIndex(mutatedLines);
+check(mutatedLines, 3.5, 4, "timing mutation after explicit invalidation");
+
+const pathologicalLines = Array.from({ length: 1_200 }, (_, index) => ({
+  time: index * 2,
+  duration: index === 3 ? 3_000 : 0.5,
+}));
+const pathologicalStats = { visitedNodes: 0, examinedLeaves: 0 };
+const pathologicalMinimumEndTime = 2_200;
+const pathologicalMaximumStartTime = 2_200.25;
+collectActiveLineCandidates(
+  pathologicalLines,
+  pathologicalMinimumEndTime,
+  pathologicalMaximumStartTime,
+  candidates,
+  pathologicalStats
+);
+assert.deepEqual(
+  candidates,
+  fullScan(pathologicalLines, pathologicalMinimumEndTime, pathologicalMaximumStartTime),
+  "pathological long overlap"
+);
+assert.ok(candidates.length < 10, "pathological query must have few candidates");
+assert.deepEqual(
+  candidates,
+  [...new Set(candidates)].sort((left, right) => left - right),
+  "results sorted and unique"
+);
+assert.ok(pathologicalStats.examinedLeaves < pathologicalLines.length, "query must not examine every leaf");
+assert.ok(pathologicalStats.visitedNodes < pathologicalLines.length, "query must not visit one node per line");
+
+const merged: number[] = [];
+mergeSortedUniqueIndices([0, 2, 4, 4, 8], [1, 2, 3, 8, 9], merged);
+assert.deepEqual(merged, [0, 1, 2, 3, 4, 8, 9], "previous/current candidates merge sorted and unique");
+mergeSortedUniqueIndices([], [], merged);
+assert.deepEqual(merged, [], "empty candidate merge");
+
+console.log("activeLineIndex self-check passed");

--- a/src/modules/ui/activeLineIndex.ts
+++ b/src/modules/ui/activeLineIndex.ts
@@ -1,0 +1,110 @@
+export interface TimedLine {
+  time: number;
+  duration: number;
+}
+
+interface TimingIndex {
+  leafOffset: number;
+  rangeMaxEnds: number[];
+}
+
+export interface ActiveLineIndexQueryStats {
+  visitedNodes: number;
+  examinedLeaves: number;
+}
+
+const timingIndexCache = new WeakMap<readonly TimedLine[], TimingIndex>();
+
+export function invalidateActiveLineIndex(lines: readonly TimedLine[]): void {
+  timingIndexCache.delete(lines);
+}
+
+export function mergeSortedUniqueIndices(left: readonly number[], right: readonly number[], output: number[]): void {
+  output.length = 0;
+  let leftIndex = 0;
+  let rightIndex = 0;
+
+  while (leftIndex < left.length || rightIndex < right.length) {
+    const leftValue = left[leftIndex] ?? Infinity;
+    const rightValue = right[rightIndex] ?? Infinity;
+    const value = Math.min(leftValue, rightValue);
+    output.push(value);
+    while (left[leftIndex] === value) leftIndex++;
+    while (right[rightIndex] === value) rightIndex++;
+  }
+}
+
+function getTimingIndex(lines: readonly TimedLine[]): TimingIndex {
+  const cached = timingIndexCache.get(lines);
+  if (cached) return cached;
+
+  let leafOffset = 1;
+  while (leafOffset < lines.length) leafOffset *= 2;
+  const rangeMaxEnds = new Array<number>(leafOffset * 2).fill(-Infinity);
+
+  for (let index = 0; index < lines.length; index++) {
+    const nextTime = lines[index + 1]?.time ?? Infinity;
+    const effectiveEnd = Math.max(nextTime, lines[index].time + lines[index].duration + 0.05);
+    rangeMaxEnds[leafOffset + index] = effectiveEnd;
+  }
+  for (let node = leafOffset - 1; node > 0; node--) {
+    rangeMaxEnds[node] = Math.max(rangeMaxEnds[node * 2], rangeMaxEnds[node * 2 + 1]);
+  }
+
+  const timingIndex = { leafOffset, rangeMaxEnds };
+  timingIndexCache.set(lines, timingIndex);
+  return timingIndex;
+}
+
+function collectFromTree(
+  timingIndex: TimingIndex,
+  node: number,
+  rangeStart: number,
+  rangeEnd: number,
+  upperBound: number,
+  minimumEndTime: number,
+  output: number[],
+  stats?: ActiveLineIndexQueryStats
+): void {
+  if (stats) stats.visitedNodes++;
+  if (rangeStart >= upperBound || timingIndex.rangeMaxEnds[node] <= minimumEndTime) return;
+  if (rangeEnd - rangeStart === 1) {
+    if (stats) stats.examinedLeaves++;
+    output.push(rangeStart);
+    return;
+  }
+
+  const middle = (rangeStart + rangeEnd) >>> 1;
+  collectFromTree(timingIndex, node * 2, rangeStart, middle, upperBound, minimumEndTime, output, stats);
+  collectFromTree(timingIndex, node * 2 + 1, middle, rangeEnd, upperBound, minimumEndTime, output, stats);
+}
+
+export function collectActiveLineCandidates(
+  lines: readonly TimedLine[],
+  minimumEndTime: number,
+  maximumStartTime: number,
+  output: number[],
+  stats?: ActiveLineIndexQueryStats
+): void {
+  output.length = 0;
+  if (stats) {
+    stats.visitedNodes = 0;
+    stats.examinedLeaves = 0;
+  }
+  if (lines.length === 0) return;
+
+  let low = 0;
+  let high = lines.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (lines[middle].time <= maximumStartTime) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+
+  const upperBound = low;
+  const timingIndex = getTimingIndex(lines);
+  collectFromTree(timingIndex, 1, 0, timingIndex.leafOffset, upperBound, minimumEndTime, output, stats);
+}

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -16,6 +16,7 @@ import { calculateLyricPositions, type LineData } from "@modules/lyrics/injectLy
 import { registerThemeSetting } from "@modules/settings/themeOptions";
 import { hideAdOverlay, isAdPlaying, isLoaderActive, showAdOverlay } from "@modules/ui/dom";
 import { log } from "@utils";
+import { collectActiveLineCandidates, mergeSortedUniqueIndices } from "./activeLineIndex";
 import { ctx, resetDebugRender } from "./animationEngineDebug";
 
 const LYRIC_ENDING_THRESHOLD_S = registerThemeSetting("blyrics-lyric-ending-threshold-s", 0.5);
@@ -28,6 +29,9 @@ const ENABLE_DEBUG_RENDER = registerThemeSetting("blyrics-debug-renderer", false
 let cachedTabRendererHeight: number | null = null;
 let tabRendererResizeObserver: ResizeObserver | null = null;
 let observedTabRenderer: HTMLElement | null = null;
+let currentCandidateIndices: number[] = [];
+let previousCandidateIndices: number[] = [];
+const processedLineIndices: number[] = [];
 
 // 0.5 means the selected lyric will be in the middle of the screen, 0 means top, 1 means bottom
 export const SCROLL_POS_OFFSET_RATIO = registerThemeSetting("blyrics-target-scroll-pos-ratio", 0.37);
@@ -114,6 +118,9 @@ export function resetAnimEngineState(): void {
   animEngineState.passiveLastWallTime = 0;
   stopPassiveScrollLoop();
   cachedDurations.clear();
+  currentCandidateIndices.length = 0;
+  previousCandidateIndices.length = 0;
+  processedLineIndices.length = 0;
 }
 
 export let cachedDurations: Map<string, number> = new Map();
@@ -390,8 +397,17 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
     let activeElems = [] as LineData[];
     const linesToAnimate: LineData[] = [];
     let newLyricSelected = timeJumped;
+    const setUpAnimationEarlyTime = isPlaying ? 2 : 0;
+    collectActiveLineCandidates(
+      lines,
+      Math.min(currentTime, lyricScrollTime),
+      Math.max(currentTime + setUpAnimationEarlyTime, lyricScrollTime + EARLY_SCROLL_CONSIDER.getNumberValue()),
+      currentCandidateIndices
+    );
+    mergeSortedUniqueIndices(previousCandidateIndices, currentCandidateIndices, processedLineIndices);
 
-    lines.every((lineData, index) => {
+    for (const index of processedLineIndices) {
+      const lineData = lines[index];
       const time = lineData.time;
       let nextTime = Infinity;
       if (index + 1 < lines.length) {
@@ -427,12 +443,6 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
       /**
        * Time in seconds to set up animations. This shouldn't affect any visible effects, just help when the browser stutters
        */
-      let setUpAnimationEarlyTime: number = 2;
-
-      if (!isPlaying) {
-        setUpAnimationEarlyTime = 0;
-      }
-
       const effectiveEndTime = Math.max(nextTime, time + lineData.duration + 0.05);
       if (currentTime + setUpAnimationEarlyTime >= time && currentTime < effectiveEndTime) {
         lineData.isSelected = true;
@@ -489,8 +499,11 @@ export function animationEngine(currentTime: number, eventCreationTime: number, 
           lineData.isAnimating = false;
         }
       }
-      return true;
-    });
+    }
+
+    const candidateSwap = previousCandidateIndices;
+    previousCandidateIndices = currentCandidateIndices;
+    currentCandidateIndices = candidateSwap;
 
     // Batched animation to avoid multiple reflows and bring reflows from O(n) to O(1)
     if (linesToAnimate.length > 0) {


### PR DESCRIPTION
Reduces per-tick work in the lyrics animation engine by replacing the full scan of every lyric line with an indexed candidate lookup.

The new active-line index:

* Uses binary search to exclude lines that start after the current processing window.
* Uses a segment tree containing the maximum effective end time for each range.
* Prunes ranges that cannot contain an active or animation-relevant line.
* Returns candidate indices in ascending order without sorting.
* Caches the index with a `WeakMap` keyed by the lyric-line array.
* Supports explicit invalidation when lyric timing is modified.

The animation engine processes candidates from both the current and previous tick. Including the previous candidates ensures that lines leaving the active window are processed once more so stale classes and animation state are cleared correctly.

The index is invalidated after `applySegmentMapToLyrics()` changes line timing.

Deterministic self-checks compare indexed results against the previous full-scan condition across sequential, overlapping, long-duration, zero-duration, boundary, randomized, and timing-mutation cases. A pathological 1,200-line case also verifies that one long overlapping line does not cause the query to examine every lyric line.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue (if applicable)

N/A

## Screenshots (if applicable)

N/A — this change does not modify the UI or visual behavior.

## Checklist

* [x] I have performed a self-review of my code
* [x] Will this be part of a product update? If yes, please write one phrase about this update.

Reduce lyrics animation overhead by processing only timing-relevant lyric lines on each tick.