### PR TITLE
fix(themes): apply the updated css when a store theme auto-updates

### DIFF
--- a/src/core/customCss.ts
+++ b/src/core/customCss.ts
@@ -1,0 +1,186 @@
+import { LOG_PREFIX } from "@constants";
+import { compressString } from "./compression";
+import { getLocalStorage } from "./storage";
+
+const SYNC_STORAGE_LIMIT = 7000;
+const LOCAL_STORAGE_SAFE_LIMIT = 500 * 1024;
+const LOCAL_STORAGE_TOTAL = 5 * 1024 * 1024;
+const CHUNK_SIZE = 100 * 1024;
+const COMPRESSION_THRESHOLD = 50000;
+const SPACE_HEADROOM = 1.2;
+const MAX_RETRY_ATTEMPTS = 3;
+
+interface SaveResult {
+  success: boolean;
+  strategy?: "local" | "sync" | "chunked";
+  wasRetry?: boolean;
+  error?: any;
+}
+
+interface ChunkMetadata {
+  customCSS_chunked?: boolean;
+  customCSS_chunkCount?: number;
+}
+
+export function buildStoreThemeContent(title: string, creators: string[], css: string): string {
+  return `/* ${title}, a marketplace theme by ${creators.join(", ")} */\n\n${css}\n`;
+}
+
+// -- Space Reclamation --------------------------
+
+async function getStorageUsage(): Promise<{ used: number; total: number }> {
+  const bytesInUse = await chrome.storage.local.getBytesInUse();
+  return { used: bytesInUse, total: LOCAL_STORAGE_TOTAL };
+}
+
+async function clearCSSChunks(): Promise<void> {
+  const allData = await chrome.storage.local.get(null);
+  const chunkKeys = Object.keys(allData).filter(key => key.startsWith("customCSS_chunk_"));
+  if (chunkKeys.length > 0) {
+    await chrome.storage.local.remove(chunkKeys);
+  }
+}
+
+async function clearLyricsCacheIfNeeded(requiredSpace: number): Promise<void> {
+  const usage = await getStorageUsage();
+  const availableSpace = usage.total - usage.used;
+
+  console.log(LOG_PREFIX, `Available space: ${availableSpace} bytes, Required: ${requiredSpace} bytes`);
+
+  if (availableSpace < requiredSpace) {
+    console.log(LOG_PREFIX, "Not enough space, clearing lyrics cache...");
+    const allData = await chrome.storage.local.get(null);
+    const lyricsKeys = Object.keys(allData).filter(key => key.startsWith("blyrics_"));
+
+    if (lyricsKeys.length > 0) {
+      console.log(LOG_PREFIX, `Removing ${lyricsKeys.length} cached lyrics entries`);
+      await chrome.storage.local.remove(lyricsKeys);
+
+      const newUsage = await getStorageUsage();
+      console.log(LOG_PREFIX, `Storage after cache clear: ${newUsage.used} / ${newUsage.total} bytes`);
+    }
+  }
+}
+
+// -- Write Strategies --------------------------
+
+async function saveChunkedCSS(css: string): Promise<void> {
+  console.log(LOG_PREFIX, `Saving CSS in chunks. Total size: ${css.length} bytes`);
+
+  const storageUsage = await getStorageUsage();
+  console.log(LOG_PREFIX, `Storage usage before save: ${storageUsage.used} / ${storageUsage.total} bytes`);
+
+  await clearLyricsCacheIfNeeded(css.length * SPACE_HEADROOM);
+
+  const chunks: string[] = [];
+  for (let i = 0; i < css.length; i += CHUNK_SIZE) {
+    chunks.push(css.substring(i, i + CHUNK_SIZE));
+  }
+
+  console.log(LOG_PREFIX, `Splitting into ${chunks.length} chunks of ~${CHUNK_SIZE} bytes each`);
+
+  const oldMetadata = await getLocalStorage<ChunkMetadata>(["customCSS_chunkCount"]);
+  const oldChunkCount = oldMetadata.customCSS_chunkCount || 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    try {
+      await chrome.storage.local.set({ [`customCSS_chunk_${i}`]: chunks[i] });
+      console.log(LOG_PREFIX, `Saved chunk ${i + 1}/${chunks.length} (${chunks[i].length} bytes)`);
+    } catch (error) {
+      console.error(LOG_PREFIX, `Failed to save chunk ${i}:`, error);
+      throw error;
+    }
+  }
+
+  await chrome.storage.local.set({
+    customCSS_chunked: true,
+    customCSS_chunkCount: chunks.length,
+  });
+  await chrome.storage.sync.set({
+    cssStorageType: "chunked",
+    customCSS_chunkCount: chunks.length,
+  });
+
+  await chrome.storage.local.remove(["customCSS", "cssCompressed"]);
+  await chrome.storage.sync.remove("customCSS");
+
+  if (oldChunkCount > chunks.length) {
+    const extraChunkKeys = Array.from(
+      { length: oldChunkCount - chunks.length },
+      (_, i) => `customCSS_chunk_${chunks.length + i}`
+    );
+    await chrome.storage.local.remove(extraChunkKeys);
+  }
+
+  const finalUsage = await getStorageUsage();
+  console.log(LOG_PREFIX, `Storage usage after save: ${finalUsage.used} / ${finalUsage.total} bytes`);
+}
+
+function getStorageStrategy(css: string): "local" | "sync" | "chunked" {
+  const cssSize = new Blob([css]).size;
+  if (cssSize > LOCAL_STORAGE_SAFE_LIMIT) {
+    return "chunked";
+  }
+  return cssSize > SYNC_STORAGE_LIMIT ? "local" : "sync";
+}
+
+export async function saveCustomCss(css: string, retryCount = 0): Promise<SaveResult> {
+  try {
+    const cssSize = new Blob([css]).size;
+    console.log(LOG_PREFIX, `Saving CSS: ${cssSize} bytes (${(cssSize / 1024).toFixed(2)} KB)`);
+
+    const shouldCompress = cssSize > COMPRESSION_THRESHOLD;
+    const cssToStore = shouldCompress ? compressString(css) : css;
+    const compressedSize = new Blob([cssToStore]).size;
+
+    if (shouldCompress) {
+      const ratio = ((1 - compressedSize / cssSize) * 100).toFixed(1);
+      console.log(LOG_PREFIX, `Compressed: ${compressedSize} bytes (${ratio}% reduction)`);
+    }
+
+    const strategy = getStorageStrategy(cssToStore);
+    console.log(LOG_PREFIX, `Selected strategy: ${strategy}`);
+
+    if (strategy === "chunked") {
+      await saveChunkedCSS(cssToStore);
+      await chrome.storage.sync.set({ cssCompressed: shouldCompress });
+      return { success: true, strategy: "chunked" };
+    }
+
+    if (strategy === "local") {
+      await clearLyricsCacheIfNeeded(compressedSize * SPACE_HEADROOM);
+      await chrome.storage.local.set({ customCSS: cssToStore, cssCompressed: shouldCompress });
+      await chrome.storage.sync.set({ cssStorageType: "local", cssCompressed: shouldCompress });
+      await clearCSSChunks();
+      await chrome.storage.sync.remove("customCSS");
+      console.log(LOG_PREFIX, "Saved to local storage");
+    } else {
+      await chrome.storage.sync.set({ customCSS: cssToStore, cssStorageType: "sync", cssCompressed: shouldCompress });
+      await clearCSSChunks();
+      await chrome.storage.local.remove(["customCSS", "cssCompressed"]);
+      console.log(LOG_PREFIX, "Saved to sync storage");
+    }
+
+    return { success: true, strategy };
+  } catch (error: any) {
+    console.error(LOG_PREFIX, "Storage save attempt failed:", error);
+
+    if (error.message?.includes("quota") && retryCount < MAX_RETRY_ATTEMPTS) {
+      try {
+        console.log(LOG_PREFIX, "Attempting chunked storage fallback...");
+        const cssSize = new Blob([css]).size;
+        const shouldCompress = cssSize > COMPRESSION_THRESHOLD;
+        const cssToStore = shouldCompress ? compressString(css) : css;
+
+        await saveChunkedCSS(cssToStore);
+        await chrome.storage.sync.set({ cssCompressed: shouldCompress });
+        return { success: true, strategy: "chunked", wasRetry: true };
+      } catch (chunkError) {
+        console.error(LOG_PREFIX, "Chunked storage fallback failed:", chunkError);
+        return { success: false, error: chunkError };
+      }
+    }
+
+    return { success: false, error };
+  }
+}

