### PR TITLE
fix(edge): omit notes on store submit to avoid 400

### DIFF
--- a/tooling/publish-edge.ts
+++ b/tooling/publish-edge.ts
@@ -52,12 +52,15 @@ async function main() {
       return;
     }
 
-    const submissionId = await client.publish("Automated submission via API");
+    // Notes must stay empty: @plasmohq/edge-addons-api@2.0.0 serializes non-empty notes as a
+    // malformed body (`{ "notes"="..." }`), which the Edge API rejects with a 400.
+    const submissionId = await client.publish();
     console.log(`Submission ID: ${submissionId}`);
     await pollPublish(submissionId);
     console.log("Process completed successfully.");
   } catch (error) {
-    console.error("Failed to publish to Edge Add-ons:", error);
+    const responseBody = (error as { response?: { body?: unknown } }).response?.body;
+    console.error("Failed to publish to Edge Add-ons:", responseBody ?? error);
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Overview

The automated Edge submit was failing with a 400 on every release. Turns out @plasmohq/edge-addons-api mangles a non-empty submission note into a body the Edge API can't parse, so the package uploaded fine but the submit-for-review call bounced. Dropped the note so the submit goes through, and the catch now prints the API's actual response body instead of an opaque error blob.
