### PR TITLE
fix(pip): flip clipped help tooltips and even out the artwork control hover

### DIFF
--- a/public/css/blyrics/picture-in-picture.css
+++ b/public/css/blyrics/picture-in-picture.css
@@ -215,51 +215,68 @@ body {
   pointer-events: auto;
 }
 
+.blyrics-pip-artwork__controls {
+  --blyrics-pip-control-size: clamp(24px, 8vw, 36px);
+}
+
 .blyrics-pip-artwork__control {
+  position: relative;
   box-sizing: border-box;
   display: grid;
-  width: clamp(24px, 8vw, 36px);
-  height: clamp(24px, 8vw, 36px);
+  width: var(--blyrics-pip-control-size);
+  height: var(--blyrics-pip-control-size);
   padding: 0;
   border: 0;
   border-radius: 50%;
   place-items: center;
-  background: rgb(0 0 0 / 28%);
-  backdrop-filter: blur(8px);
+  background: none;
   color: #fff;
   cursor: pointer;
+}
+
+/* The disc takes the hover pop rather than the button, because scaling the button scales the glyph
+   with it, and the hard outer bar of the skip icons then reads as sliding sideways instead of
+   growing. Held at one size, the glyph only ever gets a larger disc behind it. */
+.blyrics-pip-artwork__control::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: rgb(0 0 0 / 28%);
+  backdrop-filter: blur(8px);
   transition:
     background-color 140ms ease,
     transform 140ms ease;
 }
 
-.blyrics-pip-artwork__control:hover {
+.blyrics-pip-artwork__control:hover::before {
   background: rgb(255 255 255 / 22%);
-  transform: scale(1.05);
+  transform: scale(1.08);
 }
 
-.blyrics-pip-artwork__control:active {
+.blyrics-pip-artwork__control:active::before {
   transform: scale(0.95);
 }
 
 .blyrics-pip-artwork__control--play-pause {
-  background: rgb(255 255 255 / 92%);
+  width: calc(var(--blyrics-pip-control-size) * 1.25);
+  height: calc(var(--blyrics-pip-control-size) * 1.25);
   color: #111;
-  transform: scale(1.05);
 }
 
-.blyrics-pip-artwork__control--play-pause:hover {
+.blyrics-pip-artwork__control--play-pause::before {
+  background: rgb(255 255 255 / 92%);
+  backdrop-filter: none;
+}
+
+.blyrics-pip-artwork__control--play-pause:hover::before {
   background: #fff;
-  transform: scale(1.1);
-}
-
-.blyrics-pip-artwork__control--play-pause:active {
-  transform: scale(1);
 }
 
 .blyrics-pip-artwork__control-icon {
-  width: 62%;
-  height: 62%;
+  position: relative;
+  width: calc(var(--blyrics-pip-control-size) * 0.62);
+  height: calc(var(--blyrics-pip-control-size) * 0.62);
   fill: currentColor;
 }
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -178,6 +178,12 @@ body {
     z-index: 100;
 }
 
+.setting-help[data-tooltip-placement="bottom"]::after {
+    top: calc(100% + 8px);
+    bottom: auto;
+    transform: translateX(-50%) translateY(-4px);
+}
+
 .setting-help:hover::after,
 .setting-help:focus-visible::after {
     opacity: 1;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -602,6 +602,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   initI18n();
   populateLanguageDropdown();
   initTabScrollIndicators();
+  initSettingHelpTooltips();
   restoreOptions();
   restoreActiveTab();
 });
@@ -661,6 +662,38 @@ function initTabScrollIndicators(): void {
 
   container.addEventListener("scroll", update);
   update();
+}
+
+// -- Setting help tooltips --------------------------
+
+const TOOLTIP_GAP = 8;
+
+// A modal body counts as a boundary even though it does not clip: a tooltip that runs past its top
+// covers the modal title, which is the thing the tooltip is explaining.
+function getBoundaryTop(element: HTMLElement): number {
+  for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
+    const clips = !getComputedStyle(ancestor)
+      .overflow.split(" ")
+      .every(axis => axis === "visible");
+
+    if (clips || ancestor.classList.contains("modal-body")) {
+      return ancestor.getBoundingClientRect().top;
+    }
+  }
+  return 0;
+}
+
+function initSettingHelpTooltips(): void {
+  for (const help of document.querySelectorAll<HTMLElement>(".setting-help")) {
+    const place = (): void => {
+      const height = parseFloat(getComputedStyle(help, "::after").height) || 0;
+      const spaceAbove = help.getBoundingClientRect().top - getBoundaryTop(help);
+      help.dataset.tooltipPlacement = spaceAbove >= height + TOOLTIP_GAP ? "top" : "bottom";
+    };
+
+    help.addEventListener("pointerenter", place);
+    help.addEventListener("focus", place);
+  }
 }
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Overview

The help tooltip in the floating lyrics settings opened upward and covered the modal title, so the thing it was explaining got hidden. It now checks the space it has and drops below when there isn't room above.

Also evened out the artwork controls. Hovering a skip button scaled the whole button, glyph and all, and the hard bar on the outer edge read as sliding sideways instead of growing. The hover pop now sits on the disc behind the glyph so the icon stays put, and play/pause is genuinely bigger than the other two instead of faking it with a resting transform.
