### PR TITLE
fix(pip): album art, paused word highlights, stale mirrored animations, and a searching state

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -98,10 +98,6 @@
     "message": "Open Picture-in-Picture lyrics",
     "description": "Accessible label for the dock action that opens the floating lyrics window"
   },
-  "picture_in_picture_loading": {
-    "message": "Loading lyrics…",
-    "description": "Status displayed while the Picture-in-Picture lyrics window initializes"
-  },
   "picture_in_picture_previous": {
     "message": "Previous",
     "description": "Accessible label for the previous track button in the Picture-in-Picture lyrics window, used when the YouTube Music player bar exposes no label of its own"

--- a/public/css/blyrics/picture-in-picture.css
+++ b/public/css/blyrics/picture-in-picture.css
@@ -177,7 +177,6 @@ body {
 }
 
 .blyrics-pip-content {
-  position: relative;
   display: flex;
   min-width: 0;
   flex: 1;
@@ -287,15 +286,12 @@ body {
   height: 1em;
 }
 
-/* Spans the whole content column, header included, so it lines up with the artwork's centre. */
 .blyrics-pip-loader {
-  position: absolute;
   display: flex;
-  inset: 0;
+  min-height: 100%;
   align-items: center;
   justify-content: center;
   gap: clamp(8px, 2.5vw, 12px);
-  pointer-events: none;
 }
 
 .blyrics-pip-loader__mark {
@@ -332,16 +328,5 @@ body {
 
   .blyrics-pip-header {
     padding-bottom: 4px;
-  }
-
-  /* Too short to centre on the artwork without landing on the byline, so it sits under the
-     header instead and takes the space the empty viewport would have held. */
-  .blyrics-pip-loader {
-    position: static;
-    flex: 1;
-  }
-
-  .blyrics-pip-content:has(.blyrics-pip-loader) .blyrics-pip-lyrics {
-    display: none;
   }
 }

--- a/public/css/blyrics/picture-in-picture.css
+++ b/public/css/blyrics/picture-in-picture.css
@@ -177,6 +177,7 @@ body {
 }
 
 .blyrics-pip-content {
+  position: relative;
   display: flex;
   min-width: 0;
   flex: 1;
@@ -286,17 +287,21 @@ body {
   height: 1em;
 }
 
+/* Spans the whole content column, header included, so it lines up with the artwork's centre. */
 .blyrics-pip-loader {
+  position: absolute;
   display: flex;
-  min-height: 100%;
+  inset: 0;
   align-items: center;
+  justify-content: center;
   gap: clamp(8px, 2.5vw, 12px);
+  pointer-events: none;
 }
 
 .blyrics-pip-loader__mark {
   flex: 0 0 auto;
-  width: clamp(22px, 7vw, 30px);
-  height: clamp(22px, 7vw, 30px);
+  width: clamp(14px, 4.5vw, 19px);
+  height: clamp(14px, 4.5vw, 19px);
   background: url("https://betterlyrics.org/icon-512.png") 50% / cover;
   animation: blyrics-spin 1.5s linear infinite;
 }
@@ -307,7 +312,7 @@ body {
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
-  font-size: clamp(12px, 3.5vw, 16px);
+  font-size: clamp(10px, 2.4vw, 12px);
   font-weight: 700;
   line-height: 1.4;
   animation: blyrics-shimmer 3s linear infinite;
@@ -327,5 +332,16 @@ body {
 
   .blyrics-pip-header {
     padding-bottom: 4px;
+  }
+
+  /* Too short to centre on the artwork without landing on the byline, so it sits under the
+     header instead and takes the space the empty viewport would have held. */
+  .blyrics-pip-loader {
+    position: static;
+    flex: 1;
+  }
+
+  .blyrics-pip-content:has(.blyrics-pip-loader) .blyrics-pip-lyrics {
+    display: none;
   }
 }

--- a/public/css/blyrics/picture-in-picture.css
+++ b/public/css/blyrics/picture-in-picture.css
@@ -286,14 +286,31 @@ body {
   height: 1em;
 }
 
-.blyrics-pip-lyrics__status {
-  display: grid;
+.blyrics-pip-loader {
+  display: flex;
   min-height: 100%;
+  align-items: center;
+  gap: clamp(8px, 2.5vw, 12px);
+}
+
+.blyrics-pip-loader__mark {
+  flex: 0 0 auto;
+  width: clamp(22px, 7vw, 30px);
+  height: clamp(22px, 7vw, 30px);
+  background: url("https://betterlyrics.org/icon-512.png") 50% / cover;
+  animation: blyrics-spin 1.5s linear infinite;
+}
+
+.blyrics-pip-loader__label {
   margin: 0;
-  place-items: center start;
-  color: rgb(255 255 255 / 56%);
+  background: var(--blyrics-shimmer-gradient) 0 0 / 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
   font-size: clamp(12px, 3.5vw, 16px);
+  font-weight: 700;
   line-height: 1.4;
+  animation: blyrics-shimmer 3s linear infinite;
 }
 
 @media (max-height: 130px) {

--- a/src/modules/lyrics/requestSniffer/requestSniffer.ts
+++ b/src/modules/lyrics/requestSniffer/requestSniffer.ts
@@ -221,6 +221,27 @@ export function getSongMetadata(
 }
 
 /**
+ * Resolves the metadata whose thumbnail is the square album art. A music video's own thumbnail is a
+ * 16:9 frame, so its audio counterpart is preferred whenever the queue exposes one.
+ *
+ * @param videoId
+ * @param maxCheckCount
+ * @param signal - AbortSignal to cancel polling
+ * @return
+ */
+export async function getArtworkMetadata(
+  videoId: string,
+  maxCheckCount = 250,
+  signal?: AbortSignal
+): Promise<VideoMetadata | null> {
+  const metadata = await getSongMetadata(videoId, maxCheckCount, signal);
+  if (metadata?.isVideo && metadata.counterpartVideoId) {
+    return getSongMetadata(metadata.counterpartVideoId, 10, signal);
+  }
+  return metadata;
+}
+
+/**
  * @param videoId
  * @param signal - AbortSignal to cancel polling
  * @return

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -35,7 +35,7 @@ import { AppState } from "@core/appState";
 import { t } from "@core/i18n";
 import { disconnectResizeObserver, WORD_HIGHLIGHT_CLASS } from "@modules/lyrics/injectLyrics";
 import type { ThumbnailElement } from "@modules/lyrics/requestSniffer/NextResponse";
-import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
+import { getArtworkMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
 import {
   animEngineState,
   getResumeScrollElement,
@@ -121,7 +121,7 @@ function thumbnailUrlFor(videoId: string): string {
 }
 
 async function resolveArtworkUrl(videoId: string): Promise<string> {
-  const sniffed = await getSongMetadata(videoId);
+  const sniffed = await getArtworkMetadata(videoId);
   if (sniffed?.thumbnail?.url) return getHighResImageUrl(sniffed.thumbnail);
 
   const ytImg = document.querySelector<HTMLImageElement>("#thumbnail>#img");

--- a/src/modules/ui/nativeLyricsFocus.ts
+++ b/src/modules/ui/nativeLyricsFocus.ts
@@ -1,3 +1,4 @@
+import { LOG_PREFIX } from "@constants";
 import { log } from "@utils";
 
 const NATIVE_LYRICS_SHELF_SELECTOR = "#tab-renderer ytmusic-description-shelf-renderer";
@@ -46,11 +47,12 @@ function shouldHandleMutation(mutation: MutationRecord): boolean {
 }
 
 function handleMutations(mutations: MutationRecord[]): void {
-  log("Native lyrics focus observer fired", { mutationCount: mutations.length });
-
-  if (mutations.some(shouldHandleMutation)) {
-    scheduleApply();
+  if (!mutations.some(shouldHandleMutation)) {
+    return;
   }
+
+  log(LOG_PREFIX, "Native lyrics focus observer fired", { mutationCount: mutations.length });
+  scheduleApply();
 }
 
 export function disableNativeLyricsFocus(): void {

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -422,7 +422,10 @@ export function initializeLyrics(): void {
       }
     }
 
-    if (document.visibilityState === "visible") {
+    // A window owning a Picture-in-Picture document still reports "hidden", and this is the only
+    // path that ticks the engine while playback is paused, so pausing would never reach the
+    // running word animations.
+    if (document.visibilityState === "visible" || AppState.isPictureInPictureOpen) {
       runAnimationEngine(performance.now(), true);
     }
   });

--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -15,7 +15,7 @@ import {
 } from "@constants";
 import { AppState, handleModifications, type PlayerDetails, reloadLyrics } from "@core/appState";
 import { preFetchLyrics } from "@modules/lyrics/lyrics";
-import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
+import { getArtworkMetadata, getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
 import { onAutoSwitchEnabled, onFullScreenDisabled, wakeDockIdle } from "@modules/settings/settings";
 import {
   animationEngine,
@@ -354,13 +354,8 @@ export function initializeLyrics(): void {
       metadataAbortController = abortController;
 
       const videoIdAtStart = detail.videoId;
-      getSongMetadata(detail.videoId, 250, abortController.signal).then(async songMetadata => {
+      getArtworkMetadata(detail.videoId, 250, abortController.signal).then(songMetadata => {
         if (AppState.lastVideoId !== videoIdAtStart) return;
-
-        if (songMetadata?.isVideo && songMetadata.counterpartVideoId) {
-          songMetadata = await getSongMetadata(songMetadata.counterpartVideoId, 10, abortController.signal);
-          if (AppState.lastVideoId !== videoIdAtStart) return;
-        }
 
         if (songMetadata) {
           addThumbnail(songMetadata.smallThumbnail);

--- a/src/modules/ui/pictureInPicture/browserController.ts
+++ b/src/modules/ui/pictureInPicture/browserController.ts
@@ -155,7 +155,13 @@ function syncTwin(): void {
   const view = activeView;
   if (!view) return;
   const mainRoot = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement | undefined;
-  if (!mainRoot) return;
+  if (!mainRoot) {
+    // The page drops its lyrics container while fetching, so this covers the first open and every
+    // song switch after it; without it the window keeps mirroring the previous song.
+    view.showSearching();
+    lastMirroredRoot = null;
+    return;
+  }
   if (mainRoot !== lastMirroredRoot || needsRebuild() || !view.hasTwinMounted()) {
     const twin = buildTwin(mainRoot, view.pipDocument);
     view.mountLyrics(twin);

--- a/src/modules/ui/pictureInPicture/lyricsView.ts
+++ b/src/modules/ui/pictureInPicture/lyricsView.ts
@@ -98,10 +98,8 @@ export class PictureInPictureLyricsView {
   private readonly playPauseButton: HTMLButtonElement;
   private readonly title: HTMLElement;
   private readonly byline: HTMLElement;
-  private readonly content: HTMLElement;
   private readonly lyricsViewport: HTMLElement;
   private readonly lyricsScroller: HTMLElement;
-  private loader: HTMLElement | null = null;
   private readonly lifecycleController = new AbortController();
   private artworkController: AbortController | null = null;
   private currentVideoId: string | null = null;
@@ -159,8 +157,8 @@ export class PictureInPictureLyricsView {
     artworkControls.append(previousButton, this.playPauseButton, nextButton);
     this.artworkContainer.append(artworkPlaceholder, this.artwork, this.artworkVideo, artworkControls);
 
-    this.content = pipDocument.createElement("section");
-    this.content.className = "blyrics-pip-content";
+    const content = pipDocument.createElement("section");
+    content.className = "blyrics-pip-content";
 
     const header = pipDocument.createElement("header");
     header.className = "blyrics-pip-header";
@@ -182,9 +180,10 @@ export class PictureInPictureLyricsView {
       signal: this.lifecycleController.signal,
     });
 
-    this.content.append(header, this.lyricsViewport);
     this.showSearching();
-    this.shell.append(this.artworkContainer, this.content);
+
+    content.append(header, this.lyricsViewport);
+    this.shell.append(this.artworkContainer, content);
     pipDocument.body.replaceChildren(this.shell);
 
     sourceDocument.addEventListener(PLAYER_TIME_EVENT, this.handlePlayerTime, {
@@ -203,22 +202,19 @@ export class PictureInPictureLyricsView {
 
   mountLyrics(twinRoot: HTMLElement): void {
     this.isSearching = false;
-    this.loader?.remove();
-    this.loader = null;
     this.lyricsScroller.replaceChildren(twinRoot);
     this.lyricsViewport.replaceChildren(this.lyricsScroller);
     this.shell.setAttribute("aria-busy", "false");
   }
 
-  // Called from the sync loop, so it has to no-op once the loader is already up. It hangs off the
-  // content column rather than the lyrics viewport so it centres on the artwork, not below it.
+  // Called from the sync loop, so it has to no-op once the loader is already up.
   showSearching(): void {
     if (this.isSearching) return;
     this.isSearching = true;
 
     const pipDocument = this.pipWindow.document;
-    this.loader = pipDocument.createElement("div");
-    this.loader.className = "blyrics-pip-loader";
+    const loader = pipDocument.createElement("div");
+    loader.className = "blyrics-pip-loader";
 
     const mark = pipDocument.createElement("span");
     mark.className = "blyrics-pip-loader__mark";
@@ -229,9 +225,8 @@ export class PictureInPictureLyricsView {
     label.setAttribute("role", "status");
     label.textContent = t("lyrics_searching");
 
-    this.loader.append(mark, label);
-    this.lyricsViewport.replaceChildren();
-    this.content.appendChild(this.loader);
+    loader.append(mark, label);
+    this.lyricsViewport.replaceChildren(loader);
     this.shell.setAttribute("aria-busy", "true");
   }
 

--- a/src/modules/ui/pictureInPicture/lyricsView.ts
+++ b/src/modules/ui/pictureInPicture/lyricsView.ts
@@ -98,8 +98,10 @@ export class PictureInPictureLyricsView {
   private readonly playPauseButton: HTMLButtonElement;
   private readonly title: HTMLElement;
   private readonly byline: HTMLElement;
+  private readonly content: HTMLElement;
   private readonly lyricsViewport: HTMLElement;
   private readonly lyricsScroller: HTMLElement;
+  private loader: HTMLElement | null = null;
   private readonly lifecycleController = new AbortController();
   private artworkController: AbortController | null = null;
   private currentVideoId: string | null = null;
@@ -157,8 +159,8 @@ export class PictureInPictureLyricsView {
     artworkControls.append(previousButton, this.playPauseButton, nextButton);
     this.artworkContainer.append(artworkPlaceholder, this.artwork, this.artworkVideo, artworkControls);
 
-    const content = pipDocument.createElement("section");
-    content.className = "blyrics-pip-content";
+    this.content = pipDocument.createElement("section");
+    this.content.className = "blyrics-pip-content";
 
     const header = pipDocument.createElement("header");
     header.className = "blyrics-pip-header";
@@ -180,10 +182,9 @@ export class PictureInPictureLyricsView {
       signal: this.lifecycleController.signal,
     });
 
+    this.content.append(header, this.lyricsViewport);
     this.showSearching();
-
-    content.append(header, this.lyricsViewport);
-    this.shell.append(this.artworkContainer, content);
+    this.shell.append(this.artworkContainer, this.content);
     pipDocument.body.replaceChildren(this.shell);
 
     sourceDocument.addEventListener(PLAYER_TIME_EVENT, this.handlePlayerTime, {
@@ -202,19 +203,22 @@ export class PictureInPictureLyricsView {
 
   mountLyrics(twinRoot: HTMLElement): void {
     this.isSearching = false;
+    this.loader?.remove();
+    this.loader = null;
     this.lyricsScroller.replaceChildren(twinRoot);
     this.lyricsViewport.replaceChildren(this.lyricsScroller);
     this.shell.setAttribute("aria-busy", "false");
   }
 
-  // Called from the sync loop, so it has to no-op once the loader is already up.
+  // Called from the sync loop, so it has to no-op once the loader is already up. It hangs off the
+  // content column rather than the lyrics viewport so it centres on the artwork, not below it.
   showSearching(): void {
     if (this.isSearching) return;
     this.isSearching = true;
 
     const pipDocument = this.pipWindow.document;
-    const loader = pipDocument.createElement("div");
-    loader.className = "blyrics-pip-loader";
+    this.loader = pipDocument.createElement("div");
+    this.loader.className = "blyrics-pip-loader";
 
     const mark = pipDocument.createElement("span");
     mark.className = "blyrics-pip-loader__mark";
@@ -225,8 +229,9 @@ export class PictureInPictureLyricsView {
     label.setAttribute("role", "status");
     label.textContent = t("lyrics_searching");
 
-    loader.append(mark, label);
-    this.lyricsViewport.replaceChildren(loader);
+    this.loader.append(mark, label);
+    this.lyricsViewport.replaceChildren();
+    this.content.appendChild(this.loader);
     this.shell.setAttribute("aria-busy", "true");
   }
 

--- a/src/modules/ui/pictureInPicture/lyricsView.ts
+++ b/src/modules/ui/pictureInPicture/lyricsView.ts
@@ -385,6 +385,10 @@ export class PictureInPictureLyricsView {
     const controller = new AbortController();
     this.artworkController = controller;
     this.fallbackArtworkUrl = getFallbackArtworkUrl(videoId);
+    // The metadata poll runs for seconds, so the previous song's art has to go now rather than when
+    // its replacement arrives. Leaving src alone keeps the onerror fallback from firing.
+    this.artwork.removeAttribute("data-loaded");
+    this.shell.style.removeProperty("--blyrics-pip-art");
 
     void getArtworkMetadata(videoId, 250, controller.signal).then(metadata => {
       if (controller.signal.aborted || this.currentVideoId !== videoId) return;

--- a/src/modules/ui/pictureInPicture/lyricsView.ts
+++ b/src/modules/ui/pictureInPicture/lyricsView.ts
@@ -2,7 +2,7 @@ import { CURRENT_LYRICS_CLASS, LINE_CLASS, LYRICS_CLASS, PLAYER_BAR_SELECTOR, SE
 import type { PlayerDetails } from "@core/appState";
 import { t } from "@core/i18n";
 import { getSeekTimeFromClick } from "@modules/lyrics/injectLyrics";
-import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
+import { getArtworkMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
 import { animEngineState } from "@modules/ui/animationEngine";
 import { MIRROR_ID_ATTR } from "./pipMirror";
 
@@ -108,6 +108,7 @@ export class PictureInPictureLyricsView {
   private controlsIdleTimer: number | null = null;
   private lastPointerMoveTime = 0;
   private fallbackArtworkUrl = "";
+  private isSearching = false;
 
   constructor(
     private readonly pipWindow: Window,
@@ -179,7 +180,7 @@ export class PictureInPictureLyricsView {
       signal: this.lifecycleController.signal,
     });
 
-    this.renderStatus(t("picture_in_picture_loading"));
+    this.showSearching();
 
     content.append(header, this.lyricsViewport);
     this.shell.append(this.artworkContainer, content);
@@ -200,9 +201,33 @@ export class PictureInPictureLyricsView {
   }
 
   mountLyrics(twinRoot: HTMLElement): void {
+    this.isSearching = false;
     this.lyricsScroller.replaceChildren(twinRoot);
     this.lyricsViewport.replaceChildren(this.lyricsScroller);
     this.shell.setAttribute("aria-busy", "false");
+  }
+
+  // Called from the sync loop, so it has to no-op once the loader is already up.
+  showSearching(): void {
+    if (this.isSearching) return;
+    this.isSearching = true;
+
+    const pipDocument = this.pipWindow.document;
+    const loader = pipDocument.createElement("div");
+    loader.className = "blyrics-pip-loader";
+
+    const mark = pipDocument.createElement("span");
+    mark.className = "blyrics-pip-loader__mark";
+    mark.setAttribute("aria-hidden", "true");
+
+    const label = pipDocument.createElement("p");
+    label.className = "blyrics-pip-loader__label";
+    label.setAttribute("role", "status");
+    label.textContent = t("lyrics_searching");
+
+    loader.append(mark, label);
+    this.lyricsViewport.replaceChildren(loader);
+    this.shell.setAttribute("aria-busy", "true");
   }
 
   hasTwinMounted(): boolean {
@@ -360,14 +385,14 @@ export class PictureInPictureLyricsView {
     const controller = new AbortController();
     this.artworkController = controller;
     this.fallbackArtworkUrl = getFallbackArtworkUrl(videoId);
-    this.setArtwork(this.fallbackArtworkUrl);
 
-    void getSongMetadata(videoId, 250, controller.signal).then(metadata => {
-      if (controller.signal.aborted || this.currentVideoId !== videoId || !metadata) return;
-      if (metadata.displayTitle) this.title.textContent = metadata.displayTitle;
-      const displayByline = metadata.displayByline || metadata.artist;
+    void getArtworkMetadata(videoId, 250, controller.signal).then(metadata => {
+      if (controller.signal.aborted || this.currentVideoId !== videoId) return;
+      if (metadata?.displayTitle) this.title.textContent = metadata.displayTitle;
+      const displayByline = metadata?.displayByline || metadata?.artist;
       if (displayByline) this.byline.textContent = displayByline;
-      if (metadata.thumbnail?.url) this.setArtwork(getArtworkUrl(metadata.thumbnail.url));
+      // The fallback is a 16:9 video frame, so it only lands when the queue yielded no art at all.
+      this.setArtwork(metadata?.thumbnail?.url ? getArtworkUrl(metadata.thumbnail.url) : this.fallbackArtworkUrl);
     });
   }
 
@@ -381,13 +406,5 @@ export class PictureInPictureLyricsView {
       }
     };
     this.artwork.src = url;
-  }
-
-  private renderStatus(message: string): void {
-    const status = this.pipWindow.document.createElement("p");
-    status.className = "blyrics-pip-lyrics__status";
-    status.setAttribute("role", "status");
-    status.textContent = message;
-    this.lyricsViewport.replaceChildren(status);
   }
 }

--- a/src/modules/ui/pictureInPicture/pipMirror.ts
+++ b/src/modules/ui/pictureInPicture/pipMirror.ts
@@ -94,6 +94,13 @@ export function buildTwin(mainRoot: HTMLElement, pipDoc: Document): HTMLElement 
   return twin;
 }
 
+function copyPlaybackState(source: Animation, twin: Animation): void {
+  if (source.currentTime !== null) twin.currentTime = source.currentTime;
+  twin.playbackRate = source.playbackRate;
+  if (source.playState === "paused") twin.pause();
+  else if (source.playState === "running" && twin.playState !== "running") twin.play();
+}
+
 export function sync(mainRoot: HTMLElement): void {
   if (!twinRoot) return;
   const live = mainRoot.getAnimations({ subtree: true });
@@ -126,10 +133,7 @@ export function sync(mainRoot: HTMLElement): void {
       sourceToTwin.set(source, twin);
     }
     nextKnown.add(source);
-    if (source.currentTime !== null) twin.currentTime = source.currentTime;
-    twin.playbackRate = source.playbackRate;
-    if (source.playState === "paused") twin.pause();
-    else if (source.playState === "running" && twin.playState !== "running") twin.play();
+    copyPlaybackState(source, twin);
   }
 
   for (const source of knownSources) {
@@ -140,9 +144,13 @@ export function sync(mainRoot: HTMLElement): void {
     if (source.playState === "idle") {
       sourceToTwin.get(source)?.cancel();
       sourceToTwin.delete(source);
-    } else {
-      nextKnown.add(source);
+      continue;
     }
+    // A minimised window unrenders every target at once, so without this the retained twins freeze
+    // at whatever value they held and the lines they belong to stop matching the page.
+    const twin = sourceToTwin.get(source);
+    if (twin) copyPlaybackState(source, twin);
+    nextKnown.add(source);
   }
   knownSources = nextKnown;
 }

--- a/src/modules/ui/pictureInPicture/pipMirror.ts
+++ b/src/modules/ui/pictureInPicture/pipMirror.ts
@@ -139,9 +139,11 @@ export function sync(mainRoot: HTMLElement): void {
   for (const source of knownSources) {
     if (nextKnown.has(source)) continue;
     // Dropping out of getAnimations() does not mean the source ended: an unrendered target takes
-    // its animation off the list while it is still running. Retire the twin only once the source
-    // is genuinely gone, so a stall can never blank the window.
-    if (source.playState === "idle") {
+    // its animation off the list while it is still running. Only a source that is cancelled or
+    // finished is genuinely gone, so a stall can never blank the window. Retiring the finished
+    // ones matters because several engine animations fill forwards, and a surviving twin of one
+    // outranks the theme's own declarations and pins its line visible.
+    if (source.playState === "idle" || source.playState === "finished") {
       sourceToTwin.get(source)?.cancel();
       sourceToTwin.delete(source);
       continue;


### PR DESCRIPTION
## Overview

Artwork in the floating window fell back to YouTube's 16:9 video thumbnail whenever a song had a music video, since it never swapped to the audio version's square art like the main page does. Minimising the window also stopped the animation engine ticking while paused, so word highlights swept to the end of the line instead of freezing mid-word. Mirrored animations were never retired once their source finished, so a forwards-filled one could outrank the theme and hold a line visible after the page had faded it out. Fetching shows the main panel's spinner now too.
