### PR TITLE
fix(pip): stop the floating window restyling, re-arming and double-mirroring itself

### DIFF
--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -884,7 +884,10 @@ function startWordAnimations(
   resetPartAnimations(part);
 
   const rawElapsedMs = (currentTime - part.time) * 1000;
-  const timedDurationMs = part.duration * 1000;
+  // Providers do ship words that end before they start: one -0.01s word in a Musixmatch richsync
+  // was enough to make animate() throw here, and the throw took the rest of the tick with it, so
+  // the line never finished setting up and the engine tried it again on every frame.
+  const timedDurationMs = Math.max(0, part.duration * 1000);
   const isLineSyncedWord = part.lyricElement.classList.contains(LINE_SYNCED_WORD_CLASS);
   const swipeLeadMs = timedDurationMs * SWIPE_LEAD_RATIO.getNumberValue();
   const swipeTimeMs = rawElapsedMs + swipeLeadMs;

--- a/src/modules/ui/animationEngine.ts
+++ b/src/modules/ui/animationEngine.ts
@@ -926,7 +926,13 @@ function startWordAnimations(
               offset: config.word.wobblePeakOffset,
               easing: config.word.wobblePeakEasing,
             },
-            { transform: config.word.wobbleSettle, offset: config.word.wobbleSettleOffset },
+            // The two offsets are read and clamped independently, so a theme is free to settle
+            // before it peaks. animate() rejects offsets that go backwards, and that throw would
+            // orphan the highlight animations above, which are not tracked until the end.
+            {
+              transform: config.word.wobbleSettle,
+              offset: Math.max(config.word.wobblePeakOffset, config.word.wobbleSettleOffset),
+            },
             { transform: config.word.wobbleTo, easing: config.word.wobbleEndEasing },
           ],
           {

--- a/src/modules/ui/pictureInPicture/headerMarquee.ts
+++ b/src/modules/ui/pictureInPicture/headerMarquee.ts
@@ -146,6 +146,7 @@ export class PictureInPictureHeaderMarquee {
   private rearmTimer: number | null = null;
   private keyframeSequence = 0;
   private isEnabled = true;
+  private lastMeasurements: string | null = null;
 
   constructor(
     private readonly pipWindow: Window,
@@ -175,21 +176,20 @@ export class PictureInPictureHeaderMarquee {
   // matters because the cycle is shared, so no row can be set up until all of
   // them have been sized.
   arm(): void {
-    this.clearArmTimer();
-
+    const fitting: HTMLElement[] = [];
     const measured: MeasuredLine[] = [];
+    const signature: string[] = [String(this.isEnabled)];
+
+    // Measuring reads scrollWidth and clientWidth, neither of which a running row can move, so
+    // the rows are sized before anything is torn down. That is what leaves the option of
+    // walking away below without having disturbed one.
     for (const line of this.lines) {
-      this.stop(line);
       const front = line.querySelector<HTMLElement>(`.${LAYER_CLASS}[data-front="true"]`);
       const scroll = front?.querySelector<HTMLElement>(`.${SCROLL_CLASS}`);
-      if (!front || !scroll) {
-        this.unmask(line);
-        continue;
-      }
-
-      const distance = Math.ceil(scroll.scrollWidth - line.clientWidth);
-      if (distance <= 1) {
-        this.unmask(line);
+      const distance = front && scroll ? Math.ceil(scroll.scrollWidth - line.clientWidth) : 0;
+      if (!front || !scroll || distance <= 1) {
+        fitting.push(line);
+        signature.push("fits");
         continue;
       }
 
@@ -208,7 +208,22 @@ export class PictureInPictureHeaderMarquee {
         shift: `${isRtl ? distance : -distance}px`,
         fade,
       });
+      signature.push(`${distance}:${line.clientWidth}:${fade}:${isRtl}`);
     }
+
+    // Re-arming is a restart: the row snaps home and sits out the lead-in again. Callers fire on
+    // anything that could have changed the metrics, and most of the time nothing has, so a row
+    // already travelling the same distance is left running. The armed half of the test is what
+    // covers a swap, which stops a row without changing a single thing it measures.
+    const measurements = signature.join("|");
+    const isArmed =
+      !this.isEnabled || this.armTimer !== null || measured.every(row => row.line.dataset.marquee === "read");
+    if (measurements === this.lastMeasurements && isArmed) return;
+    this.lastMeasurements = measurements;
+
+    this.clearArmTimer();
+    for (const line of this.lines) this.stop(line);
+    for (const line of fitting) this.unmask(line);
 
     // Only rows that actually scroll are in here, which is what scopes the shared
     // cycle to exactly the right set. A title that overflows while the artist

--- a/src/modules/ui/pictureInPicture/pipHost.ts
+++ b/src/modules/ui/pictureInPicture/pipHost.ts
@@ -55,8 +55,12 @@ export function createPictureInPictureHost(
     pipStyle.id = CUSTOM_STYLE_ID;
     pipWindow.document.head.appendChild(pipStyle);
 
+    // Every head mutation lands here, and the page rewrites <title> on each play, pause and track
+    // change. Re-assigning identical CSS is not free: the sheet is re-parsed, so every face the
+    // theme imports is re-resolved and the font event that follows re-arms the header marquee.
     const sync = (): void => {
-      pipStyle.textContent = document.getElementById(CUSTOM_STYLE_ID)?.textContent ?? "";
+      const next = document.getElementById(CUSTOM_STYLE_ID)?.textContent ?? "";
+      if (next !== pipStyle.textContent) pipStyle.textContent = next;
     };
     sync();
 

--- a/src/modules/ui/pictureInPicture/pipMirror.ts
+++ b/src/modules/ui/pictureInPicture/pipMirror.ts
@@ -49,8 +49,9 @@ const KEYFRAME_TIMING_KEYS = new Set(["offset", "computedOffset", "easing", "com
 // The engine holds one animation per element, pseudo-element and property set: a part's
 // animations are cancelled before it is re-animated. Naming that slot is what lets the mirror
 // hold the same invariant, instead of leaving a replaced animation's twin running alongside its
-// replacement and a beat behind it. A theme's CSS animations are keyed by name on top of that,
-// since two of those can legitimately drive the same property at once.
+// replacement and a beat behind it. Declarative animations are keyed by name and transitions by
+// property on top of that, since those can legitimately run at the same time as the engine's own
+// animation on a property, and nothing else in the key tells the three kinds apart.
 function effectSlot(source: Animation, mirrorId: string, keyframes: readonly Keyframe[]): string {
   const effect = source.effect as KeyframeEffect;
   const properties = new Set<string>();
@@ -59,8 +60,9 @@ function effectSlot(source: Animation, mirrorId: string, keyframes: readonly Key
       if (!KEYFRAME_TIMING_KEYS.has(property)) properties.add(property);
     }
   }
-  const cssName = (source as Partial<CSSAnimation>).animationName ?? "";
-  return `${mirrorId}|${effect.pseudoElement ?? ""}|${cssName}|${[...properties].sort().join(",")}`;
+  const declared = source as Partial<CSSAnimation> & Partial<CSSTransition>;
+  const declaredName = declared.animationName ?? declared.transitionProperty ?? "";
+  return `${mirrorId}|${effect.pseudoElement ?? ""}|${declaredName}|${[...properties].sort().join(",")}`;
 }
 
 function retireTwin(source: Animation): void {
@@ -189,9 +191,13 @@ export function sync(mainRoot: HTMLElement): void {
       const previous = slotToSource.get(slot);
       if (previous) {
         retireTwin(previous);
-        // Dropped from the known set as well: the retirement pass would otherwise copy playback
-        // state onto the cancelled twin, which starts it over.
+        // Superseded for good. Dropping it from the live sets is not enough on its own: a source
+        // that is still in effect comes straight back from getAnimations(), and the two would
+        // trade the slot every frame, rebuilding both twins and leaking a cancel listener each
+        // time. Skipping it costs one of a colliding pair its twin, which beats the churn.
+        skippedSources.add(previous);
         knownSources.delete(previous);
+        nextKnown.delete(previous);
       }
       const twin = twinElement.animate(keyframes, {
         ...effect.getTiming(),

--- a/src/modules/ui/pictureInPicture/pipMirror.ts
+++ b/src/modules/ui/pictureInPicture/pipMirror.ts
@@ -22,19 +22,53 @@ function indexTree(root: Element): Map<string, Element> {
   return map;
 }
 
+interface MirroredAnimation {
+  readonly twin: Animation;
+  readonly slot: string;
+}
+
 let twinRoot: HTMLElement | null = null;
 let idToTwin = new Map<string, Element>();
 let observer: MutationObserver | null = null;
 let rebuildRequested = false;
-let sourceToTwin = new WeakMap<Animation, Animation>();
+let sourceToTwin = new WeakMap<Animation, MirroredAnimation>();
 let knownSources = new Set<Animation>();
 let skippedSources = new WeakSet<Animation>();
+let slotToSource = new Map<string, Animation>();
 
 function resetMirrorAnimations(): void {
-  for (const source of knownSources) sourceToTwin.get(source)?.cancel();
+  for (const source of knownSources) sourceToTwin.get(source)?.twin.cancel();
   sourceToTwin = new WeakMap();
   knownSources = new Set();
   skippedSources = new WeakSet();
+  slotToSource = new Map();
+}
+
+const KEYFRAME_TIMING_KEYS = new Set(["offset", "computedOffset", "easing", "composite"]);
+
+// The engine holds one animation per element, pseudo-element and property set: a part's
+// animations are cancelled before it is re-animated. Naming that slot is what lets the mirror
+// hold the same invariant, instead of leaving a replaced animation's twin running alongside its
+// replacement and a beat behind it. A theme's CSS animations are keyed by name on top of that,
+// since two of those can legitimately drive the same property at once.
+function effectSlot(source: Animation, mirrorId: string, keyframes: readonly Keyframe[]): string {
+  const effect = source.effect as KeyframeEffect;
+  const properties = new Set<string>();
+  for (const frame of keyframes) {
+    for (const property of Object.keys(frame)) {
+      if (!KEYFRAME_TIMING_KEYS.has(property)) properties.add(property);
+    }
+  }
+  const cssName = (source as Partial<CSSAnimation>).animationName ?? "";
+  return `${mirrorId}|${effect.pseudoElement ?? ""}|${cssName}|${[...properties].sort().join(",")}`;
+}
+
+function retireTwin(source: Animation): void {
+  const mirrored = sourceToTwin.get(source);
+  if (!mirrored) return;
+  mirrored.twin.cancel();
+  sourceToTwin.delete(source);
+  if (slotToSource.get(mirrored.slot) === source) slotToSource.delete(mirrored.slot);
 }
 
 export function needsRebuild(): boolean {
@@ -132,11 +166,12 @@ export function sync(mainRoot: HTMLElement): void {
     const target = getKeyframeTarget(source);
     if (!target) continue;
     const effect = source.effect as KeyframeEffect;
-    const twinElement = idToTwin.get(target.getAttribute(MIRROR_ID_ATTR) ?? "");
+    const mirrorId = target.getAttribute(MIRROR_ID_ATTR) ?? "";
+    const twinElement = idToTwin.get(mirrorId);
     if (!twinElement) continue;
 
-    let twin = sourceToTwin.get(source);
-    if (!twin) {
+    let mirrored = sourceToTwin.get(source);
+    if (!mirrored) {
       // getKeyframes() reserializes every property, so it stays behind the twin cache and the
       // skip decision is memoized; keyframes never change once an animation is created.
       const keyframes = effect.getKeyframes();
@@ -147,15 +182,28 @@ export function sync(mainRoot: HTMLElement): void {
         skippedSources.add(source);
         continue;
       }
-      twin = twinElement.animate(keyframes, {
+      // Whatever held this slot has just been superseded in the page, so it goes now rather than
+      // whenever the retirement pass below gets to it. Waiting is what left two copies of a
+      // line's exit fade running out of phase, holding it lit after the page had let it go.
+      const slot = effectSlot(source, mirrorId, keyframes);
+      const previous = slotToSource.get(slot);
+      if (previous) {
+        retireTwin(previous);
+        // Dropped from the known set as well: the retirement pass would otherwise copy playback
+        // state onto the cancelled twin, which starts it over.
+        knownSources.delete(previous);
+      }
+      const twin = twinElement.animate(keyframes, {
         ...effect.getTiming(),
         composite: effect.composite,
         pseudoElement: effect.pseudoElement ?? undefined,
       });
-      sourceToTwin.set(source, twin);
+      mirrored = { twin, slot };
+      sourceToTwin.set(source, mirrored);
+      slotToSource.set(slot, source);
     }
     nextKnown.add(source);
-    copyPlaybackState(source, twin);
+    copyPlaybackState(source, mirrored.twin);
   }
 
   for (const source of knownSources) {
@@ -166,14 +214,13 @@ export function sync(mainRoot: HTMLElement): void {
     // ones matters because several engine animations fill forwards, and a surviving twin of one
     // outranks the theme's own declarations and pins its line visible.
     if (source.playState === "idle" || source.playState === "finished") {
-      sourceToTwin.get(source)?.cancel();
-      sourceToTwin.delete(source);
+      retireTwin(source);
       continue;
     }
     // A minimised window unrenders every target at once, so without this the retained twins freeze
     // at whatever value they held and the lines they belong to stop matching the page.
-    const twin = sourceToTwin.get(source);
-    if (twin) copyPlaybackState(source, twin);
+    const mirrored = sourceToTwin.get(source);
+    if (mirrored) copyPlaybackState(source, mirrored.twin);
     nextKnown.add(source);
   }
   knownSources = nextKnown;

--- a/src/modules/ui/pictureInPicture/pipMirror.ts
+++ b/src/modules/ui/pictureInPicture/pipMirror.ts
@@ -201,6 +201,19 @@ export function sync(mainRoot: HTMLElement): void {
       mirrored = { twin, slot };
       sourceToTwin.set(source, mirrored);
       slotToSource.set(slot, source);
+      // A cancelled animation stops applying in the page immediately, while a twin holds whatever
+      // time it was last given, so the gap until the next sync pass notices is a gap where the
+      // window shows a value the page has already dropped. Only cancellation: a finished
+      // animation that fills forwards is still applying, and retiring its twin there would take
+      // the end state away and then put it back a frame later.
+      source.addEventListener(
+        "cancel",
+        () => {
+          retireTwin(source);
+          knownSources.delete(source);
+        },
+        { once: true }
+      );
     }
     nextKnown.add(source);
     copyPlaybackState(source, mirrored.twin);


### PR DESCRIPTION
## Overview

The theme mirror watched all of document.head, and YouTube Music rewrites the page title on every play, pause and skip. Each of those rewrote the floating window's whole stylesheet and re-resolved every font the theme imports, and the font event that followed yanked both header rows back to the start mid-scroll. It only writes when the CSS actually changed now, and the marquee leaves a row running when it measures the same as last time.

The line that stayed lit after the page had faded it out turned out to be two things. The mirror was letting a replaced animation's twin run on beside its replacement, so twins are keyed by the element and properties they drive now, and the outgoing one goes as soon as its replacement lands or the page cancels it. Underneath that, a single word with a negative duration from Musixmatch made the engine throw inside animate() on every tick, which took the rest of the tick with it and left half-built animations behind for the mirror to copy. Word durations are clamped, so a malformed part costs that word rather than the whole frame.
