### PR TITLE
fix(pip): run the floating lyrics window in the page world on firefox

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,7 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": [
     "src/index.ts",
+    "src/pageWorld.ts",
     "src/options/background.ts",
     "src/options/options.ts",
     "src/options/editor.ts",

--- a/manifest.json
+++ b/manifest.json
@@ -110,6 +110,16 @@
       ],
       "run_at": "document_end",
       "world": "MAIN"
+    },
+    {
+      "matches": [
+        "*://music.youtube.com/*"
+      ],
+      "js": [
+        "src/pageWorld.ts"
+      ],
+      "run_at": "document_end",
+      "world": "MAIN"
     }
   ],
   "action": {

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
         "*://music.youtube.com/*"
       ],
       "resources": [
+        "_locales/*/messages.json",
         "css/blyrics/*.css",
         "css/ytmusic/*.css",
         "css/disablestylizedanimations.css",

--- a/public/css/blyrics/picture-in-picture.css
+++ b/public/css/blyrics/picture-in-picture.css
@@ -47,6 +47,8 @@ body {
 }
 
 .blyrics-pip-artwork {
+  --blyrics-pip-artwork-radius: clamp(10px, 3vw, 18px);
+
   position: relative;
   flex: 0 0 auto;
   width: min(34vw, calc(100vh - clamp(24px, 7vw, 40px)));
@@ -55,7 +57,7 @@ body {
   align-self: center;
   aspect-ratio: 1;
   overflow: hidden;
-  border-radius: clamp(10px, 3vw, 18px);
+  border-radius: var(--blyrics-pip-artwork-radius);
   background: linear-gradient(145deg, #353538, #202023);
   box-shadow: 0 10px 30px rgb(0 0 0 / 38%);
 }
@@ -86,13 +88,19 @@ body {
   opacity: 1;
 }
 
+/* Gecko composites the video in its own layer and ignores the container's overflow clip, so the
+   radius has to sit on the video itself. The mask is not decorative: it is what makes that rounded
+   corner survive compositing. Without it the corners are square on Firefox even with the radius
+   set. `inherit` keeps the video matched to the container however the radius was set. */
 .blyrics-pip-artwork__video {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
+  border-radius: inherit;
   opacity: 0;
+  mask-image: radial-gradient(#fff, #fff);
   pointer-events: none;
   transition: opacity 300ms ease;
 }
@@ -321,9 +329,10 @@ body {
   }
 
   .blyrics-pip-artwork {
+    --blyrics-pip-artwork-radius: 9px;
+
     width: calc(100vh - 16px);
     min-width: 64px;
-    border-radius: 9px;
   }
 
   .blyrics-pip-header {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -141,17 +141,24 @@ const AUTH_PARTNER_METADATA: Record<string, Pick<AuthPartner, "id" | "iconUrl">>
   "https://blrcunison.vercel.app": { id: "blrcunison", iconUrl: "https://blrcunison.vercel.app/logo_mono.svg" },
 };
 
-const AUTH_PARTNERS: readonly AuthPartner[] = (chrome.runtime.getManifest().externally_connectable?.matches ?? [])
-  .map(match => match.replace(/\/\*$/, ""))
-  .map(origin => ({
-    origin,
-    id: AUTH_PARTNER_METADATA[origin]?.id ?? origin,
-    iconUrl: AUTH_PARTNER_METADATA[origin]?.iconUrl ?? null,
-  }));
+let authPartners: readonly AuthPartner[] | null = null;
+
+// Resolved on demand rather than at module scope: this file is imported by page-world code that
+// has no chrome.* at all, and reading the manifest eagerly would throw before it ran a line.
+function getAuthPartners(): readonly AuthPartner[] {
+  authPartners ??= (chrome.runtime.getManifest().externally_connectable?.matches ?? [])
+    .map(match => match.replace(/\/\*$/, ""))
+    .map(origin => ({
+      origin,
+      id: AUTH_PARTNER_METADATA[origin]?.id ?? origin,
+      iconUrl: AUTH_PARTNER_METADATA[origin]?.iconUrl ?? null,
+    }));
+  return authPartners;
+}
 
 export function getAuthPartnerByOrigin(origin: string | undefined): AuthPartner | undefined {
   if (!origin) return undefined;
-  return AUTH_PARTNERS.find(p => p.origin === origin);
+  return getAuthPartners().find(p => p.origin === origin);
 }
 
 export function isAllowedAuthOrigin(origin: string | undefined): boolean {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -29,6 +29,8 @@ export const NO_LYRICS_TEXT_SELECTOR =
   "#tab-renderer > ytmusic-message-renderer > yt-formatted-string.text.style-scope.ytmusic-message-renderer" as const;
 export const FULLSCREEN_BUTTON_SELECTOR = ".fullscreen-button" as const;
 export const SHADERS_DETECTION_SELECTOR = '[id^="better-lyrics-kawarp-"]' as const;
+export const MINI_PLAYER_BUTTON_SELECTOR = ".player-minimize-button" as const;
+export const PICTURE_IN_PICTURE_TOGGLE_SELECTOR = "[data-blyrics-picture-in-picture-toggle]" as const;
 
 // DOM IDs and Attributes
 export const LYRICS_LOADER_ID = "blyrics-loader" as const;

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -99,11 +99,14 @@ export function getLanguageDisplayName(langCode: string): string {
   }
 }
 
-export function subscribeToLocaleChanges(): void {
+// Consumers that cache resolved strings rather than calling t() at render time have to
+// republish here, once the override has actually swapped, not from their own storage listener.
+export function subscribeToLocaleChanges(onLocaleApplied?: () => void): void {
   chrome.storage.onChanged.addListener(async (changes, area) => {
     if (area !== "sync" || !changes.uiLanguage) return;
     await loadLocaleOverride();
     injectI18nCssVars();
+    onLocaleApplied?.();
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ async function modify(): Promise<void> {
   await injectHeadTags();
   await loadLocaleOverride();
   injectI18nCssVars();
-  subscribeToLocaleChanges();
+  subscribeToLocaleChanges(publishPictureInPictureResources);
   publishPictureInPictureResources();
   setupAdObserver();
   enableLyricsTab();

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import {
 import {
   initializePictureInPictureAutoRestore,
   mirrorNativeMiniPlayerButton,
+  publishPictureInPictureResources,
 } from "@modules/ui/pictureInPicture/browserController";
 import { subscribeToCustomStyles } from "@modules/ui/styleInjector";
 import { log, setUpLog } from "@utils";
@@ -45,6 +46,7 @@ async function modify(): Promise<void> {
   await loadLocaleOverride();
   injectI18nCssVars();
   subscribeToLocaleChanges();
+  publishPictureInPictureResources();
   setupAdObserver();
   enableLyricsTab();
   setupHomepageFullscreenHandler();

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -26,6 +26,7 @@ import { createInstrumentalElement } from "@modules/lyrics/createInstrumentalEle
 import { containsNonLatin, detectNonLatinLanguage, testRtl } from "@modules/lyrics/lyricParseUtils";
 import { applySegmentMapToLyrics, type LyricSourceResultWithMeta } from "@modules/lyrics/lyrics";
 import type { Lyric, LyricPart } from "@modules/lyrics/providers/shared";
+import { getSeekTimeFromClick } from "@modules/lyrics/seekFromClick";
 import {
   getRomanizationFromCache,
   getTranslationFromCache,
@@ -546,36 +547,6 @@ function buildLineSyncedParts(item: Lyric): LyricPart[] {
   }
 
   return parts;
-}
-
-export function getSeekTimeFromClick(event: MouseEvent, lyricElement: HTMLElement): number | null {
-  const target = event.target as HTMLElement;
-  const container = lyricElement.closest(`.${LYRICS_CLASS}`) as HTMLElement | null;
-  const isRichsync = container?.dataset.sync === "richsync";
-
-  if (!isRichsync || !event.altKey) {
-    return parseFloat(lyricElement.dataset.time || "0");
-  }
-
-  let wordElement = target.closest(`.${WORD_CLASS}`) as HTMLElement | null;
-
-  if (!wordElement) {
-    const words = lyricElement.querySelectorAll(`.${WORD_CLASS}`);
-    let closestDist = Infinity;
-    words.forEach(word => {
-      const rect = word.getBoundingClientRect();
-      const centerX = rect.left + rect.width / 2;
-      const centerY = rect.top + rect.height / 2;
-      const dist = Math.hypot(event.clientX - centerX, event.clientY - centerY);
-      if (dist < closestDist) {
-        closestDist = dist;
-        wordElement = word as HTMLElement;
-      }
-    });
-  }
-
-  if (!wordElement) return null;
-  return parseFloat(wordElement.dataset.time || "0");
 }
 
 function addSeekHandler(lyricElement: HTMLElement, allZero: boolean): void {

--- a/src/modules/lyrics/seekFromClick.ts
+++ b/src/modules/lyrics/seekFromClick.ts
@@ -1,0 +1,31 @@
+import { LYRICS_CLASS, WORD_CLASS } from "@constants";
+
+export function getSeekTimeFromClick(event: MouseEvent, lyricElement: HTMLElement): number | null {
+  const target = event.target as HTMLElement;
+  const container = lyricElement.closest(`.${LYRICS_CLASS}`) as HTMLElement | null;
+  const isRichsync = container?.dataset.sync === "richsync";
+
+  if (!isRichsync || !event.altKey) {
+    return parseFloat(lyricElement.dataset.time || "0");
+  }
+
+  let wordElement = target.closest(`.${WORD_CLASS}`) as HTMLElement | null;
+
+  if (!wordElement) {
+    const words = lyricElement.querySelectorAll(`.${WORD_CLASS}`);
+    let closestDist = Infinity;
+    words.forEach(word => {
+      const rect = word.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const dist = Math.hypot(event.clientX - centerX, event.clientY - centerY);
+      if (dist < closestDist) {
+        closestDist = dist;
+        wordElement = word as HTMLElement;
+      }
+    });
+  }
+
+  if (!wordElement) return null;
+  return parseFloat(wordElement.dataset.time || "0");
+}

--- a/src/modules/ui/pictureInPicture/bridge.ts
+++ b/src/modules/ui/pictureInPicture/bridge.ts
@@ -1,0 +1,58 @@
+import { GENERAL_ERROR_LOG } from "@constants";
+import type { PictureInPictureSongMetadata } from "./types";
+
+const PIP_INIT_EVENT = "blyrics-pip-init" as const;
+const PIP_SIGNAL_EVENT = "blyrics-pip-signal" as const;
+const PIP_METADATA_EVENT = "blyrics-pip-metadata" as const;
+
+export interface PictureInPictureInitPayload {
+  readonly strings: Record<string, string>;
+  readonly lyricsStylesheetUrl: string;
+  readonly pipStylesheetUrl: string;
+  readonly fontUrls: readonly string[];
+  readonly autoRestoreEnabled: boolean;
+}
+
+export type PictureInPictureSignal =
+  | { readonly type: "ready" }
+  | { readonly type: "opened" }
+  | { readonly type: "closed" }
+  | { readonly type: "reset-scroll" }
+  | { readonly type: "want-metadata"; readonly requestId: number; readonly videoId: string };
+
+interface PictureInPictureMetadataPayload {
+  readonly requestId: number;
+  readonly metadata: PictureInPictureSongMetadata | null;
+}
+
+// Details cross as JSON strings, not objects. Gecko hands the page a dead wrapper for any object a
+// content script puts on a CustomEvent unless it is cloneInto'd first, and a string never needs
+// that. The existing ISOLATED to MAIN events pass primitives for the same reason.
+function send(eventName: string, payload: unknown): void {
+  document.dispatchEvent(new CustomEvent(eventName, { detail: JSON.stringify(payload) }));
+}
+
+function subscribe<TPayload>(eventName: string, handler: (payload: TPayload) => void): void {
+  document.addEventListener(eventName, event => {
+    const detail = (event as CustomEvent<string>).detail;
+    if (typeof detail !== "string") return;
+    try {
+      handler(JSON.parse(detail) as TPayload);
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      console.warn(`${GENERAL_ERROR_LOG} Picture-in-Picture bridge payload: ${reason}`);
+    }
+  });
+}
+
+export const sendInit = (payload: PictureInPictureInitPayload): void => send(PIP_INIT_EVENT, payload);
+export const onInit = (handler: (payload: PictureInPictureInitPayload) => void): void =>
+  subscribe(PIP_INIT_EVENT, handler);
+
+export const sendSignal = (signal: PictureInPictureSignal): void => send(PIP_SIGNAL_EVENT, signal);
+export const onSignal = (handler: (signal: PictureInPictureSignal) => void): void =>
+  subscribe(PIP_SIGNAL_EVENT, handler);
+
+export const sendMetadata = (payload: PictureInPictureMetadataPayload): void => send(PIP_METADATA_EVENT, payload);
+export const onMetadata = (handler: (payload: PictureInPictureMetadataPayload) => void): void =>
+  subscribe(PIP_METADATA_EVENT, handler);

--- a/src/modules/ui/pictureInPicture/browserController.ts
+++ b/src/modules/ui/pictureInPicture/browserController.ts
@@ -1,31 +1,40 @@
-import { FONT_LINK, GENERAL_ERROR_LOG, LYRICS_CLASS, NOTO_SANS_UNIVERSAL_LINK, TAB_HEADER_CLASS } from "@constants";
+import { FONT_LINK, GENERAL_ERROR_LOG, NOTO_SANS_UNIVERSAL_LINK, TAB_HEADER_CLASS } from "@constants";
 import { AppState } from "@core/appState";
 import { t } from "@core/i18n";
 import { getStorage } from "@core/storage";
+import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
+import { animEngineState } from "@modules/ui/animationEngine";
 import { log } from "@utils";
-import { PictureInPictureController } from "./controller";
-import { PictureInPictureLyricsView } from "./lyricsView";
-import { buildTwin, needsRebuild, sync as syncMirror, teardown as teardownMirror } from "./pipMirror";
+import { onSignal, sendInit, sendMetadata } from "./bridge";
+import { createPictureInPictureHost } from "./pipHost";
+import type { PictureInPictureToggle, PictureInPictureViewDependencies } from "./types";
 
 const STYLESHEET_PATH = "css/blyrics/picture-in-picture.css";
 const LYRIC_STYLESHEET_PATH = "css/blyrics/index.css";
-const CUSTOM_STYLE_ID = "blyrics-custom-style";
 const MINI_PLAYER_BUTTON_SELECTOR = ".player-minimize-button";
-const PIP_OPEN_ATTRIBUTE = "blyrics-pip-open";
-let activeView: PictureInPictureLyricsView | null = null;
-let activeWindow: Window | null = null;
-let lastMirroredRoot: HTMLElement | null = null;
-let syncFrame: number | null = null;
-let themeObserver: MutationObserver | null = null;
+const PIP_STRING_KEYS = [
+  "picture_in_picture_open",
+  "picture_in_picture_loading",
+  "picture_in_picture_previous",
+  "picture_in_picture_play",
+  "picture_in_picture_pause",
+  "picture_in_picture_next",
+] as const;
 let hasInitializedAutoRestore = false;
 let hasAttemptedAutoRestore = false;
 let hasMirroredMiniPlayer = false;
 let autoRestoreInteractionController: AbortController | null = null;
 
-function renderLoadingShell(pipWindow: Window): void {
-  activeWindow = pipWindow;
+const isolatedViewDependencies: PictureInPictureViewDependencies = {
+  translate: t,
+  getSongMetadata,
+  resetScrollResume: () => {
+    animEngineState.scrollResumeTime = 0;
+  },
+};
+
+function markPictureInPictureOpened(): void {
   AppState.isPictureInPictureOpen = true;
-  document.documentElement.setAttribute(PIP_OPEN_ATTRIBUTE, "");
   if (!AppState.areLyricsLoaded || AppState.lastLoadedVideoId !== AppState.lastVideoId) {
     AppState.queueLyricInjection = true;
   } else {
@@ -33,84 +42,14 @@ function renderLoadingShell(pipWindow: Window): void {
     // back on while the lyrics stay loaded, so the window would mount a frozen snapshot.
     AppState.areLyricsTicking = true;
   }
-  pipWindow.document.title = t("picture_in_picture_open");
-  injectLyricStyles(pipWindow);
-  mirrorCustomTheme(pipWindow);
-  activeView = new PictureInPictureLyricsView(pipWindow, document);
-  startSyncLoop(pipWindow);
 }
 
-function mirrorCustomTheme(pipWindow: Window): void {
-  stopThemeMirror();
-  const pipStyle = pipWindow.document.createElement("style");
-  pipStyle.id = CUSTOM_STYLE_ID;
-  pipWindow.document.head.appendChild(pipStyle);
-
-  const sync = (): void => {
-    pipStyle.textContent = document.getElementById(CUSTOM_STYLE_ID)?.textContent ?? "";
-  };
-  sync();
-
-  themeObserver = new MutationObserver(sync);
-  themeObserver.observe(document.head, { childList: true, subtree: true, characterData: true });
-}
-
-function stopThemeMirror(): void {
-  themeObserver?.disconnect();
-  themeObserver = null;
-}
-
-function startSyncLoop(pipWindow: Window): void {
-  stopSyncLoop(pipWindow);
-  const loop = (): void => {
-    try {
-      syncTwin();
-    } catch (error) {
-      reportFailure("Document Picture-in-Picture sync failed", error);
-    }
-    syncFrame = pipWindow.requestAnimationFrame(loop);
-  };
-  syncFrame = pipWindow.requestAnimationFrame(loop);
-}
-
-function stopSyncLoop(pipWindow: Window): void {
-  if (syncFrame === null || activeWindow !== pipWindow) return;
-  pipWindow.cancelAnimationFrame(syncFrame);
-  syncFrame = null;
-}
-
-// A closed window's pagehide can arrive after its successor opened; only the owner may tear down.
-function teardownWindow(pipWindow: Window): void {
-  if (activeWindow !== pipWindow) return;
+function markPictureInPictureClosed(): void {
   AppState.isPictureInPictureOpen = false;
-  document.documentElement.removeAttribute(PIP_OPEN_ATTRIBUTE);
   const tabSelector = document.getElementsByClassName(TAB_HEADER_CLASS)[1];
   if (tabSelector?.getAttribute("aria-selected") !== "true") {
     AppState.areLyricsTicking = false;
   }
-  stopSyncLoop(pipWindow);
-  stopThemeMirror();
-  teardownMirror();
-  activeView = null;
-  lastMirroredRoot = null;
-  activeWindow = null;
-}
-
-function injectLyricStyles(pipWindow: Window): void {
-  const lyricStyles = pipWindow.document.createElement("link");
-  lyricStyles.rel = "stylesheet";
-  lyricStyles.href = chrome.runtime.getURL(LYRIC_STYLESHEET_PATH);
-  pipWindow.document.head.appendChild(lyricStyles);
-
-  const fontLink = pipWindow.document.createElement("link");
-  fontLink.href = FONT_LINK;
-  fontLink.rel = "stylesheet";
-  pipWindow.document.head.appendChild(fontLink);
-
-  const notoFontLink = pipWindow.document.createElement("link");
-  notoFontLink.href = NOTO_SANS_UNIVERSAL_LINK;
-  notoFontLink.rel = "stylesheet";
-  pipWindow.document.head.appendChild(notoFontLink);
 }
 
 function injectStylesheet(pipWindow: Window, stylesheet: string): void {
@@ -130,39 +69,68 @@ function reportFailure(message: string, error: unknown): void {
   log(GENERAL_ERROR_LOG, `${message}: ${detail}`);
 }
 
-export const pictureInPictureController = new PictureInPictureController<Window>({
-  host: window,
-  loadStylesheet,
-  renderLoadingShell,
-  injectStylesheet,
-  closeWindow: pipWindow => {
-    teardownWindow(pipWindow);
-    pipWindow.close();
-  },
-  observePageHide: (pipWindow, listener) =>
-    pipWindow.addEventListener(
-      "pagehide",
-      () => {
-        teardownWindow(pipWindow);
-        listener();
-      },
-      { once: true }
-    ),
-  reportFailure,
-});
+// Gecko hands a content script a cross-origin wrapper on the Picture-in-Picture window, so nothing
+// in this world can script it (bugzilla 2045666 and 2053139, fixed upstream in Firefox 154). The
+// page world is unaffected on every version, so Gecko always delegates and Chromium never does.
+// `wrappedJSObject` is the Xray marker that identifies the sandbox with the restriction.
+const delegatesToPageWorld = "wrappedJSObject" in window;
 
-function syncTwin(): void {
-  const view = activeView;
-  if (!view) return;
-  const mainRoot = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement | undefined;
-  if (!mainRoot) return;
-  if (mainRoot !== lastMirroredRoot || needsRebuild() || !view.hasTwinMounted()) {
-    const twin = buildTwin(mainRoot, view.pipDocument);
-    view.mountLyrics(twin);
-    lastMirroredRoot = mainRoot;
-  }
-  syncMirror(mainRoot);
-  view.updateScroll();
+export const pictureInPictureController: PictureInPictureToggle = delegatesToPageWorld
+  ? createPageWorldDelegate()
+  : createPictureInPictureHost({
+      view: isolatedViewDependencies,
+      windowTitle: () => t("picture_in_picture_open"),
+      stylesheetUrls: () => ({
+        lyrics: chrome.runtime.getURL(LYRIC_STYLESHEET_PATH),
+        fonts: [FONT_LINK, NOTO_SANS_UNIVERSAL_LINK],
+      }),
+      loadStylesheet,
+      injectStylesheet,
+      onOpened: markPictureInPictureOpened,
+      onClosed: markPictureInPictureClosed,
+      reportFailure,
+    });
+
+// The page world owns the window and already acted on the same click via its own capture listener,
+// so toggling here would open a second one. This exists to keep the dock button rendering and to
+// report the state the page world reports back.
+function createPageWorldDelegate(): PictureInPictureToggle {
+  let isOpen = false;
+  onSignal(signal => {
+    if (signal.type === "opened") {
+      isOpen = true;
+      markPictureInPictureOpened();
+    } else if (signal.type === "closed") {
+      isOpen = false;
+      markPictureInPictureClosed();
+    } else if (signal.type === "reset-scroll") {
+      animEngineState.scrollResumeTime = 0;
+    } else if (signal.type === "want-metadata") {
+      void getSongMetadata(signal.videoId, 250).then(metadata =>
+        sendMetadata({ requestId: signal.requestId, metadata })
+      );
+    } else if (signal.type === "ready") {
+      publishResources();
+    }
+  });
+
+  return {
+    isSupported: () => "documentPictureInPicture" in window,
+    isOpen: () => isOpen,
+    toggle: () => undefined,
+  };
+}
+
+function publishResources(): void {
+  getStorage({ isPictureInPictureAutoRestoreEnabled: false }, items => {
+    sendInit({
+      strings: Object.fromEntries(PIP_STRING_KEYS.map(key => [key, t(key)])),
+      lyricsStylesheetUrl: chrome.runtime.getURL(LYRIC_STYLESHEET_PATH),
+      pipStylesheetUrl: chrome.runtime.getURL(STYLESHEET_PATH),
+      fontUrls: [FONT_LINK, NOTO_SANS_UNIVERSAL_LINK],
+      autoRestoreEnabled: Boolean(items.isPictureInPictureAutoRestoreEnabled),
+    });
+  });
 }
 
 function disarmAutoRestore(): void {
@@ -211,6 +179,14 @@ export function initializePictureInPictureAutoRestore(): void {
   if (hasInitializedAutoRestore) return;
   hasInitializedAutoRestore = true;
 
+  if (delegatesToPageWorld) {
+    publishResources();
+    chrome.storage.onChanged.addListener((changes, areaName) => {
+      if (areaName === "sync" && changes.isPictureInPictureAutoRestoreEnabled) publishResources();
+    });
+    return;
+  }
+
   getStorage({ isPictureInPictureAutoRestoreEnabled: false }, items => {
     if (items.isPictureInPictureAutoRestoreEnabled) armAutoRestore();
   });
@@ -225,8 +201,9 @@ export function initializePictureInPictureAutoRestore(): void {
   });
 }
 
+// The page world runs its own copy of this against the same button when it owns the window.
 export function mirrorNativeMiniPlayerButton(): void {
-  if (hasMirroredMiniPlayer) return;
+  if (hasMirroredMiniPlayer || delegatesToPageWorld) return;
   hasMirroredMiniPlayer = true;
 
   document.addEventListener(

--- a/src/modules/ui/pictureInPicture/browserController.ts
+++ b/src/modules/ui/pictureInPicture/browserController.ts
@@ -1,4 +1,11 @@
-import { FONT_LINK, GENERAL_ERROR_LOG, NOTO_SANS_UNIVERSAL_LINK, TAB_HEADER_CLASS } from "@constants";
+import {
+  FONT_LINK,
+  GENERAL_ERROR_LOG,
+  MINI_PLAYER_BUTTON_SELECTOR,
+  NOTO_SANS_UNIVERSAL_LINK,
+  PICTURE_IN_PICTURE_TOGGLE_SELECTOR,
+  TAB_HEADER_CLASS,
+} from "@constants";
 import { AppState } from "@core/appState";
 import { t } from "@core/i18n";
 import { getStorage } from "@core/storage";
@@ -11,7 +18,6 @@ import type { PictureInPictureToggle, PictureInPictureViewDependencies } from ".
 
 const STYLESHEET_PATH = "css/blyrics/picture-in-picture.css";
 const LYRIC_STYLESHEET_PATH = "css/blyrics/index.css";
-const MINI_PLAYER_BUTTON_SELECTOR = ".player-minimize-button";
 const PIP_STRING_KEYS = [
   "picture_in_picture_open",
   "picture_in_picture_loading",
@@ -110,7 +116,7 @@ function createPageWorldDelegate(): PictureInPictureToggle {
         sendMetadata({ requestId: signal.requestId, metadata })
       );
     } else if (signal.type === "ready") {
-      publishResources();
+      publishPictureInPictureResources();
     }
   });
 
@@ -121,7 +127,10 @@ function createPageWorldDelegate(): PictureInPictureToggle {
   };
 }
 
-function publishResources(): void {
+// The page world caches this payload, so the strings must be resolved after the locale override has
+// loaded. `modify()` calls this again once it has; the `ready` handshake only bootstraps the toggle.
+export function publishPictureInPictureResources(): void {
+  if (!delegatesToPageWorld) return;
   getStorage({ isPictureInPictureAutoRestoreEnabled: false }, items => {
     sendInit({
       strings: Object.fromEntries(PIP_STRING_KEYS.map(key => [key, t(key)])),
@@ -165,7 +174,7 @@ function armAutoRestore(): void {
     hasAttemptedAutoRestore = true;
     disarmAutoRestore();
     const target = event.target;
-    if (target instanceof Element && target.closest("[data-blyrics-picture-in-picture-toggle]")) return;
+    if (target instanceof Element && target.closest(PICTURE_IN_PICTURE_TOGGLE_SELECTOR)) return;
     if (!pictureInPictureController.isOpen()) pictureInPictureController.toggle();
   };
 
@@ -180,9 +189,10 @@ export function initializePictureInPictureAutoRestore(): void {
   hasInitializedAutoRestore = true;
 
   if (delegatesToPageWorld) {
-    publishResources();
     chrome.storage.onChanged.addListener((changes, areaName) => {
-      if (areaName === "sync" && changes.isPictureInPictureAutoRestoreEnabled) publishResources();
+      if (areaName === "sync" && changes.isPictureInPictureAutoRestoreEnabled) {
+        publishPictureInPictureResources();
+      }
     });
     return;
   }

--- a/src/modules/ui/pictureInPicture/capability.selfcheck.ts
+++ b/src/modules/ui/pictureInPicture/capability.selfcheck.ts
@@ -194,4 +194,29 @@ assert.equal(
   "Given stylesheet injection failure, When the partial window closes, Then state resets"
 );
 
+const unscriptableWindow = new FakeWindow();
+const unscriptableDependencies = createDependencies(
+  new FakeApi([Promise.resolve(unscriptableWindow)]),
+  () => Promise.resolve(".pip {}"),
+  () => undefined
+);
+const unscriptableController = new PictureInPictureController({
+  ...unscriptableDependencies,
+  observePageHide: () => {
+    throw new Error("Permission denied to access property 'addEventListener' on cross-origin object");
+  },
+});
+unscriptableController.toggle();
+await settle();
+assert.equal(
+  unscriptableWindow.closeCount,
+  1,
+  "Given a window this world cannot script, When observing it throws, Then the empty window closes"
+);
+assert.equal(
+  unscriptableController.isOpen(),
+  false,
+  "Given a window this world cannot script, When observing it throws, Then state resets so the next click retries"
+);
+
 console.log("Picture-in-Picture controller selfcheck passed");

--- a/src/modules/ui/pictureInPicture/controller.ts
+++ b/src/modules/ui/pictureInPicture/controller.ts
@@ -64,11 +64,13 @@ export class PictureInPictureController<TWindow> {
   private initialize(pipWindow: TWindow): void {
     this.isOpening = false;
     this.activeWindow = pipWindow;
-    this.dependencies.observePageHide(pipWindow, () => {
-      if (this.activeWindow === pipWindow) this.reset();
-    });
 
+    // Both calls must stay guarded: a browser that hands back a window this world cannot script
+    // throws on the very first property access, and an unguarded throw here strands an empty window.
     try {
+      this.dependencies.observePageHide(pipWindow, () => {
+        if (this.activeWindow === pipWindow) this.reset();
+      });
       this.dependencies.renderLoadingShell(pipWindow);
     } catch (error) {
       this.dependencies.reportFailure("Document Picture-in-Picture shell setup failed", error);

--- a/src/modules/ui/pictureInPicture/lyricsView.ts
+++ b/src/modules/ui/pictureInPicture/lyricsView.ts
@@ -1,10 +1,8 @@
 import { CURRENT_LYRICS_CLASS, LINE_CLASS, LYRICS_CLASS, PLAYER_BAR_SELECTOR, SEEK_EVENT } from "@constants";
 import type { PlayerDetails } from "@core/appState";
-import { t } from "@core/i18n";
-import { getSeekTimeFromClick } from "@modules/lyrics/injectLyrics";
-import { getSongMetadata } from "@modules/lyrics/requestSniffer/requestSniffer";
-import { animEngineState } from "@modules/ui/animationEngine";
+import { getSeekTimeFromClick } from "@modules/lyrics/seekFromClick";
 import { MIRROR_ID_ATTR } from "./pipMirror";
+import type { PictureInPictureViewDependencies } from "./types";
 
 interface DisplayMetadata {
   readonly title: string;
@@ -111,7 +109,8 @@ export class PictureInPictureLyricsView {
 
   constructor(
     private readonly pipWindow: Window,
-    private readonly sourceDocument: Document
+    private readonly sourceDocument: Document,
+    private readonly dependencies: PictureInPictureViewDependencies
   ) {
     const pipDocument = pipWindow.document;
 
@@ -143,15 +142,15 @@ export class PictureInPictureLyricsView {
     artworkControls.className = "blyrics-pip-artwork__controls";
     const previousButton = this.createPlayerControlButton(
       "previous",
-      getSourceControlLabel(sourceDocument, "previous", t("picture_in_picture_previous"))
+      getSourceControlLabel(sourceDocument, "previous", dependencies.translate("picture_in_picture_previous"))
     );
     this.playPauseButton = this.createPlayerControlButton(
       "play-pause",
-      getSourceControlLabel(sourceDocument, "play-pause", t("picture_in_picture_play"))
+      getSourceControlLabel(sourceDocument, "play-pause", dependencies.translate("picture_in_picture_play"))
     );
     const nextButton = this.createPlayerControlButton(
       "next",
-      getSourceControlLabel(sourceDocument, "next", t("picture_in_picture_next"))
+      getSourceControlLabel(sourceDocument, "next", dependencies.translate("picture_in_picture_next"))
     );
     artworkControls.append(previousButton, this.playPauseButton, nextButton);
     this.artworkContainer.append(artworkPlaceholder, this.artwork, this.artworkVideo, artworkControls);
@@ -179,7 +178,7 @@ export class PictureInPictureLyricsView {
       signal: this.lifecycleController.signal,
     });
 
-    this.renderStatus(t("picture_in_picture_loading"));
+    this.renderStatus(dependencies.translate("picture_in_picture_loading"));
 
     content.append(header, this.lyricsViewport);
     this.shell.append(this.artworkContainer, content);
@@ -249,7 +248,7 @@ export class PictureInPictureLyricsView {
     const seekTime = getSeekTimeFromClick(event, line);
     if (seekTime === null) return;
     this.sourceDocument.dispatchEvent(new CustomEvent(SEEK_EVENT, { detail: seekTime }));
-    animEngineState.scrollResumeTime = 0;
+    this.dependencies.resetScrollResume();
   };
 
   private readonly handlePointerMove = (): void => {
@@ -314,7 +313,7 @@ export class PictureInPictureLyricsView {
       getSourceControlLabel(
         this.sourceDocument,
         "play-pause",
-        isPlaying ? t("picture_in_picture_pause") : t("picture_in_picture_play")
+        this.dependencies.translate(isPlaying ? "picture_in_picture_pause" : "picture_in_picture_play")
       )
     );
   }
@@ -362,7 +361,7 @@ export class PictureInPictureLyricsView {
     this.fallbackArtworkUrl = getFallbackArtworkUrl(videoId);
     this.setArtwork(this.fallbackArtworkUrl);
 
-    void getSongMetadata(videoId, 250, controller.signal).then(metadata => {
+    void this.dependencies.getSongMetadata(videoId, 250, controller.signal).then(metadata => {
       if (controller.signal.aborted || this.currentVideoId !== videoId || !metadata) return;
       if (metadata.displayTitle) this.title.textContent = metadata.displayTitle;
       const displayByline = metadata.displayByline || metadata.artist;

--- a/src/modules/ui/pictureInPicture/mainWorldHost.ts
+++ b/src/modules/ui/pictureInPicture/mainWorldHost.ts
@@ -1,4 +1,4 @@
-import { GENERAL_ERROR_LOG } from "@constants";
+import { GENERAL_ERROR_LOG, MINI_PLAYER_BUTTON_SELECTOR, PICTURE_IN_PICTURE_TOGGLE_SELECTOR } from "@constants";
 import {
   onInit,
   onMetadata,
@@ -10,8 +10,6 @@ import type { PictureInPictureController } from "./controller";
 import { createPictureInPictureHost } from "./pipHost";
 import type { PictureInPictureSongMetadata } from "./types";
 
-const TOGGLE_SELECTOR = "[data-blyrics-picture-in-picture-toggle]";
-const MINI_PLAYER_BUTTON_SELECTOR = ".player-minimize-button";
 const IGNORED_AUTO_RESTORE_KEYS = new Set(["Escape", "Alt", "Control", "Meta", "Shift"]);
 
 let resources: PictureInPictureInitPayload | null = null;
@@ -89,7 +87,7 @@ function armAutoRestore(): void {
     hasAttemptedAutoRestore = true;
     disarmAutoRestore();
     const target = event.target;
-    if (target instanceof Element && target.closest(TOGGLE_SELECTOR)) return;
+    if (target instanceof Element && target.closest(PICTURE_IN_PICTURE_TOGGLE_SELECTOR)) return;
     if (!controller?.isOpen()) controller?.toggle();
   };
 
@@ -108,7 +106,7 @@ function observeToggleClicks(): void {
       if (!controller) return;
       const target = event.target;
       if (!(target instanceof Element)) return;
-      if (target.closest(TOGGLE_SELECTOR)) {
+      if (target.closest(PICTURE_IN_PICTURE_TOGGLE_SELECTOR)) {
         controller.toggle();
         return;
       }

--- a/src/modules/ui/pictureInPicture/mainWorldHost.ts
+++ b/src/modules/ui/pictureInPicture/mainWorldHost.ts
@@ -1,0 +1,142 @@
+import { GENERAL_ERROR_LOG } from "@constants";
+import {
+  onInit,
+  onMetadata,
+  type PictureInPictureInitPayload,
+  sendSignal,
+  type PictureInPictureSignal,
+} from "./bridge";
+import type { PictureInPictureController } from "./controller";
+import { createPictureInPictureHost } from "./pipHost";
+import type { PictureInPictureSongMetadata } from "./types";
+
+const TOGGLE_SELECTOR = "[data-blyrics-picture-in-picture-toggle]";
+const MINI_PLAYER_BUTTON_SELECTOR = ".player-minimize-button";
+const IGNORED_AUTO_RESTORE_KEYS = new Set(["Escape", "Alt", "Control", "Meta", "Shift"]);
+
+let resources: PictureInPictureInitPayload | null = null;
+let controller: PictureInPictureController<Window> | null = null;
+let nextRequestId = 0;
+let hasAttemptedAutoRestore = false;
+let autoRestoreController: AbortController | null = null;
+const pendingMetadata = new Map<number, (metadata: PictureInPictureSongMetadata | null) => void>();
+
+function requestSongMetadata(
+  videoId: string,
+  _maxCheckCount?: number,
+  signal?: AbortSignal
+): Promise<PictureInPictureSongMetadata | null> {
+  return new Promise(resolve => {
+    const requestId = ++nextRequestId;
+    pendingMetadata.set(requestId, resolve);
+    signal?.addEventListener(
+      "abort",
+      () => {
+        if (pendingMetadata.delete(requestId)) resolve(null);
+      },
+      { once: true }
+    );
+    sendSignal({ type: "want-metadata", requestId, videoId });
+  });
+}
+
+function reportFailure(message: string, error: unknown): void {
+  const detail = error instanceof Error ? error.message : String(error);
+  console.warn(`${GENERAL_ERROR_LOG} ${message}: ${detail}`);
+}
+
+function createController(): PictureInPictureController<Window> {
+  return createPictureInPictureHost({
+    view: {
+      translate: key => resources?.strings[key] ?? "",
+      getSongMetadata: requestSongMetadata,
+      resetScrollResume: () => sendSignal({ type: "reset-scroll" }),
+    },
+    windowTitle: () => resources?.strings.picture_in_picture_open ?? "",
+    stylesheetUrls: () => ({
+      lyrics: resources?.lyricsStylesheetUrl ?? "",
+      fonts: resources?.fontUrls ?? [],
+    }),
+    // The page world cannot fetch an extension resource the way a content script can, so the
+    // stylesheet travels as a URL and is linked rather than inlined.
+    loadStylesheet: () => Promise.resolve(resources?.pipStylesheetUrl ?? ""),
+    injectStylesheet: (pipWindow, href) => {
+      if (!href) return;
+      const link = pipWindow.document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = href;
+      pipWindow.document.head.appendChild(link);
+    },
+    onOpened: () => sendSignal({ type: "opened" }),
+    onClosed: () => sendSignal({ type: "closed" }),
+    reportFailure,
+  });
+}
+
+function disarmAutoRestore(): void {
+  autoRestoreController?.abort();
+  autoRestoreController = null;
+}
+
+function armAutoRestore(): void {
+  if (hasAttemptedAutoRestore || autoRestoreController || !controller || controller.isOpen()) return;
+
+  const abortController = new AbortController();
+  autoRestoreController = abortController;
+  const attemptOpen = (event: Event): void => {
+    if (!event.isTrusted || hasAttemptedAutoRestore) return;
+    if (event instanceof KeyboardEvent && IGNORED_AUTO_RESTORE_KEYS.has(event.key)) return;
+    hasAttemptedAutoRestore = true;
+    disarmAutoRestore();
+    const target = event.target;
+    if (target instanceof Element && target.closest(TOGGLE_SELECTOR)) return;
+    if (!controller?.isOpen()) controller?.toggle();
+  };
+
+  // Must be click, not pointerdown: pointerdown only grants transient user activation for a
+  // mouse, so a touch or pen tap would spend the single attempt on a request that cannot resolve.
+  document.addEventListener("click", attemptOpen, { capture: true, signal: abortController.signal });
+  document.addEventListener("keydown", attemptOpen, { capture: true, signal: abortController.signal });
+}
+
+// A capture listener on the real button, rather than a forwarded signal, is what keeps the
+// transient user activation that requestWindow() demands.
+function observeToggleClicks(): void {
+  document.addEventListener(
+    "click",
+    event => {
+      if (!controller) return;
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      if (target.closest(TOGGLE_SELECTOR)) {
+        controller.toggle();
+        return;
+      }
+      if (!controller.isOpen() && target.closest(MINI_PLAYER_BUTTON_SELECTOR)) controller.toggle();
+    },
+    { capture: true }
+  );
+}
+
+export function startPictureInPicturePageHost(): void {
+  onMetadata(({ requestId, metadata }) => {
+    const resolve = pendingMetadata.get(requestId);
+    if (!resolve) return;
+    pendingMetadata.delete(requestId);
+    resolve(metadata);
+  });
+
+  onInit(payload => {
+    resources = payload;
+    if (!controller) {
+      controller = createController();
+      observeToggleClicks();
+    }
+    if (payload.autoRestoreEnabled) armAutoRestore();
+    else disarmAutoRestore();
+  });
+
+  // The isolated world also announces itself on startup; asking covers the case where this script
+  // finished loading after that announcement.
+  sendSignal({ type: "ready" } satisfies PictureInPictureSignal);
+}

--- a/src/modules/ui/pictureInPicture/pipHost.ts
+++ b/src/modules/ui/pictureInPicture/pipHost.ts
@@ -1,0 +1,129 @@
+import { LYRICS_CLASS } from "@constants";
+import { PictureInPictureController } from "./controller";
+import { PictureInPictureLyricsView } from "./lyricsView";
+import { buildTwin, needsRebuild, sync as syncMirror, teardown as teardownMirror } from "./pipMirror";
+import type { PictureInPictureHostEnvironment } from "./types";
+
+const CUSTOM_STYLE_ID = "blyrics-custom-style";
+const PIP_OPEN_ATTRIBUTE = "blyrics-pip-open";
+
+// Everything here touches only the page document and the Picture-in-Picture document, so it runs
+// unchanged in either world. Extension APIs and the ISOLATED module singletons arrive through the
+// environment, which is the only thing that differs between the two callers.
+export function createPictureInPictureHost(
+  environment: PictureInPictureHostEnvironment
+): PictureInPictureController<Window> {
+  let activeView: PictureInPictureLyricsView | null = null;
+  let activeWindow: Window | null = null;
+  let lastMirroredRoot: HTMLElement | null = null;
+  let syncFrame: number | null = null;
+  let themeObserver: MutationObserver | null = null;
+
+  function stopThemeMirror(): void {
+    themeObserver?.disconnect();
+    themeObserver = null;
+  }
+
+  function mirrorCustomTheme(pipWindow: Window): void {
+    stopThemeMirror();
+    const pipStyle = pipWindow.document.createElement("style");
+    pipStyle.id = CUSTOM_STYLE_ID;
+    pipWindow.document.head.appendChild(pipStyle);
+
+    const sync = (): void => {
+      pipStyle.textContent = document.getElementById(CUSTOM_STYLE_ID)?.textContent ?? "";
+    };
+    sync();
+
+    themeObserver = new MutationObserver(sync);
+    themeObserver.observe(document.head, { childList: true, subtree: true, characterData: true });
+  }
+
+  function injectLyricStyles(pipWindow: Window): void {
+    const { lyrics, fonts } = environment.stylesheetUrls();
+    for (const href of [lyrics, ...fonts]) {
+      const link = pipWindow.document.createElement("link");
+      link.rel = "stylesheet";
+      link.href = href;
+      pipWindow.document.head.appendChild(link);
+    }
+  }
+
+  function syncTwin(): void {
+    const view = activeView;
+    if (!view) return;
+    const mainRoot = document.getElementsByClassName(LYRICS_CLASS)[0] as HTMLElement | undefined;
+    if (!mainRoot) return;
+    if (mainRoot !== lastMirroredRoot || needsRebuild() || !view.hasTwinMounted()) {
+      const twin = buildTwin(mainRoot, view.pipDocument);
+      view.mountLyrics(twin);
+      lastMirroredRoot = mainRoot;
+    }
+    syncMirror(mainRoot);
+    view.updateScroll();
+  }
+
+  function stopSyncLoop(pipWindow: Window): void {
+    if (syncFrame === null || activeWindow !== pipWindow) return;
+    pipWindow.cancelAnimationFrame(syncFrame);
+    syncFrame = null;
+  }
+
+  function startSyncLoop(pipWindow: Window): void {
+    stopSyncLoop(pipWindow);
+    const loop = (): void => {
+      try {
+        syncTwin();
+      } catch (error) {
+        environment.reportFailure("Document Picture-in-Picture sync failed", error);
+      }
+      syncFrame = pipWindow.requestAnimationFrame(loop);
+    };
+    syncFrame = pipWindow.requestAnimationFrame(loop);
+  }
+
+  function renderLoadingShell(pipWindow: Window): void {
+    activeWindow = pipWindow;
+    document.documentElement.setAttribute(PIP_OPEN_ATTRIBUTE, "");
+    environment.onOpened();
+    pipWindow.document.title = environment.windowTitle();
+    injectLyricStyles(pipWindow);
+    mirrorCustomTheme(pipWindow);
+    activeView = new PictureInPictureLyricsView(pipWindow, document, environment.view);
+    startSyncLoop(pipWindow);
+  }
+
+  // A closed window's pagehide can arrive after its successor opened; only the owner may tear down.
+  function teardownWindow(pipWindow: Window): void {
+    if (activeWindow !== pipWindow) return;
+    document.documentElement.removeAttribute(PIP_OPEN_ATTRIBUTE);
+    environment.onClosed();
+    stopSyncLoop(pipWindow);
+    stopThemeMirror();
+    teardownMirror();
+    activeView = null;
+    lastMirroredRoot = null;
+    activeWindow = null;
+  }
+
+  return new PictureInPictureController<Window>({
+    host: window,
+    loadStylesheet: environment.loadStylesheet,
+    renderLoadingShell,
+    injectStylesheet: environment.injectStylesheet,
+    closeWindow: pipWindow => {
+      teardownWindow(pipWindow);
+      pipWindow.close();
+    },
+    observePageHide: (pipWindow, listener) =>
+      pipWindow.addEventListener(
+        "pagehide",
+        () => {
+          teardownWindow(pipWindow);
+          listener();
+        },
+        { once: true }
+      ),
+    reportFailure: environment.reportFailure,
+  });
+}

--- a/src/modules/ui/pictureInPicture/pipMirror.ts
+++ b/src/modules/ui/pictureInPicture/pipMirror.ts
@@ -101,16 +101,38 @@ function copyPlaybackState(source: Animation, twin: Animation): void {
   else if (source.playState === "running" && twin.playState !== "running") twin.play();
 }
 
+// The engine builds these animations in the isolated world, so their effects carry that realm's
+// prototypes: `instanceof KeyframeEffect` is false when this file runs in the page world on Gecko
+// and every animation would be discarded. Shape checks hold across realms where `instanceof` does
+// not. Nodes are exempt because the DOM is shared, but nodeType costs nothing and cannot be fooled.
+function getKeyframeTarget(animation: Animation): Element | null {
+  const effect = animation.effect as KeyframeEffect | null;
+  if (!effect || typeof effect.getKeyframes !== "function" || typeof effect.getTiming !== "function") return null;
+  const target = effect.target;
+  return target && target.nodeType === Node.ELEMENT_NODE ? target : null;
+}
+
+// Gecko also returns nothing from Element.getAnimations() for animations another world created,
+// while the document-level call still reports them, so a subtree query mirrors an empty set there.
+// Scoping the document list by containment is equivalent on Chromium and works in both worlds.
+function getLiveAnimations(mainRoot: HTMLElement): Animation[] {
+  return mainRoot.ownerDocument.getAnimations().filter(animation => {
+    const target = getKeyframeTarget(animation);
+    return target !== null && mainRoot.contains(target);
+  });
+}
+
 export function sync(mainRoot: HTMLElement): void {
   if (!twinRoot) return;
-  const live = mainRoot.getAnimations({ subtree: true });
+  const live = getLiveAnimations(mainRoot);
   const nextKnown = new Set<Animation>();
 
   for (const source of live) {
     if (skippedSources.has(source)) continue;
-    const effect = source.effect;
-    if (!(effect instanceof KeyframeEffect) || !(effect.target instanceof Element)) continue;
-    const twinElement = idToTwin.get(effect.target.getAttribute(MIRROR_ID_ATTR) ?? "");
+    const target = getKeyframeTarget(source);
+    if (!target) continue;
+    const effect = source.effect as KeyframeEffect;
+    const twinElement = idToTwin.get(target.getAttribute(MIRROR_ID_ATTR) ?? "");
     if (!twinElement) continue;
 
     let twin = sourceToTwin.get(source);

--- a/src/modules/ui/pictureInPicture/types.ts
+++ b/src/modules/ui/pictureInPicture/types.ts
@@ -8,6 +8,45 @@ export interface DocumentPictureInPicture<TWindow = Window> {
   requestWindow(options: DocumentPictureInPictureWindowOptions): Promise<TWindow>;
 }
 
+// The view runs in whichever world owns the Picture-in-Picture window. Firefox content scripts get
+// a cross-origin wrapper on that window, so on Gecko it runs in the MAIN world where chrome.* and
+// the ISOLATED module singletons are out of reach; both are supplied through here instead.
+// Narrowed to what the view reads, so the MAIN world can satisfy it from a serialized bridge
+// payload rather than the full sniffed record.
+export interface PictureInPictureSongMetadata {
+  readonly displayTitle: string;
+  readonly displayByline: string;
+  readonly artist: string;
+  readonly thumbnail?: { readonly url: string };
+}
+
+export interface PictureInPictureViewDependencies {
+  readonly translate: (key: string) => string;
+  readonly getSongMetadata: (
+    videoId: string,
+    maxCheckCount?: number,
+    signal?: AbortSignal
+  ) => Promise<PictureInPictureSongMetadata | null>;
+  readonly resetScrollResume: () => void;
+}
+
+export interface PictureInPictureToggle {
+  isSupported(): boolean;
+  isOpen(): boolean;
+  toggle(): void;
+}
+
+export interface PictureInPictureHostEnvironment {
+  readonly view: PictureInPictureViewDependencies;
+  readonly windowTitle: () => string;
+  readonly stylesheetUrls: () => { readonly lyrics: string; readonly fonts: readonly string[] };
+  readonly loadStylesheet: () => Promise<string>;
+  readonly injectStylesheet: (pipWindow: Window, stylesheet: string) => void;
+  readonly onOpened: () => void;
+  readonly onClosed: () => void;
+  readonly reportFailure: (message: string, error: unknown) => void;
+}
+
 export interface PictureInPictureControllerDependencies<TWindow> {
   readonly host: object;
   readonly loadStylesheet: () => Promise<string>;

--- a/src/pageWorld.ts
+++ b/src/pageWorld.ts
@@ -1,0 +1,5 @@
+import { startPictureInPicturePageHost } from "@modules/ui/pictureInPicture/mainWorldHost";
+
+// Page-world entry point. It stays inert until the isolated world asks it to take over, which only
+// happens on Gecko, so Chromium pays nothing more than a couple of event listeners.
+startPictureInPicturePageHost();


### PR DESCRIPTION
## Overview

The floating lyrics window never worked on Firefox. Content scripts there get a cross-origin wrapper on the picture-in-picture window, so writing into it throws and you end up with an empty box. Firefox fixed that in 154, but 151 through 153 are affected and 153 becomes the next ESR, so waiting would leave those users stuck for about a year. Firefox now drives the window from the page world where the restriction doesn't apply, pulling extension URLs, strings and metadata across a small event bridge. Chrome's path is untouched. Constants also had to start resolving auth partners lazily, since reading the manifest up front broke the page-world bundle before it ran a line.
