### PR TITLE
fix(queue): restore the up next autoplay toggle after a tab switch

### DIFF
--- a/src/modules/ui/observer.ts
+++ b/src/modules/ui/observer.ts
@@ -26,6 +26,7 @@ import {
 } from "@modules/ui/animationEngine";
 import { adjustLyricOffset, OFFSET_STEP, OFFSET_STEP_LARGE } from "@modules/ui/lyricsDock/offset";
 import { preloadArtwork } from "@modules/ui/pictureInPicture/lyricsView";
+import { revealQueueAutoplaySection } from "@modules/ui/queueAutoplay";
 import {
   closePlayerPageIfOpenedForFullscreen,
   isNavigating,
@@ -298,6 +299,7 @@ export function lyricReloader(): void {
     };
 
     tab1.addEventListener("click", onNonLyricTabClick);
+    tab1.addEventListener("click", revealQueueAutoplaySection);
     tab3.addEventListener("click", onNonLyricTabClick);
   } else {
     setTimeout(() => lyricReloader(), 1000);

--- a/src/modules/ui/queueAutoplay.ts
+++ b/src/modules/ui/queueAutoplay.ts
@@ -1,0 +1,20 @@
+import { LOG_PREFIX } from "@constants";
+import { log } from "@utils";
+
+const AUTOPLAY_SECTION_SELECTOR = "#tab-renderer .autoplay.ytmusic-tab-renderer";
+const AUTOMIX_CONTENTS_SELECTOR = "#tab-renderer #automix-contents";
+
+export function revealQueueAutoplaySection(): void {
+  const section = document.querySelector<HTMLElement>(AUTOPLAY_SECTION_SELECTOR);
+  if (!section?.hasAttribute("hidden")) {
+    return;
+  }
+
+  const automixContents = document.querySelector(AUTOMIX_CONTENTS_SELECTOR);
+  if (!automixContents?.childElementCount) {
+    return;
+  }
+
+  section.removeAttribute("hidden");
+  log(LOG_PREFIX, "Restored the queue autoplay toggle hidden by a tab switch");
+}


### PR DESCRIPTION
## Overview

YouTube Music only unhides the Up next autoplay toggle if the automix queue update lands while that tab is on screen. Auto switching to lyrics steals that window and nothing recomputes it afterwards, so the toggle stays gone for the rest of the session while its automix tracks sit right there in the queue. Clear the stale attribute when you come back to Up next, only when the automix section actually has content, so a queue without automix is left alone.
