### PR TITLE
l18n fix: Add locales for Create and Edit buttons

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -344,7 +344,11 @@
   },
   "options_themes_create": {
     "message": "Create",
-    "description": "Create button label"
+    "description": "Button to open the style editor if there are no styles"
+  },
+  "options_themes_edit": {
+    "message": "Edit",
+    "description": "Button to open the style editor"
   },
   "options_themes_marketplace": {
     "message": "Theme Marketplace",

--- a/src/options/editor/features/themes.ts
+++ b/src/options/editor/features/themes.ts
@@ -486,7 +486,7 @@ async function updateCreateEditButton(): Promise<void> {
   const hasContent = customCSS && customCSS.trim().length > 0;
 
   const showEdit = !isDefaultTheme && hasContent;
-  textSpan.textContent = showEdit ? "Edit" : "Create";
+  textSpan.textContent = showEdit ? t("options_themes_edit") : t("options_themes_create");
 }
 
 export async function updateThemeSelectorButton(): Promise<void> {


### PR DESCRIPTION
# Description

Added the ability to localize the `Edit` string and display localized strings for `Edit` and `Create`, which were previously hard-coded in English.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots (example is in Ukrainian, but the Ukrainian locale is not included in the PR)

| Before             | After              |
| ------------------ | ------------------ |
| <img width="594" height="571" alt="before 1" src="https://github.com/user-attachments/assets/1051530f-0ada-4167-a7bb-9dbef2d3ad3d" /> | <img width="593" height="572" alt="after 1" src="https://github.com/user-attachments/assets/873b0c14-874a-4814-bc33-9434bc1e21d8" /> |
| <img width="593" height="566" alt="before 2" src="https://github.com/user-attachments/assets/b3e3151a-1951-4046-a1db-9769098bbb82" /> | <img width="592" height="569" alt="after 2" src="https://github.com/user-attachments/assets/b1111a4a-685d-4742-97b5-899504417858" /> |

## Checklist

- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
