### PR TITLE
fix: adjust fullscreen side panel offset for videos

### DIFF
--- a/public/css/ytmusic/mobile.css
+++ b/public/css/ytmusic/mobile.css
@@ -4,10 +4,16 @@
     max-width: unset;
   }
 
-  ytmusic-player-page:not([is-mweb-modernization-enabled])[player-fullscreened]:not([blyrics-dfs]) 
+  ytmusic-player-page:not([is-mweb-modernization-enabled])[player-fullscreened]:not([blyrics-dfs]):not([blyrics-video-mode])
   #side-panel {
     height: 100vh;
-    transform: translateY(calc(0px - var(--ytmusic-nav-bar-height) - var(--ytmusic-player-page-vertical-padding))) 
+    transform: translateY(calc(0px - var(--ytmusic-nav-bar-height) - var(--ytmusic-player-page-vertical-padding)));
+  }
+
+  ytmusic-player-page:not([is-mweb-modernization-enabled])[player-fullscreened]:not([blyrics-dfs])[blyrics-video-mode]
+  #side-panel {
+    height: 100vh;
+    transform: translateY(calc(0px - var(--ytmusic-player-page-vertical-padding)));
   }
 
 


### PR DESCRIPTION
# Description

Uses separate fullscreen side-panel offsets for song and video modes. YouTube Music removes the navbar during fullscreen video playback, so video mode now subtracts only the player-page vertical padding while song mode retains the navbar offset.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue

Fixes #740

## Testing

- [x] `npm run build` (Chrome, Edge, and Firefox)
- [x] `git diff --check`

## Checklist

- [x] I have performed a self-review of my code
- [x] Product update: Correct fullscreen lyrics panel positioning during video playback.