### PR TITLE
fix(firefox): raise the minimum version to 128 and support android

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -76,8 +76,9 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "betterlyrics@boidu.dev",
-      "strict_min_version": "100.0"
-    }
+      "strict_min_version": "128.0"
+    },
+    "gecko_android": {}
   },
   "chrome:update_url": "https://clients2.google.com/service/update2/crx",
   "edge:key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmNspBNCi4WHoRlH/rRPneLNqtWHzsEsK+Z4a7qmose6afikym7/5A/7I/OuXeJFqJXLc7YfWVUtdBWfHRSjT9Earq0wdOfElHyWnHQ1/cn55xbCdMJRSsVKEg3NRHWKbwpBFlt6XUog5sl48Gf+v6aZrv069MWEnXA13BEWqRX9hALG6WswyxaZXKokwH2AvnDDaWHrBghti6kmSNuXWCJj4c02YwZ5LgOJ3m5cI7bq/Mi7RtVuK+Odsj2/iESXAwNvLcMiOTW8vrioj/KfySjXpi16HCZIm0e6EvTq08CQUvIEpxV7Gaiq5w2j2TFKPMQ4aaHTiEgWMSZ0DeihLNQIDAQAB",


### PR DESCRIPTION
## Overview

`world: "MAIN"` needs Firefox 128 and we were claiming 100. Anything on 100 to 127 installed fine, then quietly ran the three page-world scripts in the isolated world instead, so earlyInject.js never patched fetch and the request sniffer came up empty. Bumped the minimum to 128 and added `gecko_android`, which stops AMO from listing us as desktop-only. Checked it on Firefox Android first.
