### PR TITLE
fix: resolve highlight glow color per word instead of at the container

### DIFF
--- a/STYLING-SKILL.md
+++ b/STYLING-SKILL.md
@@ -59,8 +59,8 @@ Essential reference for creating custom themes. For deep dives, see [STYLING.md]
   --blyrics-highlight-swipe-end-from: -0.1;
   --blyrics-highlight-swipe-start-to: 1.4;
   --blyrics-highlight-swipe-end-to: 1.5;
-  --blyrics-highlight-glow-filter-from: drop-shadow(0 0 0.8rem var(--blyrics-glow-color));
-  --blyrics-highlight-glow-filter-to: drop-shadow(0 0 0 var(--blyrics-glow-color));
+  --blyrics-highlight-glow-radius-from: 0.8rem;
+  --blyrics-highlight-glow-radius-to: 0;
   --blyrics-highlight-glow-duration-ratio: 1.2;
   --blyrics-highlight-glow-min-duration: 1.2s;
   --blyrics-highlight-glow-easing: ease;
@@ -590,6 +590,8 @@ Target sustained notes for special effects:
   --blyrics-glow-color: color(display-p3 1 0.8 0.3 / 1);
 }
 ```
+
+`--blyrics-glow-color` resolves per word, so different long words can glow different colors. Tune the blur with `--blyrics-highlight-glow-radius-from` / `--blyrics-highlight-glow-radius-to` while keeping per-word color. Overriding the full `--blyrics-highlight-glow-filter-from` / `--blyrics-highlight-glow-filter-to` instead resolves the color once at the container, so every word shares one glow color.
 
 ### 15. Pause Behavior
 

--- a/STYLING.md
+++ b/STYLING.md
@@ -182,8 +182,10 @@ JavaScript controls animation timing with the Web Animations API, but the visual
 | `--blyrics-highlight-swipe-end-from`          | `-0.1`                            | Swipe gradient end value before animation                                                    |
 | `--blyrics-highlight-swipe-start-to`          | `1.4`                             | Swipe gradient start value after animation                                                   |
 | `--blyrics-highlight-swipe-end-to`            | `1.5`                             | Swipe gradient end value after animation                                                     |
-| `--blyrics-highlight-glow-filter-from`     | `drop-shadow(0 0 0.8rem var(--blyrics-glow-color))` | Glow start filter                                                   |
-| `--blyrics-highlight-glow-filter-to`       | `drop-shadow(0 0 0 var(--blyrics-glow-color))` | Glow end filter                                                        |
+| `--blyrics-highlight-glow-radius-from`     | `0.8rem`                          | Glow blur radius at the start of the pulse; color stays `var(--blyrics-glow-color)` and resolves per word |
+| `--blyrics-highlight-glow-radius-to`       | `0`                               | Glow blur radius at the end of the pulse                                                     |
+| `--blyrics-highlight-glow-filter-from`     | (unset)                           | Optional full override of the glow start filter; when set, its color resolves once at the container (one color for all words) |
+| `--blyrics-highlight-glow-filter-to`       | (unset)                           | Optional full override of the glow end filter                                               |
 | `--blyrics-highlight-glow-duration-ratio`     | `1.2`                             | Glow duration multiplier relative to word duration                                           |
 | `--blyrics-highlight-glow-min-duration`       | `1.2s`                            | Minimum glow duration                                                                        |
 | `--blyrics-highlight-glow-easing`             | `ease`                            | Glow easing                                                                                  |

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/boidu/Developer/better-lyrics/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/boidu/Developer/better-lyrics/node_modules

--- a/public/css/blyrics/variables.css
+++ b/public/css/blyrics/variables.css
@@ -99,12 +99,8 @@
 	--blyrics-highlight-swipe-end-from: -0.1;
 	--blyrics-highlight-swipe-start-to: 1.4;
 	--blyrics-highlight-swipe-end-to: 1.5;
-	--blyrics-highlight-glow-filter-from: drop-shadow(
-		0 0 0.8rem var(--blyrics-glow-color)
-	);
-	--blyrics-highlight-glow-filter-to: drop-shadow(
-		0 0 0 var(--blyrics-glow-color)
-	);
+	--blyrics-highlight-glow-radius-from: 0.8rem;
+	--blyrics-highlight-glow-radius-to: 0;
 	--blyrics-highlight-glow-duration-ratio: 1.2;
 	--blyrics-highlight-glow-min-duration: 1.2s;
 	--blyrics-highlight-glow-easing: ease;

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -1175,6 +1175,20 @@ function getCSSOffset(lyricsElement: HTMLElement, property: string, fallback: nu
   return Math.max(0, Math.min(1, getCSSNumber(lyricsElement, property, fallback)));
 }
 
+// Compose the glow filter so the color stays an unresolved var(--blyrics-glow-color).
+// Reading a fully composed --blyrics-highlight-glow-filter-* off the container resolves the
+// nested color there, which would defeat per-word overrides like
+// .blyrics--word[data-long-word] { --blyrics-glow-color: ... }. Building the filter here with
+// the color left as a literal var lets the Web Animations API resolve it against each animated
+// word instead. A theme that sets the full filter var still wins, but its color resolves once
+// at the container (globally), as before.
+function resolveGlowFilter(lyricsElement: HTMLElement, suffix: "from" | "to", radiusDefault: string): string {
+  const override = getCSSValue(lyricsElement, `--blyrics-highlight-glow-filter-${suffix}`, "");
+  if (override) return override;
+  const radius = getCSSValue(lyricsElement, `--blyrics-highlight-glow-radius-${suffix}`, radiusDefault);
+  return `drop-shadow(0 0 ${radius} var(--blyrics-glow-color))`;
+}
+
 function readAnimationConfig(lyricsElement: HTMLElement): AnimationConfig {
   const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const scrollDurationMs = getCSSDurationWithFallback(lyricsElement, "--blyrics-lyric-scroll-duration", "650ms");
@@ -1221,16 +1235,8 @@ function readAnimationConfig(lyricsElement: HTMLElement): AnimationConfig {
       swipeEndFrom: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-end-from", "-0.1"),
       swipeStartTo: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-start-to", "1.4"),
       swipeEndTo: getCSSValue(lyricsElement, "--blyrics-highlight-swipe-end-to", "1.5"),
-      glowFrom: getCSSValue(
-        lyricsElement,
-        "--blyrics-highlight-glow-filter-from",
-        "drop-shadow(0 0 0.8rem var(--blyrics-glow-color))"
-      ),
-      glowTo: getCSSValue(
-        lyricsElement,
-        "--blyrics-highlight-glow-filter-to",
-        "drop-shadow(0 0 0 var(--blyrics-glow-color))"
-      ),
+      glowFrom: resolveGlowFilter(lyricsElement, "from", "0.8rem"),
+      glowTo: resolveGlowFilter(lyricsElement, "to", "0"),
       glowDurationRatio: getCSSNumber(lyricsElement, "--blyrics-highlight-glow-duration-ratio", 1.2),
       glowMinDurationMs: getCSSDurationWithFallback(lyricsElement, "--blyrics-highlight-glow-min-duration", "1.2s"),
       glowEasing: getCSSValue(lyricsElement, "--blyrics-highlight-glow-easing", "ease"),


### PR DESCRIPTION
The engine read the highlight glow filter off the lyrics container, which resolved `var(--blyrics-glow-color)` there and baked one color in, so every word glowed the same color and per-word overrides like `.blyrics--word[data-long-word] { --blyrics-glow-color: ... }` had no effect. Now it builds the filter with the color left as a literal var, so each word resolves its own through the Web Animations API. Blur radius moved to `--blyrics-highlight-glow-radius-from` / `--blyrics-highlight-glow-radius-to`, and setting the full `--blyrics-highlight-glow-filter-*` still works as a global override.