--- a/src/core/customCss.ts
+++ b/src/core/customCss.ts
@@ -22,8 +22,13 @@ interface ChunkMetadata {
   customCSS_chunkCount?: number;
 }
 
-export function buildStoreThemeContent(title: string, creators: string[], css: string): string {
-  return `/* ${title}, a marketplace theme by ${creators.join(", ")} */\n\n${css}\n`;
+/** Theme records come from unvalidated metadata.json, so creators may be absent or not an array. */
+export function formatCreators(creators: string[] | undefined): string {
+  return Array.isArray(creators) && creators.length > 0 ? creators.join(", ") : "Unknown";
+}
+
+export function buildStoreThemeContent(title: string, creators: string[] | undefined, css: string): string {
+  return `/* ${title}, a marketplace theme by ${formatCreators(creators)} */\n\n${css}\n`;
 }
 
 // -- Space Reclamation --------------------------

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -28,6 +28,15 @@ export async function getSyncStorage<T>(keys: string | string[] | null): Promise
   return (await chrome.storage.sync.get(keys as string[])) as unknown as T;
 }
 
+export const STORE_THEME_PREFIX = "store:";
+
+/** Null once edited: editing drops themeName but leaves activeStoreTheme set. */
+export async function getAppliedStoreThemeId(): Promise<string | null> {
+  const { themeName } = await getSyncStorage<{ themeName?: string }>(["themeName"]);
+  if (!themeName?.startsWith(STORE_THEME_PREFIX)) return null;
+  return themeName.slice(STORE_THEME_PREFIX.length) || null;
+}
+
 interface TransientStorageItem {
   type: "transient";
   value: any;

--- a/src/modules/ui/styleInjector.ts
+++ b/src/modules/ui/styleInjector.ts
@@ -1,6 +1,12 @@
 import { GENERAL_ERROR_LOG, LOG_PREFIX } from "@constants";
 import { decompressString, isCompressed } from "@core/compression";
-import { compileRicsToStyles, getLocalStorage, getSyncStorage, loadChunkedStyles } from "@core/storage";
+import {
+  compileRicsToStyles,
+  getAppliedStoreThemeId,
+  getLocalStorage,
+  getSyncStorage,
+  loadChunkedStyles,
+} from "@core/storage";
 import { setThemeSettings } from "@modules/settings/themeOptions";
 import { log } from "@utils";
 import { clearAnimationStyleCache } from "./animationEngine";
@@ -120,9 +126,8 @@ export async function getAndApplyCustomStyles(): Promise<void> {
 
 async function handleStoreThemeChange(key: string, change: { oldValue?: any; newValue?: any }): Promise<void> {
   const themeId = key.replace("storeTheme:", "");
-  const { activeStoreTheme } = await getSyncStorage<{ activeStoreTheme?: string }>(["activeStoreTheme"]);
 
-  if (activeStoreTheme !== themeId) return;
+  if ((await getAppliedStoreThemeId()) !== themeId) return;
 
   const theme = change.newValue;
   if (!theme?.css) return;

--- a/src/options/background.ts
+++ b/src/options/background.ts
@@ -9,10 +9,12 @@
  * @returns {boolean} Returns true to indicate asynchronous response
  */
 import { LOG_PREFIX_BACKGROUND } from "@constants";
-import { getLocalStorage, getSyncStorage } from "@core/storage";
+import { buildStoreThemeContent, saveCustomCss } from "@core/customCss";
+import { getAppliedStoreThemeId, getLocalStorage, getSyncStorage } from "@core/storage";
 import { initBackgroundAuth } from "@modules/auth/backgroundAuth";
 import {
   getInstalledStoreThemes,
+  getInstalledTheme,
   installSymlinkedThemeFromMarketplace,
   performSilentUpdates,
   performUrlThemeUpdates,
@@ -34,21 +36,6 @@ const SYMLINKED_THEME_MAP: Record<string, string> = {
   "Apple Music": "apple-music",
 };
 
-const SYNC_STORAGE_LIMIT = 7000;
-
-async function saveThemeCSS(css: string, title: string, creators: string[]): Promise<void> {
-  const themeContent = `/* ${title}, a marketplace theme by ${creators.join(", ")} */\n\n${css}\n`;
-  const cssSize = new Blob([themeContent]).size;
-
-  if (cssSize <= SYNC_STORAGE_LIMIT) {
-    await chrome.storage.sync.set({ customCSS: themeContent, cssStorageType: "sync", cssCompressed: false });
-  } else {
-    await chrome.storage.local.set({ customCSS: themeContent, cssCompressed: false });
-    await chrome.storage.sync.set({ cssStorageType: "local", cssCompressed: false });
-    await chrome.storage.sync.remove("customCSS");
-  }
-}
-
 async function migrateSymlinkedThemes(): Promise<void> {
   try {
     const result = await getLocalStorage<{ [SYMLINKED_MIGRATION_KEY]?: number }>([SYMLINKED_MIGRATION_KEY]);
@@ -69,7 +56,7 @@ async function migrateSymlinkedThemes(): Promise<void> {
           await chrome.storage.sync.remove("activeStoreTheme");
           return;
         }
-        await saveThemeCSS(installed.css, installed.title, installed.creators);
+        await saveCustomCss(buildStoreThemeContent(installed.title, installed.creators, installed.css));
         console.log(LOG_PREFIX_BACKGROUND, `Migrated active theme: ${themeName} → store:${storeId}`);
       }
     }
@@ -77,6 +64,35 @@ async function migrateSymlinkedThemes(): Promise<void> {
     await chrome.storage.local.set({ [SYMLINKED_MIGRATION_KEY]: SYMLINKED_MIGRATION_VERSION });
   } catch (err) {
     console.warn(LOG_PREFIX_BACKGROUND, "Symlinked themes migration failed:", err);
+  }
+}
+
+// -- Applied Theme CSS Resync --------------------------
+
+const THEME_CSS_RESYNC_KEY = "appliedThemeCssResyncVersion";
+const THEME_CSS_RESYNC_VERSION = 1;
+
+/** Heals installs that auto-updated before the write path was fixed. */
+async function resyncAppliedThemeCss(): Promise<void> {
+  try {
+    const stored = await getLocalStorage<{ [THEME_CSS_RESYNC_KEY]?: number }>([THEME_CSS_RESYNC_KEY]);
+    if ((stored[THEME_CSS_RESYNC_KEY] ?? 0) >= THEME_CSS_RESYNC_VERSION) return;
+
+    const themeId = await getAppliedStoreThemeId();
+    const theme = themeId ? await getInstalledTheme(themeId) : null;
+
+    if (theme?.css) {
+      const result = await saveCustomCss(buildStoreThemeContent(theme.title, theme.creators, theme.css));
+      if (!result.success) {
+        console.warn(LOG_PREFIX_BACKGROUND, `Failed to resync applied theme: ${theme.title}`, result.error);
+        return;
+      }
+      console.log(LOG_PREFIX_BACKGROUND, `Resynced applied theme: ${theme.title} v${theme.version}`);
+    }
+
+    await chrome.storage.local.set({ [THEME_CSS_RESYNC_KEY]: THEME_CSS_RESYNC_VERSION });
+  } catch (err) {
+    console.warn(LOG_PREFIX_BACKGROUND, "Applied theme resync failed:", err);
   }
 }
 
@@ -114,12 +130,14 @@ function setupThemeUpdateAlarm(): void {
 chrome.runtime.onInstalled.addListener(async () => {
   setupThemeUpdateAlarm();
   await migrateSymlinkedThemes();
+  await resyncAppliedThemeCss();
   checkAndApplyThemeUpdates();
 });
 
 chrome.runtime.onStartup.addListener(async () => {
   setupThemeUpdateAlarm();
   await migrateSymlinkedThemes();
+  await resyncAppliedThemeCss();
   checkAndApplyThemeUpdates();
 });
 

--- a/src/options/editor/core/editor.ts
+++ b/src/options/editor/core/editor.ts
@@ -48,11 +48,7 @@ interface EditorOptions {
 
 export const SAVE_DEBOUNCE_DELAY = 1000;
 export const SAVE_CUSTOM_THEME_DEBOUNCE = 2000;
-export const SYNC_STORAGE_LIMIT = 7000;
-export const MAX_RETRY_ATTEMPTS = 3;
 export const BRACKET_NESTING_LEVELS = 7;
-export const CHUNK_SIZE = 100 * 1024;
-export const LOCAL_STORAGE_SAFE_LIMIT = 500 * 1024;
 
 const RICS_LINTER_DELAY = 150;
 

--- a/src/options/editor/features/import.ts
+++ b/src/options/editor/features/import.ts
@@ -1,7 +1,8 @@
 import { LOG_PREFIX_EDITOR } from "@constants";
+import { saveCustomCss } from "@core/customCss";
 import { editorStateManager } from "../core/state";
 import { showAlert } from "../ui/feedback";
-import { broadcastRICSToTabs, saveToStorageWithFallback, showSyncSuccess } from "./storage";
+import { broadcastRICSToTabs, showSyncSuccess } from "./storage";
 import { hideThemeName, updateThemeSelectorButton } from "./themes";
 
 export const generateDefaultFilename = (): string => {
@@ -123,7 +124,7 @@ class ImportManager {
         await editorStateManager.setEditorContent(css, `file-import:${filename}`, false);
 
         console.log(LOG_PREFIX_EDITOR, ` Step 4: Saving to storage`);
-        const result = await saveToStorageWithFallback(css);
+        const result = await saveCustomCss(css);
 
         if (!result.success || !result.strategy) {
           throw new Error(`Storage save failed: ${result.error?.message || "Unknown error"}`);

--- a/src/options/editor/features/storage.ts
+++ b/src/options/editor/features/storage.ts
@@ -1,11 +1,10 @@
 import { LOG_PREFIX_EDITOR } from "@constants";
-import { compressString, decompressString, isCompressed } from "@core/compression";
-import { getLocalStorage, getSyncStorage, loadChunkedStyles } from "@core/storage";
+import { decompressString, isCompressed } from "@core/compression";
+import { buildStoreThemeContent, saveCustomCss } from "@core/customCss";
+import { getAppliedStoreThemeId, getLocalStorage, getSyncStorage, loadChunkedStyles } from "@core/storage";
 import { setActiveStoreTheme } from "@/options/store/themeStoreManager";
 import type { InstalledStoreTheme } from "@/options/store/types";
-import { CHUNK_SIZE, LOCAL_STORAGE_SAFE_LIMIT, MAX_RETRY_ATTEMPTS, SYNC_STORAGE_LIMIT } from "../core/editor";
 import { editorStateManager } from "../core/state";
-import type { SaveResult } from "../types";
 import { syncIndicator } from "../ui/dom";
 import { ricsCompiler } from "./compiler";
 import { setThemeName, showThemeName, themeSourceToEditorSource } from "./themes";
@@ -15,171 +14,6 @@ interface CSSStorageData {
   customCSS?: string | null;
   cssCompressed?: boolean;
 }
-
-interface ChunkMetadata {
-  customCSS_chunked?: boolean;
-  customCSS_chunkCount?: number;
-}
-
-async function getStorageUsage(): Promise<{ used: number; total: number }> {
-  const bytesInUse = await chrome.storage.local.getBytesInUse();
-  return {
-    used: bytesInUse,
-    total: 5 * 1024 * 1024,
-  };
-}
-
-async function clearCSSChunks(): Promise<void> {
-  const allData = await chrome.storage.local.get(null);
-  const chunkKeys = Object.keys(allData).filter(key => key.startsWith("customCSS_chunk_"));
-  if (chunkKeys.length > 0) {
-    await chrome.storage.local.remove(chunkKeys);
-  }
-}
-
-async function clearLyricsCacheIfNeeded(requiredSpace: number): Promise<void> {
-  const usage = await getStorageUsage();
-  const availableSpace = usage.total - usage.used;
-
-  console.log(LOG_PREFIX_EDITOR, `Available space: ${availableSpace} bytes, Required: ${requiredSpace} bytes`);
-
-  if (availableSpace < requiredSpace) {
-    console.log(LOG_PREFIX_EDITOR, "Not enough space, clearing lyrics cache...");
-    const allData = await chrome.storage.local.get(null);
-    const lyricsKeys = Object.keys(allData).filter(key => key.startsWith("blyrics_"));
-
-    if (lyricsKeys.length > 0) {
-      console.log(LOG_PREFIX_EDITOR, `Removing ${lyricsKeys.length} cached lyrics entries`);
-      await chrome.storage.local.remove(lyricsKeys);
-
-      const newUsage = await getStorageUsage();
-      console.log(LOG_PREFIX_EDITOR, `Storage after cache clear: ${newUsage.used} / ${newUsage.total} bytes`);
-    }
-  }
-}
-
-async function saveChunkedCSS(css: string): Promise<void> {
-  console.log(LOG_PREFIX_EDITOR, `Saving CSS in chunks. Total size: ${css.length} bytes`);
-
-  const storageUsage = await getStorageUsage();
-  console.log(LOG_PREFIX_EDITOR, `Storage usage before save: ${storageUsage.used} / ${storageUsage.total} bytes`);
-
-  const estimatedSize = css.length * 1.2;
-  await clearLyricsCacheIfNeeded(estimatedSize);
-
-  const chunks: string[] = [];
-  for (let i = 0; i < css.length; i += CHUNK_SIZE) {
-    chunks.push(css.substring(i, i + CHUNK_SIZE));
-  }
-
-  console.log(LOG_PREFIX_EDITOR, `Splitting into ${chunks.length} chunks of ~${CHUNK_SIZE} bytes each`);
-
-  const oldMetadata = await getLocalStorage<ChunkMetadata>(["customCSS_chunkCount"]);
-  const oldChunkCount = oldMetadata.customCSS_chunkCount || 0;
-
-  for (let i = 0; i < chunks.length; i++) {
-    try {
-      await chrome.storage.local.set({ [`customCSS_chunk_${i}`]: chunks[i] });
-      console.log(LOG_PREFIX_EDITOR, `Saved chunk ${i + 1}/${chunks.length} (${chunks[i].length} bytes)`);
-    } catch (error) {
-      console.error(LOG_PREFIX_EDITOR, `Failed to save chunk ${i}:`, error);
-      throw error;
-    }
-  }
-
-  await chrome.storage.local.set({
-    customCSS_chunked: true,
-    customCSS_chunkCount: chunks.length,
-  });
-  await chrome.storage.sync.set({
-    cssStorageType: "chunked",
-    customCSS_chunkCount: chunks.length,
-  });
-
-  await chrome.storage.local.remove(["customCSS", "cssCompressed"]);
-  await chrome.storage.sync.remove("customCSS");
-
-  if (oldChunkCount > chunks.length) {
-    const extraChunkKeys = Array.from(
-      { length: oldChunkCount - chunks.length },
-      (_, i) => `customCSS_chunk_${chunks.length + i}`
-    );
-    await chrome.storage.local.remove(extraChunkKeys);
-  }
-
-  const finalUsage = await getStorageUsage();
-  console.log(LOG_PREFIX_EDITOR, `Storage usage after save: ${finalUsage.used} / ${finalUsage.total} bytes`);
-}
-
-const getStorageStrategy = (css: string): "local" | "sync" | "chunked" => {
-  const cssSize = new Blob([css]).size;
-  if (cssSize > LOCAL_STORAGE_SAFE_LIMIT) {
-    return "chunked";
-  }
-  return cssSize > SYNC_STORAGE_LIMIT ? "local" : "sync";
-};
-
-export const saveToStorageWithFallback = async (css: string, _isTheme = false, retryCount = 0): Promise<SaveResult> => {
-  try {
-    const cssSize = new Blob([css]).size;
-    console.log(LOG_PREFIX_EDITOR, `Saving CSS: ${cssSize} bytes (${(cssSize / 1024).toFixed(2)} KB)`);
-
-    const shouldCompress = cssSize > 50000;
-    const cssToStore = shouldCompress ? compressString(css) : css;
-    const compressedSize = new Blob([cssToStore]).size;
-
-    if (shouldCompress) {
-      const ratio = ((1 - compressedSize / cssSize) * 100).toFixed(1);
-      console.log(LOG_PREFIX_EDITOR, `Compressed: ${compressedSize} bytes (${ratio}% reduction)`);
-    }
-
-    const strategy = getStorageStrategy(cssToStore);
-    console.log(LOG_PREFIX_EDITOR, `Selected strategy: ${strategy}`);
-
-    if (strategy === "chunked") {
-      await saveChunkedCSS(cssToStore);
-      await chrome.storage.sync.set({ cssCompressed: shouldCompress });
-      return { success: true, strategy: "chunked" };
-    }
-
-    if (strategy === "local") {
-      const estimatedSize = compressedSize * 1.2;
-      await clearLyricsCacheIfNeeded(estimatedSize);
-      await chrome.storage.local.set({ customCSS: cssToStore, cssCompressed: shouldCompress });
-      await chrome.storage.sync.set({ cssStorageType: "local", cssCompressed: shouldCompress });
-      await clearCSSChunks();
-      await chrome.storage.sync.remove("customCSS");
-      console.log(LOG_PREFIX_EDITOR, "Saved to local storage");
-    } else {
-      await chrome.storage.sync.set({ customCSS: cssToStore, cssStorageType: "sync", cssCompressed: shouldCompress });
-      await clearCSSChunks();
-      await chrome.storage.local.remove(["customCSS", "cssCompressed"]);
-      console.log(LOG_PREFIX_EDITOR, "Saved to sync storage");
-    }
-
-    return { success: true, strategy };
-  } catch (error: any) {
-    console.error(LOG_PREFIX_EDITOR, "Storage save attempt failed:", error);
-
-    if (error.message?.includes("quota") && retryCount < MAX_RETRY_ATTEMPTS) {
-      try {
-        console.log(LOG_PREFIX_EDITOR, "Attempting chunked storage fallback...");
-        const cssSize = new Blob([css]).size;
-        const shouldCompress = cssSize > 50000;
-        const cssToStore = shouldCompress ? compressString(css) : css;
-
-        await saveChunkedCSS(cssToStore);
-        await chrome.storage.sync.set({ cssCompressed: shouldCompress });
-        return { success: true, strategy: "chunked", wasRetry: true };
-      } catch (chunkError) {
-        console.error(LOG_PREFIX_EDITOR, "Chunked storage fallback failed:", chunkError);
-        return { success: false, error: chunkError };
-      }
-    }
-
-    return { success: false, error };
-  }
-};
 
 async function loadCustomCSS(): Promise<string> {
   let css: string | null = null;
@@ -304,7 +138,7 @@ interface ApplyStoreThemeOptions {
 
 export async function applyStoreThemeComplete(options: ApplyStoreThemeOptions): Promise<boolean> {
   const { themeId, css, title, creators, source } = options;
-  const themeContent = `/* ${title}, a marketplace theme by ${creators.join(", ")} */\n\n${css}\n`;
+  const themeContent = buildStoreThemeContent(title, creators, css);
 
   try {
     editorStateManager.incrementSaveCount();
@@ -312,7 +146,7 @@ export async function applyStoreThemeComplete(options: ApplyStoreThemeOptions): 
     await chrome.storage.sync.set({ themeName: `store:${themeId}` });
     await setActiveStoreTheme(themeId);
 
-    const saveResult = await saveToStorageWithFallback(themeContent, true);
+    const saveResult = await saveCustomCss(themeContent);
     if (!saveResult.success) {
       throw new Error("Failed to save theme to storage");
     }
@@ -441,13 +275,7 @@ class StorageManager {
       return;
     }
 
-    const syncData = await getSyncStorage<{ themeName?: string }>(["themeName"]);
-    const currentThemeName = syncData.themeName;
-
-    if (!currentThemeName?.startsWith("store:")) return;
-
-    const activeThemeId = currentThemeName.slice(6);
-    if (activeThemeId !== themeId) return;
+    if ((await getAppliedStoreThemeId()) !== themeId) return;
 
     const newTheme = change.newValue;
     if (!newTheme?.css || !newTheme?.title) return;
@@ -458,11 +286,11 @@ class StorageManager {
     }
 
     const themeVersion = newTheme.version || "unknown";
-    const themeCreators = Array.isArray(newTheme.creators) ? newTheme.creators.join(", ") : "Unknown";
+    const themeCreators = Array.isArray(newTheme.creators) ? newTheme.creators : ["Unknown"];
 
     console.log(LOG_PREFIX_EDITOR, `Store theme updated: ${newTheme.title} v${themeVersion}`);
 
-    const themeContent = `/* ${newTheme.title}, a marketplace theme by ${themeCreators} */\n\n${newTheme.css}\n`;
+    const themeContent = buildStoreThemeContent(newTheme.title, themeCreators, newTheme.css);
     const displayName = newTheme.version ? `${newTheme.title} (v${newTheme.version})` : newTheme.title;
 
     await editorStateManager.queueOperation("storage", async () => {
@@ -472,7 +300,7 @@ class StorageManager {
       const editorSource = themeSourceToEditorSource(newTheme.source);
       showThemeName(displayName, editorSource);
 
-      const result = await saveToStorageWithFallback(themeContent, true);
+      const result = await saveCustomCss(themeContent);
       if (result.success && result.strategy) {
         showSyncSuccess(result.strategy, result.wasRetry);
         await broadcastRICSToTabs(themeContent, result.strategy);

--- a/src/options/editor/features/storage.ts
+++ b/src/options/editor/features/storage.ts
@@ -286,11 +286,10 @@ class StorageManager {
     }
 
     const themeVersion = newTheme.version || "unknown";
-    const themeCreators = Array.isArray(newTheme.creators) ? newTheme.creators : ["Unknown"];
 
     console.log(LOG_PREFIX_EDITOR, `Store theme updated: ${newTheme.title} v${themeVersion}`);
 
-    const themeContent = buildStoreThemeContent(newTheme.title, themeCreators, newTheme.css);
+    const themeContent = buildStoreThemeContent(newTheme.title, newTheme.creators, newTheme.css);
     const displayName = newTheme.version ? `${newTheme.title} (v${newTheme.version})` : newTheme.title;
 
     await editorStateManager.queueOperation("storage", async () => {

--- a/src/options/editor/features/themes.ts
+++ b/src/options/editor/features/themes.ts
@@ -1,6 +1,8 @@
 import { LOG_PREFIX_EDITOR } from "@constants";
 import { t } from "@core/i18n";
 import { getSyncStorage } from "@core/storage";
+import { saveCustomCss } from "@core/customCss";
+import { STORE_THEME_PREFIX } from "@core/storage";
 import {
   getInstalledStoreThemes,
   getInstalledTheme,
@@ -28,15 +30,8 @@ import {
   themeSourceBadge,
 } from "../ui/dom";
 import { showAlert, showConfirm, showPrompt } from "../ui/feedback";
-import {
-  applyStoreThemeComplete,
-  broadcastRICSToTabs,
-  saveToStorageWithFallback,
-  showSyncError,
-  showSyncSuccess,
-} from "./storage";
+import { applyStoreThemeComplete, broadcastRICSToTabs, showSyncError, showSyncSuccess } from "./storage";
 
-const STORE_THEME_PREFIX = "store:";
 const preloadedImages = new Set<string>();
 
 function documentLoaded(): Promise<void> {
@@ -261,7 +256,7 @@ class ThemeManager {
     editorStateManager.setIsSaving(true);
 
     try {
-      const result = await saveToStorageWithFallback(css, true);
+      const result = await saveCustomCss(css);
 
       if (!result.success || !result.strategy) {
         throw new Error(`Failed to save theme: ${result.error?.message || "Unknown error"}`);
@@ -459,9 +454,9 @@ export function saveToStorage(isTheme = false) {
     editorStateManager.setCurrentThemeName(null);
   }
 
-  saveToStorageWithFallback(css, isTheme)
+  saveCustomCss(css)
     .then(result => {
-      console.log(LOG_PREFIX_EDITOR, "saveToStorageWithFallback result:", result);
+      console.log(LOG_PREFIX_EDITOR, "saveCustomCss result:", result);
       if (result.success && result.strategy) {
         showSyncSuccess(result.strategy, result.wasRetry);
         broadcastRICSToTabs(css, result.strategy);

--- a/src/options/editor/features/themes.ts
+++ b/src/options/editor/features/themes.ts
@@ -1,7 +1,7 @@
 import { LOG_PREFIX_EDITOR } from "@constants";
 import { t } from "@core/i18n";
 import { getSyncStorage } from "@core/storage";
-import { saveCustomCss } from "@core/customCss";
+import { formatCreators, saveCustomCss } from "@core/customCss";
 import { STORE_THEME_PREFIX } from "@core/storage";
 import {
   getInstalledStoreThemes,
@@ -519,8 +519,7 @@ export async function updateThemeSelectorButton(): Promise<void> {
       const storeThemeId = storedThemeName.slice(STORE_THEME_PREFIX.length);
       const installedTheme = await getInstalledTheme(storeThemeId);
       if (installedTheme) {
-        const author = installedTheme.creators?.join(", ");
-        if (author) authorText = t("theme_author_prefix", author);
+        authorText = t("theme_author_prefix", formatCreators(installedTheme.creators));
         badgeIcon = installedTheme.source === "url" ? createGitHubIcon() : createMarketplaceIcon();
         badgeLabel = installedTheme.source === "url" ? "GitHub" : "Marketplace";
         bgUrl = installedTheme.imageUrls?.[0] ?? installedTheme.coverUrl ?? "";

--- a/src/options/editor/types.ts
+++ b/src/options/editor/types.ts
@@ -9,13 +9,6 @@ export interface ModalOptions {
   showInput?: boolean;
 }
 
-export interface SaveResult {
-  success: boolean;
-  strategy?: "local" | "sync" | "chunked";
-  wasRetry?: boolean;
-  error?: any;
-}
-
 export interface BracketStackItem {
   type: string;
   from: number;

--- a/src/options/store/store.ts
+++ b/src/options/store/store.ts
@@ -1,4 +1,5 @@
 import { LOG_PREFIX_STORE } from "@constants";
+import { formatCreators } from "@core/customCss";
 import { t } from "@core/i18n";
 import { getLocalStorage, getSyncStorage } from "@core/storage";
 import autoAnimate, { type AnimationController } from "@formkit/auto-animate";
@@ -1334,7 +1335,7 @@ function renderNextBatch(batchSize: number): void {
 function matchesSearchQuery(theme: StoreTheme, query: string): boolean {
   if (!query) return true;
 
-  const searchableText = [theme.title, theme.description, ...theme.creators].join(" ").toLowerCase();
+  const searchableText = [theme.title, theme.description, formatCreators(theme.creators)].join(" ").toLowerCase();
 
   return searchableText.includes(query);
 }
@@ -1479,7 +1480,7 @@ function createStoreThemeCard(
 
   const author = document.createElement("div");
   author.className = "store-card-author";
-  author.textContent = `By ${theme.creators.join(", ")}`;
+  author.textContent = `By ${formatCreators(theme.creators)}`;
 
   const actionBtn = document.createElement("button");
   actionBtn.className = `store-card-btn ${isInstalled ? "store-card-btn-remove" : "store-card-btn-install"}`;
@@ -1750,7 +1751,7 @@ async function openDetailModal(theme: StoreTheme, urlThemeInfo?: UrlThemeInfo): 
       titleEl.appendChild(createGitHubBadge("detail-url-badge", title));
     }
   }
-  if (authorEl) authorEl.textContent = `By ${theme.creators.join(", ")} · v${theme.version}`;
+  if (authorEl) authorEl.textContent = `By ${formatCreators(theme.creators)} · v${theme.version}`;
   if (descEl) descEl.replaceChildren(parseMarkdown(theme.description));
 
   const statsEl = document.getElementById("detail-stats");
@@ -2418,7 +2419,7 @@ async function updateYourThemesDropdown(): Promise<void> {
 
     const meta = document.createElement("span");
     meta.className = "your-themes-item-meta";
-    meta.textContent = `By ${theme.creators.join(", ")} · v${theme.version}`;
+    meta.textContent = `By ${formatCreators(theme.creators)} · v${theme.version}`;
 
     info.appendChild(titleRow);
     info.appendChild(meta);

--- a/src/options/store/themeStoreManager.ts
+++ b/src/options/store/themeStoreManager.ts
@@ -1,5 +1,6 @@
 import { LOG_PREFIX_STORE } from "@constants";
-import { getLocalStorage, getSyncStorage } from "@core/storage";
+import { buildStoreThemeContent, saveCustomCss } from "@core/customCss";
+import { getAppliedStoreThemeId, getLocalStorage, getSyncStorage } from "@core/storage";
 import {
   fetchFullTheme,
   fetchRegistryShaderConfig,
@@ -272,8 +273,27 @@ async function checkForThemeUpdates(
   return updates;
 }
 
-async function updateTheme(theme: StoreTheme): Promise<InstalledStoreTheme> {
-  return installTheme(theme);
+async function updateTheme(theme: StoreTheme, previous: InstalledStoreTheme): Promise<InstalledStoreTheme> {
+  return installTheme(theme, {
+    source: previous.source,
+    sourceUrl: previous.sourceUrl,
+    branch: previous.branch,
+  });
+}
+
+/** Without this an update lands only in the record, so old CSS keeps rendering. */
+async function syncAppliedThemeCss(theme: InstalledStoreTheme): Promise<void> {
+  if ((await getAppliedStoreThemeId()) !== theme.id) return;
+
+  await setActiveStoreTheme(theme.id);
+
+  const result = await saveCustomCss(buildStoreThemeContent(theme.title, theme.creators, theme.css));
+  if (!result.success) {
+    console.warn(LOG_PREFIX_STORE, `Failed to re-apply theme after update: ${theme.title}`, result.error);
+    return;
+  }
+
+  console.log(LOG_PREFIX_STORE, `Re-applied active theme after update: ${theme.title}`);
 }
 
 export async function performSilentUpdates(storeThemes: StoreTheme[]): Promise<string[]> {
@@ -283,18 +303,18 @@ export async function performSilentUpdates(storeThemes: StoreTheme[]): Promise<s
 
   if (updates.size === 0) return updatedIds;
 
-  const activeThemeId = await getActiveStoreTheme();
+  const installedById = new Map(installed.map(theme => [theme.id, theme]));
 
   for (const [themeId, storeTheme] of updates) {
     try {
-      await updateTheme(storeTheme);
+      const previous = installedById.get(themeId);
+      if (!previous) continue;
+
+      const updated = await updateTheme(storeTheme, previous);
       updatedIds.push(themeId);
       console.log(LOG_PREFIX_STORE, `Auto-updated theme: ${storeTheme.title} to v${storeTheme.version}`);
 
-      if (activeThemeId === themeId) {
-        await applyStoreTheme(themeId);
-        console.log(LOG_PREFIX_STORE, `Re-applied active theme after update: ${storeTheme.title}`);
-      }
+      await syncAppliedThemeCss(updated);
     } catch (err) {
       console.warn(LOG_PREFIX_STORE, `Failed to auto-update theme ${themeId}:`, err);
     }
@@ -310,15 +330,13 @@ export async function performUrlThemeUpdates(): Promise<string[]> {
 
   if (urlThemes.length === 0) return updatedIds;
 
-  const activeThemeId = await getActiveStoreTheme();
-
   for (const theme of urlThemes) {
     try {
       const metadata = await fetchThemeMetadata(theme.repo, theme.branch);
       if (metadata.version === theme.version) continue;
 
       const fullTheme = await fetchFullTheme(theme.repo, theme.branch);
-      await installTheme(fullTheme, {
+      const updated = await installTheme(fullTheme, {
         source: "url",
         sourceUrl: theme.sourceUrl,
         branch: theme.branch,
@@ -326,9 +344,7 @@ export async function performUrlThemeUpdates(): Promise<string[]> {
 
       updatedIds.push(theme.id);
 
-      if (activeThemeId === theme.id) {
-        await applyStoreTheme(theme.id);
-      }
+      await syncAppliedThemeCss(updated);
     } catch (err) {
       console.warn(LOG_PREFIX_STORE, `Failed to check/update URL theme ${theme.id}:`, err);
     }

--- a/src/options/store/themeStoreManager.ts
+++ b/src/options/store/themeStoreManager.ts
@@ -297,7 +297,7 @@ async function syncAppliedThemeCss(theme: InstalledStoreTheme): Promise<void> {
 }
 
 export async function performSilentUpdates(storeThemes: StoreTheme[]): Promise<string[]> {
-  const installed = await getInstalledStoreThemes();
+  const installed = (await getInstalledStoreThemes()).filter(theme => theme.source !== "url");
   const updates = await checkForThemeUpdates(installed, storeThemes);
   const updatedIds: string[] = [];
 
@@ -361,12 +361,14 @@ export async function refreshUrlThemesMetadata(): Promise<number> {
   for (const theme of urlThemesNeedingRefresh) {
     try {
       const fullTheme = await fetchFullTheme(theme.repo, theme.branch);
-      await installTheme(fullTheme, {
+      const updated = await installTheme(fullTheme, {
         source: "url",
         sourceUrl: theme.sourceUrl,
         branch: theme.branch,
       });
       refreshedCount++;
+
+      await syncAppliedThemeCss(updated);
     } catch (err) {
       console.warn(LOG_PREFIX_STORE, `Failed to refresh URL theme ${theme.id}:`, err);
     }


### PR DESCRIPTION
## Overview

Auto-updating a store theme only wrote the theme record, never `customCSS`, which is what actually gets applied. So the version in Settings went up while the old CSS kept rendering, with no way out short of re-applying the theme by hand. Updates now write the new CSS through, and a one-shot resync fixes installs that are already stuck. The check keys off `themeName` rather than `activeStoreTheme` since editing a theme clears the first but not the second, so local customisations survive.
